### PR TITLE
Move data store specs into shared examples

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Metrics/BlockLength:
   Exclude:
@@ -16,3 +16,7 @@ Lint/AmbiguousBlockAssociation:
 Metrics/ClassLength:
   Enabled: true
   Max: 110
+
+Layout/BlockAlignment:
+  Exclude:
+    - 'spec/support/**/*'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'simplecov'
 
 require 'stoplight'
 require 'timecop'
+require_relative 'support/data_store/base'
 
 Timecop.safe_mode = true
 

--- a/spec/stoplight/data_store/memory_spec.rb
+++ b/spec/stoplight/data_store/memory_spec.rb
@@ -7,153 +7,16 @@ RSpec.describe Stoplight::DataStore::Memory do
   let(:light) { Stoplight::Light.new(name) {} }
   let(:name) { ('a'..'z').to_a.shuffle.join }
   let(:failure) { Stoplight::Failure.new('class', 'message', Time.new) }
+  let(:other) { Stoplight::Failure.new('class', 'message 2', Time.new) }
 
-  it 'is a class' do
-    expect(described_class).to be_a(Class)
-  end
-
-  it 'is a subclass of Base' do
-    expect(described_class).to be < Stoplight::DataStore::Base
-  end
-
-  describe '#names' do
-    it 'is initially empty' do
-      expect(data_store.names).to eql([])
-    end
-
-    it 'contains the name of a light with a failure' do
-      data_store.record_failure(light, failure)
-      expect(data_store.names).to eql([light.name])
-    end
-
-    it 'contains the name of a light with a set state' do
-      data_store.set_state(light, Stoplight::State::UNLOCKED)
-      expect(data_store.names).to eql([light.name])
-    end
-
-    it 'does not duplicate names' do
-      data_store.record_failure(light, failure)
-      data_store.set_state(light, Stoplight::State::UNLOCKED)
-      expect(data_store.names).to eql([light.name])
-    end
-
-    it 'supports names containing colons' do
-      light = Stoplight::Light.new('http://api.example.com/some/action')
-      data_store.record_failure(light, failure)
-      expect(data_store.names).to eql([light.name])
-    end
-  end
-
-  describe '#get_all' do
-    it 'returns the failures and the state' do
-      failures, state = data_store.get_all(light)
-      expect(failures).to eql([])
-      expect(state).to eql(Stoplight::State::UNLOCKED)
-    end
-  end
-
-  describe '#get_failures' do
-    it 'is initially empty' do
-      expect(data_store.get_failures(light)).to eql([])
-    end
-  end
-
-  describe '#record_failure' do
-    it 'returns the number of failures' do
-      expect(data_store.record_failure(light, failure)).to eql(1)
-    end
-
-    it 'persists the failure' do
-      data_store.record_failure(light, failure)
-      expect(data_store.get_failures(light)).to eql([failure])
-    end
-
-    it 'stores more recent failures at the front' do
-      data_store.record_failure(light, failure)
-      other = Stoplight::Failure.new('class', 'message 2', Time.new)
-      data_store.record_failure(light, other)
-      expect(data_store.get_failures(light)).to eql([other, failure])
-    end
-
-    it 'limits the number of stored failures' do
-      light.with_threshold(1)
-      data_store.record_failure(light, failure)
-      other = Stoplight::Failure.new('class', 'message 2', Time.new)
-      data_store.record_failure(light, other)
-      expect(data_store.get_failures(light)).to eql([other])
-    end
-  end
-
-  describe '#clear_failures' do
-    it 'returns the failures' do
-      data_store.record_failure(light, failure)
-      expect(data_store.clear_failures(light)).to eql([failure])
-    end
-
-    it 'clears the failures' do
-      data_store.record_failure(light, failure)
-      data_store.clear_failures(light)
-      expect(data_store.get_failures(light)).to eql([])
-    end
-  end
-
-  describe '#get_state' do
-    it 'is initially unlocked' do
-      expect(data_store.get_state(light)).to eql(Stoplight::State::UNLOCKED)
-    end
-  end
-
-  describe '#set_state' do
-    it 'returns the state' do
-      state = 'state'
-      expect(data_store.set_state(light, state)).to eql(state)
-    end
-
-    it 'persists the state' do
-      state = 'state'
-      data_store.set_state(light, state)
-      expect(data_store.get_state(light)).to eql(state)
-    end
-  end
-
-  describe '#clear_state' do
-    it 'returns the state' do
-      state = 'state'
-      data_store.set_state(light, state)
-      expect(data_store.clear_state(light)).to eql(state)
-    end
-
-    it 'clears the state' do
-      state = 'state'
-      data_store.set_state(light, state)
-      data_store.clear_state(light)
-      expect(data_store.get_state(light)).to eql(Stoplight::State::UNLOCKED)
-    end
-  end
-
-  describe '#with_notification_lock' do
-    context 'when notification is already sent' do
-      before do
-        data_store.with_notification_lock(light, Stoplight::Color::GREEN, Stoplight::Color::RED) {}
-      end
-
-      it 'does not yield passed block' do
-        expect do |b|
-          data_store.with_notification_lock(light, Stoplight::Color::GREEN, Stoplight::Color::RED, &b)
-        end.not_to yield_control
-      end
-    end
-
-    context 'when notification is not already sent' do
-      before do
-        data_store.with_notification_lock(light, Stoplight::Color::GREEN, Stoplight::Color::RED) {}
-      end
-
-      it 'yields passed block' do
-        expect do |b|
-          data_store.with_notification_lock(light, Stoplight::Color::RED, Stoplight::Color::GREEN, &b)
-        end.to yield_control
-      end
-    end
-  end
+  it_behaves_like 'Stoplight::DataStore::Base'
+  it_behaves_like 'Stoplight::DataStore::Base#names'
+  it_behaves_like 'Stoplight::DataStore::Base#get_failures'
+  it_behaves_like 'Stoplight::DataStore::Base#get_all'
+  it_behaves_like 'Stoplight::DataStore::Base#record_failure'
+  it_behaves_like 'Stoplight::DataStore::Base#clear_failures'
+  it_behaves_like 'Stoplight::DataStore::Base#get_state'
+  it_behaves_like 'Stoplight::DataStore::Base#set_state'
+  it_behaves_like 'Stoplight::DataStore::Base#clear_state'
+  it_behaves_like 'Stoplight::DataStore::Base#with_notification_lock'
 end

