### PR TITLE
Add window parameter to get_all, get_failures, record_failure, and clear_failures methods

### DIFF
--- a/lib/stoplight/data_store/base.rb
+++ b/lib/stoplight/data_store/base.rb
@@ -11,26 +11,30 @@ module Stoplight
 
       # @param _light [Light]
       # @return [Array(Array<Failure>, String)]
-      def get_all(_light)
+      # @param window [Integer, nil]
+      def get_all(_light, window: nil)
         raise NotImplementedError
       end
 
       # @param _light [Light]
+      # @param window [Integer, nil]
       # @return [Array<Failure>]
-      def get_failures(_light)
+      def get_failures(_light, window: nil)
         raise NotImplementedError
       end
 
       # @param _light [Light]
       # @param _failure [Failure]
+      # @param window [Integer, nil]
       # @return [Fixnum]
-      def record_failure(_light, _failure)
+      def record_failure(_light, _failure, window: nil)
         raise NotImplementedError
       end
 
       # @param _light [Light]
+      # @param window [Integer, nil]
       # @return [Array<Failure>]
-      def clear_failures(_light)
+      def clear_failures(_light, window: nil)
         raise NotImplementedError
       end
 

--- a/lib/stoplight/data_store/memory.rb
+++ b/lib/stoplight/data_store/memory.rb
@@ -20,15 +20,15 @@ module Stoplight
         synchronize { @failures.keys | @states.keys }
       end
 
-      def get_all(light)
+      def get_all(light, window: nil)
         synchronize { [@failures[light.name], @states[light.name]] }
       end
 
-      def get_failures(light)
+      def get_failures(light, window: nil)
         synchronize { @failures[light.name] }
       end
 
-      def record_failure(light, failure)
+      def record_failure(light, failure, window: nil)
         synchronize do
           n = light.threshold - 1
           @failures[light.name] = @failures[light.name].first(n)
@@ -36,7 +36,7 @@ module Stoplight
         end
       end
 
-      def clear_failures(light)
+      def clear_failures(light, window: nil)
         synchronize { @failures.delete(light.name) }
       end
 

--- a/lib/stoplight/data_store/redis.rb
+++ b/lib/stoplight/data_store/redis.rb
@@ -27,7 +27,7 @@ module Stoplight
         (state_names + failure_names).uniq
       end
 
-      def get_all(light)
+      def get_all(light, window: nil)
         failures, state = @redis.multi do |transaction|
           query_failures(light, transaction: transaction)
           transaction.hget(states_key, light.name)
@@ -39,11 +39,11 @@ module Stoplight
         ]
       end
 
-      def get_failures(light)
+      def get_failures(light, window: nil)
         normalize_failures(query_failures(light), light.error_notifier)
       end
 
-      def record_failure(light, failure)
+      def record_failure(light, failure, window: nil)
         size, = @redis.multi do |transaction|
           transaction.lpush(failures_key(light), failure.to_json)
           transaction.ltrim(failures_key(light), 0, light.threshold - 1)
@@ -52,7 +52,7 @@ module Stoplight
         size
       end
 
-      def clear_failures(light)
+      def clear_failures(light, window: nil)
         failures, = @redis.multi do |transaction|
           query_failures(light, transaction: transaction)
           transaction.del(failures_key(light))

--- a/spec/support/data_store/base/clear_failures.rb
+++ b/spec/support/data_store/base/clear_failures.rb
@@ -1,18 +1,26 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'Stoplight::DataStore::Base#clear_failures' do
-  before do
-    data_store.record_failure(light, failure)
+  shared_examples '#clear_failures' do
+    before do
+      data_store.record_failure(light, failure, window: window)
+    end
+
+    it 'returns the failures' do
+      expect(data_store.clear_failures(light, window: window)).to contain_exactly(failure)
+    end
+
+    it 'clears the failures' do
+      expect do
+        data_store.clear_failures(light, window: window)
+      end.to change { data_store.get_failures(light, window: window) }
+        .from([failure]).to(be_empty)
+    end
   end
 
-  it 'returns the failures' do
-    expect(data_store.clear_failures(light)).to contain_exactly(failure)
-  end
+  context 'without window' do
+    let(:window) { nil }
 
-  it 'clears the failures' do
-    expect do
-      data_store.clear_failures(light)
-    end.to change { data_store.get_failures(light) }
-      .from([failure]).to(be_empty)
+    it_behaves_like '#clear_failures'
   end
 end

--- a/spec/support/data_store/base/get_all.rb
+++ b/spec/support/data_store/base/get_all.rb
@@ -1,25 +1,33 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'Stoplight::DataStore::Base#get_all' do
-  context 'when there are no errors' do
-    it 'returns the failures and the state' do
-      failures, state = data_store.get_all(light)
+  shared_examples '#get_all' do
+    context 'when there are no errors' do
+      it 'returns the failures and the state' do
+        failures, state = data_store.get_all(light, window: window)
 
