### PR TITLE
Remove hipchat requirement from initializer

### DIFF
--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -20,7 +20,6 @@ require 'stoplight/notifier/base'
 require 'stoplight/notifier/generic'
 
 require 'stoplight/notifier/bugsnag'
-require 'stoplight/notifier/hip_chat'
 require 'stoplight/notifier/honeybadger'
 require 'stoplight/notifier/io'
 require 'stoplight/notifier/logger'


### PR DESCRIPTION
Following up on https://github.com/bolshakov/stoplight/pull/154. This PR removes the last bit of hipchat that is left in the initializer.