--- a/spec/stoplight/data_store/redis_spec.rb
+++ b/spec/stoplight/data_store/redis_spec.rb
@@ -10,168 +10,38 @@ RSpec.describe Stoplight::DataStore::Redis do
   let(:light) { Stoplight::Light.new(name) {} }
   let(:name) { ('a'..'z').to_a.shuffle.join }
   let(:failure) { Stoplight::Failure.new('class', 'message', Time.new) }
+  let(:other) { Stoplight::Failure.new('class', 'message 2', Time.new) }
 
-  it 'is a class' do
-    expect(described_class).to be_a(Class)
-  end
+  it_behaves_like 'Stoplight::DataStore::Base'
+  it_behaves_like 'Stoplight::DataStore::Base#names'
+  it_behaves_like 'Stoplight::DataStore::Base#get_all'
+  it_behaves_like 'Stoplight::DataStore::Base#record_failure'
+  it_behaves_like 'Stoplight::DataStore::Base#clear_failures'
+  it_behaves_like 'Stoplight::DataStore::Base#get_state'
+  it_behaves_like 'Stoplight::DataStore::Base#set_state'
+  it_behaves_like 'Stoplight::DataStore::Base#clear_state'
 
-  it 'is a subclass of Base' do
-    expect(described_class).to be < Stoplight::DataStore::Base
-  end
+  it_behaves_like 'Stoplight::DataStore::Base#get_failures' do
+    context 'when JSON is invalid' do
+      before do
+        light.with_error_notifier { |_error| }
 
-  describe '#names' do
-    it 'is initially empty' do
-      expect(data_store.names).to eql([])
-    end
+        data_store.record_failure(light, failure)
+      end
 