-      expect(failures).to eql([])
-      expect(state).to eql(Stoplight::State::UNLOCKED)
+        expect(failures).to eql([])
+        expect(state).to eql(Stoplight::State::UNLOCKED)
+      end
+    end
+
+    context 'when there are errors' do
+      before do
+        data_store.record_failure(light, failure, window: window)
+      end
+
+      it 'returns the failures and the state' do
+        failures, state = data_store.get_all(light, window: window)
+
+        expect(failures).to eq([failure])
+        expect(state).to eql(Stoplight::State::UNLOCKED)
+      end
     end
   end
 
-  context 'when there are errors' do
-    before do
-      data_store.record_failure(light, failure)
-    end
+  context 'without window' do
+    let(:window) { nil }
 
-    it 'returns the failures and the state' do
-      failures, state = data_store.get_all(light)
-
-      expect(failures).to eq([failure])
-      expect(state).to eql(Stoplight::State::UNLOCKED)
-    end
+    it_behaves_like '#get_all'
   end
 end

--- a/spec/support/data_store/base/get_failures.rb
+++ b/spec/support/data_store/base/get_failures.rb
@@ -1,14 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'Stoplight::DataStore::Base#get_failures' do
-  it 'is initially empty' do
-    expect(data_store.get_failures(light)).to eql([])
+  shared_examples '#get_failures' do
+    it 'is initially empty' do
+      expect(data_store.get_failures(light, window: window)).to eql([])
+    end
+
+    it 'handles invalid JSON' do
+      expect { data_store.record_failure(light, failure, window: window) }
+        .to change { data_store.get_failures(light, window: window) }
+        .from(be_empty)
+        .to(contain_exactly(failure))
+    end
   end
 
-  it 'handles invalid JSON' do
-    expect { data_store.record_failure(light, failure) }
-      .to change { data_store.get_failures(light) }
-      .from(be_empty)
-      .to(contain_exactly(failure))
+  context 'without window' do
+    let(:window) { nil }
+
+    it_behaves_like '#get_failures'
   end
 end

--- a/spec/support/data_store/base/record_failures.rb
+++ b/spec/support/data_store/base/record_failures.rb
@@ -1,44 +1,52 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'Stoplight::DataStore::Base#record_failure' do
-  it 'returns the number of failures' do
-    expect(data_store.record_failure(light, failure)).to eql(1)
+  shared_examples '#record_failure' do
+    it 'returns the number of failures' do
+      expect(data_store.record_failure(light, failure, window: window)).to eql(1)
+    end
+
+    context 'when there is an error' do
+      before do
+        data_store.record_failure(light, failure, window: window)
+      end
+
+      it 'persists the failure' do
+        expect(data_store.get_failures(light, window: window)).to eq([failure])
+      end
+    end
+
+    context 'when there is are several errors' do
+      before do
+        data_store.record_failure(light, failure, window: window)
+        data_store.record_failure(light, other, window: window)
+      end
+
+      it 'stores more recent failures at the head' do
+        expect(data_store.get_failures(light, window: window)).to eq([other, failure])
+      end
+    end
+
+    context 'when the number of errors is bigger then threshold' do
+      before do
+        light.with_threshold(1)
+
+        data_store.record_failure(light, failure, window: window)
+      end
+
+      it 'limits the number of stored failures' do
+        expect do
+          data_store.record_failure(light, other, window: window)
+        end.to change { data_store.get_failures(light, window: window) }
+          .from([failure])
+          .to([other])
+      end
+    end
   end
 
-  context 'when there is an error' do
-    before do
-      data_store.record_failure(light, failure)
-    end
+  context 'without window' do
+    let(:window) { nil }
 
-    it 'persists the failure' do
-      expect(data_store.get_failures(light)).to eq([failure])
-    end
-  end
-
-  context 'when there is are several errors' do
-    before do
-      data_store.record_failure(light, failure)
-      data_store.record_failure(light, other)
-    end
-
-    it 'stores more recent failures at the head' do
-      expect(data_store.get_failures(light)).to eq([other, failure])
-    end
-  end
-
-  context 'when the number of errors is bigger then threshold' do
-    before do
-      light.with_threshold(1)
-
-      data_store.record_failure(light, failure)
-    end
-
-    it 'limits the number of stored failures' do
-      expect do
-        data_store.record_failure(light, other)
-      end.to change { data_store.get_failures(light) }
-        .from([failure])
-        .to([other])
-    end
+    it_behaves_like '#record_failure'
   end
 end


### PR DESCRIPTION
This is the first step toward introducing the running window strategy. I added the `window` parameter to the `get_all`, `get_failures`, `record_failure`, and `clear_failures` methods. It does nothing now, but it will be used to specify the running window size in the future.

I make a few refactoring in the specs to prepare them for future changes. After introducing the running window strategy, we should be able to run the same specs suite.

The rubocop complains about unused parameters, but this is fine because the PR target branch is [feature/running-window](https://github.com/bolshakov/stoplight/tree/feature/running-window), which I'll be using for integrating all the changes related to "running window" effort.