-    it 'contains the name of a light with a failure' do
-      data_store.record_failure(light, failure)
-      expect(data_store.names).to eql([light.name])
-    end
-
-    it 'contains the name of a light with a set state' do
-      data_store.set_state(light, Stoplight::State::UNLOCKED)
-      expect(data_store.names).to eql([light.name])
-    end
-
-    it 'does not duplicate names' do
-      data_store.record_failure(light, failure)
-      data_store.set_state(light, Stoplight::State::UNLOCKED)
-      expect(data_store.names).to eql([light.name])
-    end
-
-    it 'supports names containing colons' do
-      light = Stoplight::Light.new('http://api.example.com/some/action')
-      data_store.record_failure(light, failure)
-      expect(data_store.names).to eql([light.name])
+      it 'handles it without an error' do
+        expect { redis.lset(redis.keys.first, 0, 'invalid JSON') }
+          .to change { data_store.get_failures(light) }
+          .to([have_attributes(error_class: 'JSON::ParserError')])
+      end
     end
   end
 
-  describe '#get_all' do
-    it 'returns the failures and the state' do
-      failures, state = data_store.get_all(light)
-      expect(failures).to eql([])
-      expect(state).to eql(Stoplight::State::UNLOCKED)
-    end
-  end
-
-  describe '#get_failures' do
-    it 'is initially empty' do
-      expect(data_store.get_failures(light)).to eql([])
-    end
-
-    it 'handles invalid JSON' do
-      expect(redis.keys.size).to eql(0)
-      data_store.record_failure(light, failure)
-      expect(redis.keys.size).to eql(1)
-      redis.lset(redis.keys.first, 0, 'invalid JSON')
-      light.with_error_notifier { |_error| }
-      expect(data_store.get_failures(light).size).to eql(1)
-    end
-  end
-
-  describe '#record_failure' do
-    it 'returns the number of failures' do
-      expect(data_store.record_failure(light, failure)).to eql(1)
-    end
-
-    it 'persists the failure' do
-      data_store.record_failure(light, failure)
-      expect(data_store.get_failures(light)).to eq([failure])
-    end
-
-    it 'stores more recent failures at the head' do
-      data_store.record_failure(light, failure)
-      other = Stoplight::Failure.new('class', 'message 2', Time.new)
-      data_store.record_failure(light, other)
-      expect(data_store.get_failures(light)).to eq([other, failure])
-    end
-
-    it 'limits the number of stored failures' do
-      light.with_threshold(1)
-      data_store.record_failure(light, failure)
-      other = Stoplight::Failure.new('class', 'message 2', Time.new)
-      data_store.record_failure(light, other)
-      expect(data_store.get_failures(light)).to eq([other])
-    end
-  end
-
-  describe '#clear_failures' do
-    it 'returns the failures' do
-      data_store.record_failure(light, failure)
-      expect(data_store.clear_failures(light)).to eq([failure])
-    end
-
-    it 'clears the failures' do
-      data_store.record_failure(light, failure)
-      data_store.clear_failures(light)
-      expect(data_store.get_failures(light)).to eql([])
-    end
-  end
-
-  describe '#get_state' do
-    it 'is initially unlocked' do
-      expect(data_store.get_state(light)).to eql(Stoplight::State::UNLOCKED)
-    end
-  end
-
-  describe '#set_state' do
-    it 'returns the state' do
-      state = 'state'
-      expect(data_store.set_state(light, state)).to eql(state)
-    end
-
-    it 'persists the state' do
-      state = 'state'
-      data_store.set_state(light, state)
-      expect(data_store.get_state(light)).to eql(state)
-    end
-  end
-
-  describe '#clear_state' do
-    it 'returns the state' do
-      state = 'state'
-      data_store.set_state(light, state)
-      expect(data_store.clear_state(light)).to eql(state)
-    end
-
-    it 'clears the state' do
-      state = 'state'
-      data_store.set_state(light, state)
-      data_store.clear_state(light)
-      expect(data_store.get_state(light)).to eql(Stoplight::State::UNLOCKED)
-    end
-  end
-
-  describe '#with_notification_lock' do
+  it_behaves_like 'Stoplight::DataStore::Base#with_notification_lock' do
     let(:lock_key) { "stoplight:notification_lock:#{name}" }
 
     before do
       allow(redlock).to receive(:lock).with(lock_key, 2_000).and_yield
-    end
-
-    context 'when notification is already sent' do
-      before do
-        data_store.with_notification_lock(light, Stoplight::Color::GREEN, Stoplight::Color::RED) {}
-      end
-
-      it 'does not yield passed block' do
-        expect do |b|
-          data_store.with_notification_lock(light, Stoplight::Color::GREEN, Stoplight::Color::RED, &b)
-        end.not_to yield_control
-      end
-    end
-
-    context 'when notification is not already sent' do
-      before do
-        data_store.with_notification_lock(light, Stoplight::Color::GREEN, Stoplight::Color::RED) {}
-      end
-
-      it 'yields passed block' do
-        expect do |b|
-          data_store.with_notification_lock(light, Stoplight::Color::RED, Stoplight::Color::GREEN, &b)
-        end.to yield_control
-      end
     end
   end
 end

--- a/spec/support/data_store/base.rb
+++ b/spec/support/data_store/base.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative 'base/names'
+require_relative 'base/get_failures'
+require_relative 'base/get_all'
+require_relative 'base/record_failures'
+require_relative 'base/clear_failures'
+require_relative 'base/get_state'
+require_relative 'base/set_state'
+require_relative 'base/clear_state'
+require_relative 'base/with_notification_lock'
+
+RSpec.shared_examples 'Stoplight::DataStore::Base' do
+  it 'is a class' do
+    expect(described_class).to be_a(Class)
+  end
+
+  it 'is a subclass of Base' do
+    expect(described_class).to be < Stoplight::DataStore::Base
+  end
+end

--- a/spec/support/data_store/base/clear_failures.rb
+++ b/spec/support/data_store/base/clear_failures.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::DataStore::Base#clear_failures' do
+  before do
+    data_store.record_failure(light, failure)
+  end
+
+  it 'returns the failures' do
+    expect(data_store.clear_failures(light)).to contain_exactly(failure)
+  end
+
+  it 'clears the failures' do
+    expect do
+      data_store.clear_failures(light)
+    end.to change { data_store.get_failures(light) }
+      .from([failure]).to(be_empty)
+  end
+end

--- a/spec/support/data_store/base/clear_state.rb
+++ b/spec/support/data_store/base/clear_state.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::DataStore::Base#clear_state' do
+  let(:state) { 'state' }
+
+  it 'returns the state' do
+    data_store.set_state(light, state)
+
+    expect(data_store.clear_state(light)).to eql(state)
+  end
+
+  it 'clears the state' do
+    data_store.set_state(light, state)
+
+    expect do
+      data_store.clear_state(light)
+    end.to change { data_store.get_state(light) }
+      .from(state).to(Stoplight::State::UNLOCKED)
+  end
+end

--- a/spec/support/data_store/base/get_all.rb
+++ b/spec/support/data_store/base/get_all.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::DataStore::Base#get_all' do
+  context 'when there are no errors' do
+    it 'returns the failures and the state' do
+      failures, state = data_store.get_all(light)
+
+      expect(failures).to eql([])
+      expect(state).to eql(Stoplight::State::UNLOCKED)
+    end
+  end
+
+  context 'when there are errors' do
+    before do
+      data_store.record_failure(light, failure)
+    end
+
+    it 'returns the failures and the state' do
+      failures, state = data_store.get_all(light)
+
+      expect(failures).to eq([failure])
+      expect(state).to eql(Stoplight::State::UNLOCKED)
+    end
+  end
+end

--- a/spec/support/data_store/base/get_failures.rb
+++ b/spec/support/data_store/base/get_failures.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::DataStore::Base#get_failures' do
+  it 'is initially empty' do
+    expect(data_store.get_failures(light)).to eql([])
+  end
+
+  it 'handles invalid JSON' do
+    expect { data_store.record_failure(light, failure) }
+      .to change { data_store.get_failures(light) }
+      .from(be_empty)
+      .to(contain_exactly(failure))
+  end
+end

--- a/spec/support/data_store/base/get_state.rb
+++ b/spec/support/data_store/base/get_state.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::DataStore::Base#get_state' do
+  it 'is initially unlocked' do
+    expect(data_store.get_state(light)).to eql(Stoplight::State::UNLOCKED)
+  end
+end

--- a/spec/support/data_store/base/names.rb
+++ b/spec/support/data_store/base/names.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::DataStore::Base#names' do
+  it 'is initially empty' do
+    expect(data_store.names).to eql([])
+  end
+
+  it 'contains the name of a light with a failure' do
+    data_store.record_failure(light, failure)
+    expect(data_store.names).to eql([light.name])
+  end
+
+  it 'contains the name of a light with a set state' do
+    data_store.set_state(light, Stoplight::State::UNLOCKED)
+    expect(data_store.names).to eql([light.name])
+  end
+
+  it 'does not duplicate names' do
+    data_store.record_failure(light, failure)
+    data_store.set_state(light, Stoplight::State::UNLOCKED)
+    expect(data_store.names).to eql([light.name])
+  end
+
+  it 'supports names containing colons' do
+    light = Stoplight::Light.new('http://api.example.com/some/action')
+    data_store.record_failure(light, failure)
+    expect(data_store.names).to eql([light.name])
+  end
+end

--- a/spec/support/data_store/base/record_failures.rb
+++ b/spec/support/data_store/base/record_failures.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::DataStore::Base#record_failure' do
+  it 'returns the number of failures' do
+    expect(data_store.record_failure(light, failure)).to eql(1)
+  end
+
+  context 'when there is an error' do
+    before do
+      data_store.record_failure(light, failure)
+    end
+
+    it 'persists the failure' do
+      expect(data_store.get_failures(light)).to eq([failure])
+    end
+  end
+
+  context 'when there is are several errors' do
+    before do
+      data_store.record_failure(light, failure)
+      data_store.record_failure(light, other)
+    end
+
+    it 'stores more recent failures at the head' do
+      expect(data_store.get_failures(light)).to eq([other, failure])
+    end
+  end
+
+  context 'when the number of errors is bigger then threshold' do
+    before do
+      light.with_threshold(1)
+
+      data_store.record_failure(light, failure)
+    end
+
+    it 'limits the number of stored failures' do
+      expect do
+        data_store.record_failure(light, other)
+      end.to change { data_store.get_failures(light) }
+        .from([failure])
+        .to([other])
+    end
+  end
+end

--- a/spec/support/data_store/base/set_state.rb
+++ b/spec/support/data_store/base/set_state.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::DataStore::Base#set_state' do
+  let(:state) { 'state' }
+
+  it 'returns the state' do
+    expect(data_store.set_state(light, state)).to eql(state)
+  end
+
+  it 'persists the state' do
+    data_store.set_state(light, state)
+
+    expect(data_store.get_state(light)).to eql(state)
+  end
+end

--- a/spec/support/data_store/base/with_notification_lock.rb
+++ b/spec/support/data_store/base/with_notification_lock.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::DataStore::Base#with_notification_lock' do
+  context 'when notification is already sent' do
+    before do
+      data_store.with_notification_lock(light, Stoplight::Color::GREEN, Stoplight::Color::RED) {}
+    end
+
+    it 'does not yield passed block' do
+      expect do |b|
+        data_store.with_notification_lock(light, Stoplight::Color::GREEN, Stoplight::Color::RED, &b)
+      end.not_to yield_control
+    end
+  end
+
+  context 'when notification is not already sent' do
+    before do
+      data_store.with_notification_lock(light, Stoplight::Color::GREEN, Stoplight::Color::RED) {}
+    end
+
+    it 'yields passed block' do
+      expect do |b|
+        data_store.with_notification_lock(light, Stoplight::Color::RED, Stoplight::Color::GREEN, &b)
+      end.to yield_control
+    end
+  end
+end

--- a/stoplight.gemspec
+++ b/stoplight.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |gem|
   ] + Dir.glob(File.join('lib', '**', '*.rb'))
   gem.test_files = Dir.glob(File.join('spec', '**', '*.rb'))
 
-  gem.required_ruby_version = '>= 2.6'
+  gem.required_ruby_version = '>= 2.7'
 
-  gem.add_dependency 'redlock', "~> 1.0"
+  gem.add_dependency 'redlock', '~> 1.0'
 
   gem.add_development_dependency('benchmark-ips', '~> 2.3')
   gem.add_development_dependency('bugsnag', '~> 4.0')


### PR DESCRIPTION
Moved data store specs to use the same specs in the https://github.com/bolshakov/stoplight/pull/165 