### PR TITLE
Feature/running window draft

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,339 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="5b905f0f-fc17-4b1d-9935-ae3a074ef19f" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/spec/support/stoplight/data_store/base.rb" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/spec/support/stoplight/data_store/base/get_all.rb" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/spec/support/stoplight/data_store/base/get_failures.rb" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/spec/support/stoplight/data_store/base/names.rb" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/spec/support/stoplight/data_store/base/record_failures.rb" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/lib/stoplight/data_store/memory.rb" beforeDir="false" afterPath="$PROJECT_DIR$/lib/stoplight/data_store/memory.rb" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/lib/stoplight/data_store/redis.rb" beforeDir="false" afterPath="$PROJECT_DIR$/lib/stoplight/data_store/redis.rb" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/spec/spec_helper.rb" beforeDir="false" afterPath="$PROJECT_DIR$/spec/spec_helper.rb" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/spec/stoplight/data_store/memory_spec.rb" beforeDir="false" afterPath="$PROJECT_DIR$/spec/stoplight/data_store/memory_spec.rb" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/spec/stoplight/data_store/redis_spec.rb" beforeDir="false" afterPath="$PROJECT_DIR$/spec/stoplight/data_store/redis_spec.rb" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="Ruby Class" />
+      </list>
+    </option>
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="HighlightingSettingsPerFile">
+    <setting file="file://$USER_HOME$/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/redis-4.8.0/lib/redis/commands/sorted_sets.rb" root0="SKIP_INSPECTION" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectId" id="2IJ6xXDNYRDaf0Hpwbhs4cjKk18" />
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "last_opened_file_path": "/Users/bolshakov/Projects/personal/stoplight/spec/support/stoplight/data_store/base",
+    "nodejs_package_manager_path": "npm",
+    "ruby.rails.projectView.checked": "true",
+    "settings.editor.selected.configurable": "org.jetbrains.plugins.ruby.settings.RubyActiveModuleSdkConfigurable"
+  }
+}]]></component>
+  <component name="RecentsManager">
+    <key name="CopyFile.RECENT_KEYS">
+      <recent name="$PROJECT_DIR$/spec/support/stoplight/data_store/base" />
+      <recent name="$PROJECT_DIR$/lib/stoplight/strategy" />
+      <recent name="$PROJECT_DIR$/spec/stoplight/strategy" />
+    </key>
+  </component>
+  <component name="RunManager" selected="RSpec.Stoplight::DataStore::Redis">
+    <configuration name="All specs in spec: stoplight" type="RSpecRunConfigurationType" factoryName="RSpec" temporary="true">
+      <module name="stoplight" />
+      <predefined_log_file enabled="true" id="RUBY_RSPEC" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
+      <envs>
+        <env name="JRUBY_OPTS" value="-X+O" />
+      </envs>
+      <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="AUTO" bundleExecEnabled="true" />
+      <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov" ENABLE_BRANCH_COVERAGE="true" ENABLE_FORKED_COVERAGE="true">
+        <COVERAGE_PATTERN ENABLED="true">
+          <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
+        </COVERAGE_PATTERN>
+      </EXTENSION>
+      <EXTENSION ID="org.jetbrains.plugins.ruby.rails.run.RailsRunConfigurationExtension" SCRATCH_USE_RAILS_RUNNER="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="$MODULE_DIR$/spec" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATHS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="ALL_IN_FOLDER" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
+      <method v="2" />
+    </configuration>
+    <configuration name="Stoplight::DataStore::Memory" type="RSpecRunConfigurationType" factoryName="RSpec" temporary="true" nameIsGenerated="true">
+      <module name="stoplight" />
+      <predefined_log_file enabled="true" id="RUBY_RSPEC" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
+      <envs>
+        <env name="JRUBY_OPTS" value="-X+O" />
+      </envs>
+      <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="AUTO" bundleExecEnabled="true" />
+      <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov" ENABLE_BRANCH_COVERAGE="true" ENABLE_FORKED_COVERAGE="true">
+        <COVERAGE_PATTERN ENABLED="true">
+          <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
+        </COVERAGE_PATTERN>
+      </EXTENSION>
+      <EXTENSION ID="org.jetbrains.plugins.ruby.rails.run.RailsRunConfigurationExtension" SCRATCH_USE_RAILS_RUNNER="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="$MODULE_DIR$/spec/stoplight/data_store/memory_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATHS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="Stoplight::DataStore::Memory" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="TEST_SCRIPT" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
+      <method v="2" />
+    </configuration>
+    <configuration name="Stoplight::DataStore::Redis" type="RSpecRunConfigurationType" factoryName="RSpec" temporary="true" nameIsGenerated="true">
+      <module name="stoplight" />
+      <predefined_log_file enabled="true" id="RUBY_RSPEC" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
+      <envs>
+        <env name="JRUBY_OPTS" value="-X+O" />
+      </envs>
+      <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="AUTO" bundleExecEnabled="true" />
+      <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov" ENABLE_BRANCH_COVERAGE="true" ENABLE_FORKED_COVERAGE="true">
+        <COVERAGE_PATTERN ENABLED="true">
+          <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
+        </COVERAGE_PATTERN>
+      </EXTENSION>
+      <EXTENSION ID="org.jetbrains.plugins.ruby.rails.run.RailsRunConfigurationExtension" SCRATCH_USE_RAILS_RUNNER="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="$MODULE_DIR$/spec/stoplight/data_store/redis_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATHS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="Stoplight::DataStore::Redis" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="TEST_SCRIPT" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
+      <method v="2" />
+    </configuration>
+    <configuration name="Stoplight::Strategy::RunningWindow" type="RSpecRunConfigurationType" factoryName="RSpec" temporary="true" nameIsGenerated="true">
+      <module name="stoplight" />
+      <predefined_log_file enabled="true" id="RUBY_RSPEC" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
+      <envs>
+        <env name="JRUBY_OPTS" value="-X+O" />
+      </envs>
+      <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="AUTO" bundleExecEnabled="true" />
+      <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov" ENABLE_BRANCH_COVERAGE="true" ENABLE_FORKED_COVERAGE="true">
+        <COVERAGE_PATTERN ENABLED="true">
+          <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
+        </COVERAGE_PATTERN>
+      </EXTENSION>
+      <EXTENSION ID="org.jetbrains.plugins.ruby.rails.run.RailsRunConfigurationExtension" SCRATCH_USE_RAILS_RUNNER="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="$MODULE_DIR$/spec/stoplight/strategy/running_window_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATHS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="Stoplight::Strategy::RunningWindow" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="TEST_SCRIPT" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
+      <method v="2" />
+    </configuration>
+    <configuration name="vintage_spec" type="RSpecRunConfigurationType" factoryName="RSpec" temporary="true" nameIsGenerated="true">
+      <module name="stoplight" />
+      <predefined_log_file enabled="true" id="RUBY_RSPEC" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
+      <envs>
+        <env name="JRUBY_OPTS" value="-X+O" />
+      </envs>
+      <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="AUTO" bundleExecEnabled="true" />
+      <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov" ENABLE_BRANCH_COVERAGE="true" ENABLE_FORKED_COVERAGE="true">
+        <COVERAGE_PATTERN ENABLED="true">
+          <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
+        </COVERAGE_PATTERN>
+      </EXTENSION>
+      <EXTENSION ID="org.jetbrains.plugins.ruby.rails.run.RailsRunConfigurationExtension" SCRATCH_USE_RAILS_RUNNER="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="$MODULE_DIR$/spec/stoplight/strategy/vintage_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATHS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="TEST_SCRIPT" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
+      <method v="2" />
+    </configuration>
+    <recent_temporary>
+      <list>
+        <item itemvalue="RSpec.Stoplight::DataStore::Redis" />
+        <item itemvalue="RSpec.All specs in spec: stoplight" />
+        <item itemvalue="RSpec.Stoplight::DataStore::Memory" />
+        <item itemvalue="RSpec.vintage_spec" />
+        <item itemvalue="RSpec.Stoplight::Strategy::RunningWindow" />
+      </list>
+    </recent_temporary>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="SpringUtil" SPRING_PRE_LOADER_OPTION="true" RAKE_SPRING_PRE_LOADER_OPTION="true" RAILS_SPRING_PRE_LOADER_OPTION="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="5b905f0f-fc17-4b1d-9935-ae3a074ef19f" name="Changes" comment="" />
+      <created>1669887585253</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1669887585253</updated>
+      <workItem from="1669887586845" duration="1546000" />
+      <workItem from="1670078519146" duration="606000" />
+      <workItem from="1670252971323" duration="30310000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager>
+      <breakpoints>
+        <line-breakpoint type="ruby-line">
+          <url>file://$PROJECT_DIR$/spec/support/stoplight/data_store/base/record_failures.rb</url>
+          <line>57</line>
+          <properties myBlockOrdinal="-1">
+            <option name="block-ordinal" value="-1" />
+          </properties>
+          <option name="timeStamp" value="29" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="ruby-line">
+          <dependency master-id="0" />
+          <url>file://$PROJECT_DIR$/lib/stoplight/data_store/memory.rb</url>
+          <line>38</line>
+          <properties myBlockOrdinal="-1">
+            <option name="block-ordinal" value="-1" />
+          </properties>
+          <option name="timeStamp" value="32" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="ruby-line">
+          <dependency id="0" />
+          <url>file://$PROJECT_DIR$/spec/support/stoplight/data_store/base/record_failures.rb</url>
+          <line>31</line>
+          <properties myBlockOrdinal="-1">
+            <option name="block-ordinal" value="-1" />
+          </properties>
+          <option name="timeStamp" value="33" />
+        </line-breakpoint>
+      </breakpoints>
+    </breakpoint-manager>
+  </component>
+  <component name="com.intellij.coverage.CoverageDataManagerImpl">
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis_record_failure_with_a_window.rcov" NAME="Stoplight::DataStore::Redis#record_failure with a window Coverage Results" MODIFIED="1670363416390" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis_get_failures_with_window_returns_failures_withing_given_window.rcov" NAME="Stoplight::DataStore::Redis#get_failures with window returns failures withing given window Coverage Results" MODIFIED="1670364301245" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis_record_failure_without_a_window_persists_the_failure.rcov" NAME="Stoplight::DataStore::Redis#record_failure without a window persists the failure Coverage Results" MODIFIED="1670361613268" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis_get_failures_handles_invalid_JSON.rcov" NAME="Stoplight::DataStore::Redis#get_failures handles invalid JSON Coverage Results" MODIFIED="1670363778273" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__Strategy__RunningWindow_Stoplight__Strategy__RunningWindow_record_failure_when_there_are_many_failures_threshold.rcov" NAME="Stoplight::Strategy::RunningWindow Stoplight::Strategy::RunningWindow#record_failure when there are many failures threshold Coverage Results" MODIFIED="1670415029657" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis.rcov" NAME="Stoplight::DataStore::Redis Coverage Results" MODIFIED="1670436144448" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis_record_failure_without_a_window_stores_more_recent_failures_at_the_head.rcov" NAME="Stoplight::DataStore::Redis#record_failure without a window stores more recent failures at the head Coverage Results" MODIFIED="1670362236363" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis_get_failures_without_window_returns_failures.rcov" NAME="Stoplight::DataStore::Redis#get_failures without window returns failures Coverage Results" MODIFIED="1670364027164" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__Strategy__Base_with_notification_lock_delegates_to_the_data_store.rcov" NAME="Stoplight::Strategy::Base#with_notification_lock delegates to the data store Coverage Results" MODIFIED="1670368727755" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@base_spec.rcov" NAME="base_spec Coverage Results" MODIFIED="1670368731061" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@redis_spec.rcov" NAME="redis_spec Coverage Results" MODIFIED="1670363613539" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__Strategy__RunningWindow_with_memory_data_store.rcov" NAME="Stoplight::Strategy::RunningWindow with memory data store Coverage Results" MODIFIED="1670372156158" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@All_specs_in_spec__stoplight__1_.rcov" NAME="All specs in spec: stoplight (1) Coverage Results" MODIFIED="1670360077427" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@running_window_spec.rcov" NAME="running_window_spec Coverage Results" MODIFIED="1670372654475" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@All_specs_in_spec__stoplight.rcov" NAME="All specs in spec: stoplight Coverage Results" MODIFIED="1670435300055" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis_get_failures_without_window_handles_invalid_JSON.rcov" NAME="Stoplight::DataStore::Redis#get_failures without window handles invalid JSON Coverage Results" MODIFIED="1670364131967" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__Strategy__Base_clear_state.rcov" NAME="Stoplight::Strategy::Base#clear_state Coverage Results" MODIFIED="1670368516691" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis_get_failures_with_window_is_initially_empty.rcov" NAME="Stoplight::DataStore::Redis#get_failures with window is initially empty Coverage Results" MODIFIED="1670364176775" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@base_spec__1_.rcov" NAME="base_spec (1) Coverage Results" MODIFIED="1670367817895" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis_get_failures_without_window.rcov" NAME="Stoplight::DataStore::Redis#get_failures without window Coverage Results" MODIFIED="1670363865106" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__Strategy__Base_get_state.rcov" NAME="Stoplight::Strategy::Base#get_state Coverage Results" MODIFIED="1670368356724" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis_record_failure_without_a_window.rcov" NAME="Stoplight::DataStore::Redis#record_failure without a window Coverage Results" MODIFIED="1670363025865" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis_record_failure.rcov" NAME="Stoplight::DataStore::Redis#record_failure Coverage Results" MODIFIED="1670364530563" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__Strategy__Base_set_state.rcov" NAME="Stoplight::Strategy::Base#set_state Coverage Results" MODIFIED="1670368419262" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__Strategy__Base_names_is_not_implemented.rcov" NAME="Stoplight::Strategy::Base#names is not implemented Coverage Results" MODIFIED="1670368162953" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis_record_failure_with_a_window_returns_the_number_of_failures.rcov" NAME="Stoplight::DataStore::Redis#record_failure with a window returns the number of failures Coverage Results" MODIFIED="1670363189751" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis_get_failures.rcov" NAME="Stoplight::DataStore::Redis#get_failures Coverage Results" MODIFIED="1670364399338" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Redis_record_failure_without_a_window_returns_the_number_of_failures.rcov" NAME="Stoplight::DataStore::Redis#record_failure without a window returns the number of failures Coverage Results" MODIFIED="1670362927541" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@vintage_spec.rcov" NAME="vintage_spec Coverage Results" MODIFIED="1670415580981" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__Strategy__Vintage_with_memory_data_store.rcov" NAME="Stoplight::Strategy::Vintage with memory data store Coverage Results" MODIFIED="1670370317112" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__Strategy__RunningWindow.rcov" NAME="Stoplight::Strategy::RunningWindow Coverage Results" MODIFIED="1670415467593" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__Strategy__RunningWindow_Stoplight__Strategy__RunningWindow_record_failure_when_there_are_many_failures_limits_the_number_of_stored_failures.rcov" NAME="Stoplight::Strategy::RunningWindow Stoplight::Strategy::RunningWindow#record_failure when there are many failures limits the number of stored failures Coverage Results" MODIFIED="1670372390012" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__Light__Runnable_run_when_the_light_is_green_when_the_data_store_is_failing_notifies_about_the_error.rcov" NAME="Stoplight::Light::Runnable#run when the light is green when the data store is failing notifies about the error Coverage Results" MODIFIED="1670357186051" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+    <SUITE FILE_PATH="coverage/stoplight@Stoplight__DataStore__Memory.rcov" NAME="Stoplight::DataStore::Memory Coverage Results" MODIFIED="1670435295855" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="rcov" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" MODULE_NAME="stoplight" />
+  </component>
+</project>

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Metrics/BlockLength:
   Exclude:

--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -15,6 +15,9 @@ require 'stoplight/data_store/base'
 require 'stoplight/data_store/memory'
 require 'stoplight/data_store/redis'
 
+require 'stoplight/strategy/base'
+require 'stoplight/strategy/vintage'
+
 require 'stoplight/notifier'
 require 'stoplight/notifier/base'
 require 'stoplight/notifier/generic'

--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -17,6 +17,7 @@ require 'stoplight/data_store/redis'
 
 require 'stoplight/strategy/base'
 require 'stoplight/strategy/vintage'
+require 'stoplight/strategy/running_window'
 
 require 'stoplight/notifier'
 require 'stoplight/notifier/base'

--- a/lib/stoplight/data_store/base.rb
+++ b/lib/stoplight/data_store/base.rb
@@ -10,27 +10,31 @@ module Stoplight
       end
 
       # @param _light [Light]
+      # @param window [Integer, nil]
       # @return [Array(Array<Failure>, String)]
-      def get_all(_light)
+      def get_all(_light, window: nil)
         raise NotImplementedError
       end
 
       # @param _light [Light]
+      # @param window [Integer, nil]
       # @return [Array<Failure>]
-      def get_failures(_light)
+      def get_failures(_light, window: nil)
         raise NotImplementedError
       end
 
       # @param _light [Light]
       # @param _failure [Failure]
+      # @param window [Integer, nil]
       # @return [Fixnum]
-      def record_failure(_light, _failure)
+      def record_failure(_light, _failure, window: nil)
         raise NotImplementedError
       end
 
       # @param _light [Light]
+      # @param window [Integer, nil]
       # @return [Array<Failure>]
-      def clear_failures(_light)
+      def clear_failures(_light, window: nil)
         raise NotImplementedError
       end
 

--- a/lib/stoplight/data_store/memory.rb
+++ b/lib/stoplight/data_store/memory.rb
@@ -88,11 +88,12 @@ module Stoplight
       private
 
       def query_failures(light, window:)
+        failures = @failures[light.name].sort_by(&:time).reverse
         if window
           window_start = Time.now - window
-          @failures[light.name].select { |x| x.time >= window_start }
+          failures.select { |x| x.time >= window_start }
         else
-          @failures[light.name]
+          failures
         end
       end
     end

--- a/lib/stoplight/data_store/redis.rb
+++ b/lib/stoplight/data_store/redis.rb
@@ -112,8 +112,8 @@ module Stoplight
       end
 
       def query_failures(light, window:, transaction: @redis)
-        to = window ? window_starts(window) : -1
-        transaction.zrange(failures_key(light), 0, to)
+        from = window ? window_starts(window) : 0
+        transaction.zrange(failures_key(light), '+inf', from, rev: true, by_score: true)
       end
 
       def normalize_failures(failures, error_notifier)

--- a/lib/stoplight/data_store/redis.rb
+++ b/lib/stoplight/data_store/redis.rb
@@ -6,8 +6,8 @@ module Stoplight
   module DataStore
     # @see Base
     class Redis < Base
-      KEY_PREFIX = 'stoplight'
       KEY_SEPARATOR = ':'
+      KEY_PREFIX = %w[stoplight v4].join(KEY_SEPARATOR)
 
       # @param redis [::Redis]
       def initialize(redis, redlock: Redlock::Client.new([redis]))

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -6,6 +6,8 @@ module Stoplight
 
     DATA_STORE = DataStore::Memory.new
 
+    Strategy = Strategy::Vintage
+
     ERROR_HANDLER = ->(error, handler) { handler.call(error) }
 
     ERROR_NOTIFIER = ->(error) { warn error }

--- a/lib/stoplight/failure.rb
+++ b/lib/stoplight/failure.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'time'
+require 'securerandom'
 
 module Stoplight
   class Failure # rubocop:disable Style/Documentation
@@ -13,6 +14,8 @@ module Stoplight
     attr_reader :error_message
     # @return [Time]
     attr_reader :time
+    # @return [String]
+    attr_reader :uuid
 
     # @param error [Exception]
     # @return (see #initialize)
@@ -31,17 +34,20 @@ module Stoplight
       error_class = error_object['class']
       error_message = error_object['message']
       time = Time.parse(object['time'])
+      uuid = object['uuid']
 
-      new(error_class, error_message, time)
+      new(error_class, error_message, time, uuid)
     end
 
     # @param error_class [String]
     # @param error_message [String]
     # @param time [Time]
-    def initialize(error_class, error_message, time)
+    # @param uuid [String]
+    def initialize(error_class, error_message, time, uuid = SecureRandom.uuid)
       @error_class = error_class
       @error_message = error_message
       @time = time
+      @uuid = uuid
     end
 
     # @param other [Failure]
@@ -61,7 +67,7 @@ module Stoplight
             class: error_class,
             message: error_message
           },
-          time: time.strftime(TIME_FORMAT)
+          time: time.strftime(TIME_FORMAT), uuid: uuid
         },
         options
       )

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -8,8 +8,6 @@ module Stoplight
     attr_reader :code
     # @return [Float]
     attr_reader :cool_off_time
-    # @return [DataStore::Base]
-    attr_reader :data_store
     # @return [Proc]
     attr_reader :error_handler
     # @return [Proc]
@@ -22,6 +20,9 @@ module Stoplight
     attr_reader :notifiers
     # @return [Fixnum]
     attr_reader :threshold
+
+    # @return [Stoplight::Strategy::Base]
+    attr_reader :strategy
 
     class << self
       # @return [DataStore::Base]
@@ -42,13 +43,14 @@ module Stoplight
       @name = name
       @code = code
 
-      @cool_off_time = Default::COOL_OFF_TIME
-      @data_store = self.class.default_data_store
-      @error_handler = Default::ERROR_HANDLER
-      @error_notifier = self.class.default_error_notifier
-      @fallback = Default::FALLBACK
-      @notifiers = self.class.default_notifiers
-      @threshold = Default::THRESHOLD
+      @strategy_class = Default::Strategy
+      with_cool_off_time(Default::COOL_OFF_TIME)
+      with_data_store(self.class.default_data_store)
+      with_error_handler(&Default::ERROR_HANDLER)
+      with_error_notifier(&self.class.default_error_notifier)
+      with_fallback(&Default::FALLBACK)
+      with_notifiers(self.class.default_notifiers)
+      with_threshold(Default::THRESHOLD)
     end
 
     # @param cool_off_time [Float]
@@ -61,7 +63,7 @@ module Stoplight
     # @param data_store [DataStore::Base]
     # @return [self]
     def with_data_store(data_store)
-      @data_store = data_store
+      @strategy = @strategy_class.new(data_store)
       self
     end
 

--- a/lib/stoplight/light/runnable.rb
+++ b/lib/stoplight/light/runnable.rb
@@ -71,15 +71,15 @@ module Stoplight
       end
 
       def clear_failures
-        safely([]) { data_store.clear_failures(self) }
+        safely([]) { strategy.clear_failures(self) }
       end
 
       def failures_and_state
-        safely([[], State::UNLOCKED]) { data_store.get_all(self) }
+        safely([[], State::UNLOCKED]) { strategy.get_all(self) }
       end
 
       def notify(from_color, to_color, error = nil)
-        data_store.with_notification_lock(self, from_color, to_color) do
+        strategy.with_notification_lock(self, from_color, to_color) do
           notifiers.each do |notifier|
             safely { notifier.notify(self, from_color, to_color, error) }
           end
@@ -88,11 +88,11 @@ module Stoplight
 
       def record_failure(error)
         failure = Failure.from_error(error)
-        safely(0) { data_store.record_failure(self, failure) }
+        safely(0) { strategy.record_failure(self, failure) }
       end
 
       def safely(default = nil, &code)
-        return yield if data_store == Default::DATA_STORE
+        return yield if strategy.data_store == Default::DATA_STORE
 
         self
           .class

--- a/lib/stoplight/strategy/base.rb
+++ b/lib/stoplight/strategy/base.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Strategy
+    # @abstract
+    class Base
+      # @!attribute data_store
+      #   @return [Stoplight::DataStore::Base]
+      attr_reader :data_store
+      private :data_store
+
+      # @param data_store [Stoplight::DataStore::Base]
+      def initialize(data_store)
+        @data_store = data_store
+      end
+    end
+  end
+end

--- a/lib/stoplight/strategy/base.rb
+++ b/lib/stoplight/strategy/base.rb
@@ -11,6 +11,7 @@ module Stoplight
       # @!attribute data_store
       #   @return [Stoplight::DataStore::Base]
       attr_reader :data_store
+
       # private :data_store
 
       # @param data_store [Stoplight::DataStore::Base]

--- a/lib/stoplight/strategy/base.rb
+++ b/lib/stoplight/strategy/base.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require 'forwardable'
+
 module Stoplight
   module Strategy
     # @abstract
     class Base
+      extend Forwardable
+
       # @!attribute data_store
       #   @return [Stoplight::DataStore::Base]
       attr_reader :data_store
@@ -13,6 +17,37 @@ module Stoplight
       def initialize(data_store)
         @data_store = data_store
       end
+
+      # @param _light [Light]
+      # @return [Array(Array<Failure>, String)]
+      def get_all(_light)
+        raise NotImplementedError
+      end
+
+      # @param _light [Light]
+      # @return [Array<Failure>]
+      def get_failures(_light)
+        raise NotImplementedError
+      end
+
+      # @param _light [Light]
+      # @param _failure [Failure]
+      # @return [Fixnum]
+      def record_failure(_light, _failure)
+        raise NotImplementedError
+      end
+
+      # @param _light [Light]
+      # @return [Array<Failure>]
+      def clear_failures(_light)
+        raise NotImplementedError
+      end
+
+      def_delegator :data_store, :clear_state
+      def_delegator :data_store, :get_state
+      def_delegator :data_store, :names
+      def_delegator :data_store, :set_state
+      def_delegator :data_store, :with_notification_lock
     end
   end
 end

--- a/lib/stoplight/strategy/base.rb
+++ b/lib/stoplight/strategy/base.rb
@@ -11,7 +11,7 @@ module Stoplight
       # @!attribute data_store
       #   @return [Stoplight::DataStore::Base]
       attr_reader :data_store
-      private :data_store
+      # private :data_store
 
       # @param data_store [Stoplight::DataStore::Base]
       def initialize(data_store)

--- a/lib/stoplight/strategy/running_window.rb
+++ b/lib/stoplight/strategy/running_window.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module Stoplight
+  module Strategy
+    # Running Window strategy takes into account only errors that happened
+    # within last last +window+ seconds
+    #
+    class RunningWindow < Base
+      # @!attribute window
+      #   @return [Integer]
+      attr_reader :window
+
+      # @param data_store [Stoplight::DataStore::Base]
+      # @param window [Integer]
+      def initialize(data_store, window:)
+        super(data_store)
+        @window = window
+      end
+
+      def clear_failures(light)
+        data_store.clear_failures(light, window: window)
+      end
+
+      def get_all(light)
+        data_store.get_all(light, window: window)
+      end
+
+      def get_failures(light)
+        data_store.get_failures(light, window: window)
+      end
+
+      def record_failure(light, failure)
+        data_store.record_failure(light, failure, window: window)
+      end
+    end
+  end
+end

--- a/lib/stoplight/strategy/vintage.rb
+++ b/lib/stoplight/strategy/vintage.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module Stoplight
+  module Strategy
+    # Vintage strategy is the old good strategy
+    # that Stoplight have been using since the beginning.
+    # It does not take into account the time when an error
+    # happens.
+    #
+    class Vintage < Base
+      extend Forwardable
+
+      attr_reader :data_store
+
+      # @param data_store [Stoplight::DataStore::Base]
+      def initialize(data_store)
+        @data_store = data_store
+      end
+
+      def_delegator :data_store, :clear_failures
+      def_delegator :data_store, :get_all
+      def_delegator :data_store, :get_failures
+      def_delegator :data_store, :record_failure
+      def_delegator :data_store, :set_state
+      def_delegator :data_store, :with_notification_lock
+    end
+  end
+end

--- a/lib/stoplight/strategy/vintage.rb
+++ b/lib/stoplight/strategy/vintage.rb
@@ -12,23 +12,10 @@ module Stoplight
     class Vintage < Base
       extend Forwardable
 
-      attr_reader :data_store
-
-      # @param data_store [Stoplight::DataStore::Base]
-      def initialize(data_store)
-        @data_store = data_store
-      end
-
       def_delegator :data_store, :clear_failures
       def_delegator :data_store, :get_all
       def_delegator :data_store, :get_failures
       def_delegator :data_store, :record_failure
-
-      def_delegator :data_store, :clear_state
-      def_delegator :data_store, :get_state
-      def_delegator :data_store, :names
-      def_delegator :data_store, :set_state
-      def_delegator :data_store, :with_notification_lock
     end
   end
 end

--- a/lib/stoplight/strategy/vintage.rb
+++ b/lib/stoplight/strategy/vintage.rb
@@ -23,6 +23,10 @@ module Stoplight
       def_delegator :data_store, :get_all
       def_delegator :data_store, :get_failures
       def_delegator :data_store, :record_failure
+
+      def_delegator :data_store, :clear_state
+      def_delegator :data_store, :get_state
+      def_delegator :data_store, :names
       def_delegator :data_store, :set_state
       def_delegator :data_store, :with_notification_lock
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'simplecov'
 
 require 'stoplight'
 require 'timecop'
+require 'support/stoplight/data_store/base'
 
 Timecop.safe_mode = true
 

--- a/spec/stoplight/data_store/memory_spec.rb
+++ b/spec/stoplight/data_store/memory_spec.rb
@@ -16,73 +16,13 @@ RSpec.describe Stoplight::DataStore::Memory do
     expect(described_class).to be < Stoplight::DataStore::Base
   end
 
-  describe '#names' do
-    it 'is initially empty' do
-      expect(data_store.names).to eql([])
-    end
+  it_behaves_like 'Stoplight::DataStore::Base#names'
 
-    it 'contains the name of a light with a failure' do
-      data_store.record_failure(light, failure)
-      expect(data_store.names).to eql([light.name])
-    end
+  it_behaves_like 'Stoplight::DataStore::Base#get_all'
 
-    it 'contains the name of a light with a set state' do
-      data_store.set_state(light, Stoplight::State::UNLOCKED)
-      expect(data_store.names).to eql([light.name])
-    end
+  it_behaves_like 'Stoplight::DataStore::Base#get_failures'
 
-    it 'does not duplicate names' do
-      data_store.record_failure(light, failure)
-      data_store.set_state(light, Stoplight::State::UNLOCKED)
-      expect(data_store.names).to eql([light.name])
-    end
-
-    it 'supports names containing colons' do
-      light = Stoplight::Light.new('http://api.example.com/some/action')
-      data_store.record_failure(light, failure)
-      expect(data_store.names).to eql([light.name])
-    end
-  end
-
-  describe '#get_all' do
-    it 'returns the failures and the state' do
-      failures, state = data_store.get_all(light)
-      expect(failures).to eql([])
-      expect(state).to eql(Stoplight::State::UNLOCKED)
-    end
-  end
-
-  describe '#get_failures' do
-    it 'is initially empty' do
-      expect(data_store.get_failures(light)).to eql([])
-    end
-  end
-
-  describe '#record_failure' do
-    it 'returns the number of failures' do
-      expect(data_store.record_failure(light, failure)).to eql(1)
-    end
-
-    it 'persists the failure' do
-      data_store.record_failure(light, failure)
-      expect(data_store.get_failures(light)).to eql([failure])
-    end
-
-    it 'stores more recent failures at the front' do
-      data_store.record_failure(light, failure)
-      other = Stoplight::Failure.new('class', 'message 2', Time.new)
-      data_store.record_failure(light, other)
-      expect(data_store.get_failures(light)).to eql([other, failure])
-    end
-
-    it 'limits the number of stored failures' do
-      light.with_threshold(1)
-      data_store.record_failure(light, failure)
-      other = Stoplight::Failure.new('class', 'message 2', Time.new)
-      data_store.record_failure(light, other)
-      expect(data_store.get_failures(light)).to eql([other])
-    end
-  end
+  it_behaves_like 'Stoplight::DataStore::Base#record_failures'
 
   describe '#clear_failures' do
     it 'returns the failures' do

--- a/spec/stoplight/data_store/redis_spec.rb
+++ b/spec/stoplight/data_store/redis_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Stoplight::DataStore::Redis do
   end
 
   describe '#with_notification_lock' do
-    let(:lock_key) { "stoplight:notification_lock:#{name}" }
+    let(:lock_key) { "stoplight:v4:notification_lock:#{name}" }
 
     before do
       allow(redlock).to receive(:lock).with(lock_key, 2_000).and_yield

--- a/spec/stoplight/failure_spec.rb
+++ b/spec/stoplight/failure_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe Stoplight::Failure do
   let(:error_class) { error.class.name }
   let(:error_message) { error.message }
   let(:time) { Time.new(2001, 2, 3, 4, 5, 6, '+07:08') }
+  let(:uuid) { SecureRandom.uuid }
   let(:json) do
     JSON.generate(
       error: { class: error_class, message: error_message },
-      time: time.strftime('%Y-%m-%dT%H:%M:%S.%N%:z')
+      time: time.strftime('%Y-%m-%dT%H:%M:%S.%N%:z'),
+      uuid: uuid
     )
   end
 
@@ -35,6 +37,7 @@ RSpec.describe Stoplight::Failure do
       expect(failure.error_class).to eql(error_class)
       expect(failure.error_message).to eql(error_message)
       expect(failure.time).to eql(time)
+      expect(failure.uuid).to eql(uuid)
     end
   end
 
@@ -85,14 +88,22 @@ RSpec.describe Stoplight::Failure do
   end
 
   describe '#to_json' do
-    it 'generates JSON' do
-      expect(described_class.new(error_class, error_message, time).to_json)
-        .to eql(json)
+    let(:failure) { described_class.new(error_class, error_message, time, uuid) }
+
+    context 'without options' do
+      subject(:serialized_failure) { failure.to_json }
+
+      it 'generates JSON' do
+        expect(serialized_failure).to eql(json)
+      end
     end
 
-    it 'generates JSON with options' do
-      expect(described_class.new(error_class, error_message, time).to_json({}))
-        .to eql(json)
+    context 'without options' do
+      subject(:serialized_failure) { failure.to_json({}) }
+
+      it 'generates JSON' do
+        expect(serialized_failure).to eql(json)
+      end
     end
   end
 

--- a/spec/stoplight/light_spec.rb
+++ b/spec/stoplight/light_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Stoplight::Light do
 
   describe '#data_store' do
     it 'is initially the default' do
-      expect(light.data_store).to eql(described_class.default_data_store)
+      expect(light.strategy.data_store).to eql(described_class.default_data_store)
     end
   end
 
@@ -131,10 +131,11 @@ RSpec.describe Stoplight::Light do
   end
 
   describe '#with_data_store' do
-    it 'sets the data store' do
+    it 'sets strategy' do
       data_store = Stoplight::DataStore::Memory.new
       light.with_data_store(data_store)
-      expect(light.data_store).to eql(data_store)
+      expect(light.strategy).to be_kind_of(Stoplight::Default::Strategy)
+      expect(light.strategy.data_store).to eql(data_store)
     end
   end
 

--- a/spec/stoplight/strategy/base_spec.rb
+++ b/spec/stoplight/strategy/base_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Stoplight::Strategy::Base do
+  subject(:strategy) { described_class.new(data_store) }
+
+  let(:data_store) { instance_double(Stoplight::DataStore::Memory) }
+
+  describe '#get_all' do
+    it 'is not implemented' do
+      expect { strategy.get_all(nil) }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#get_failures' do
+    it 'is not implemented' do
+      expect { strategy.get_failures(nil) }
+        .to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#record_failure' do
+    it 'is not implemented' do
+      expect { strategy.record_failure(nil, nil) }
+        .to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#clear_failures' do
+    it 'is not implemented' do
+      expect { strategy.clear_failures(nil) }
+        .to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#names' do
+    let(:names) { ['foo'] }
+
+    it 'delegates to the data store' do
+      expect(data_store).to receive(:names).and_return(names)
+
+      expect(strategy.names).to eq(names)
+    end
+  end
+
+  describe '#get_state' do
+    let(:state) { Stoplight::State::UNLOCKED }
+    let(:light) { instance_double(Stoplight::Light) }
+
+    it 'delegates to the data store' do
+      expect(data_store).to receive(:get_state).with(light).and_return(state)
+
+      expect(strategy.get_state(light)).to eq(state)
+    end
+  end
+
+  describe '#set_state' do
+    let(:state) { Stoplight::State::UNLOCKED }
+    let(:light) { instance_double(Stoplight::Light) }
+
+    it 'delegates to the data store' do
+      expect(data_store).to receive(:set_state).with(light, state).and_return(state)
+
+      expect(strategy.set_state(light, state)).to eq(state)
+    end
+  end
+
+  describe '#clear_state' do
+    let(:state) { Stoplight::State::UNLOCKED }
+    let(:light) { instance_double(Stoplight::Light) }
+
+    it 'delegates to the data store' do
+      expect(data_store).to receive(:clear_state).with(light).and_return(state)
+
+      expect(strategy.clear_state(light)).to eq(state)
+    end
+  end
+
+  describe '#with_notification_lock' do
+    let(:from) { Stoplight::Color::GREEN }
+    let(:to) { Stoplight::Color::RED }
+    let(:light) { instance_double(Stoplight::Light) }
+
+    it 'delegates to the data store' do
+      expect(data_store).to receive(:with_notification_lock).with(light, from, to).and_return(42)
+
+      expect(strategy.with_notification_lock(light, from, to)).to eq(42)
+    end
+  end
+end

--- a/spec/stoplight/strategy/running_window_spec.rb
+++ b/spec/stoplight/strategy/running_window_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'mock_redis'
+
+RSpec.describe Stoplight::Strategy::RunningWindow do
+  subject(:strategy) { described_class.new(data_store, window: window) }
+
+  let(:window) { 3600 }
+
+  shared_examples Stoplight::Strategy::RunningWindow do
+    let(:light) { Stoplight::Light.new(name) {} }
+    let(:name) { SecureRandom.uuid }
+
+    describe '#get_all' do
+      context 'when there is no failures' do
+        it 'returns no failures and state' do
+          failures, state = strategy.get_all(light)
+          expect(failures).to eql([])
+          expect(state).to eql(Stoplight::State::UNLOCKED)
+        end
+      end
+
+      context 'when there are failures' do
+        let(:failure) { Stoplight::Failure.new('class', 'message', Time.new) }
+
+        before do
+          strategy.record_failure(light, failure)
+        end
+
+        it 'returns failures and state' do
+          failures, state = strategy.get_all(light)
+          expect(failures).to contain_exactly(failure)
+          expect(state).to eql(Stoplight::State::UNLOCKED)
+        end
+      end
+    end
+
+    describe '#get_failures' do
+      subject { strategy.get_failures(light) }
+
+      context 'when there is no failures' do
+        it { is_expected.to be_empty }
+      end
+
+      context 'when there are failures' do
+        let(:failure) { Stoplight::Failure.new('class', 'message', Time.new) }
+
+        before do
+          strategy.record_failure(light, failure)
+        end
+
+        it { is_expected.to contain_exactly(failure) }
+      end
+    end
+
+    describe '#record_failure' do
+      let(:failure) { Stoplight::Failure.new('class', 'message', Time.new) }
+
+      it 'returns the number of failures' do
+        expect(strategy.record_failure(light, failure)).to eql(1)
+      end
+
+      context 'when there are many failures' do
+        let(:another_failure) { Stoplight::Failure.new('class', 'message 2', Time.new - 10) }
+
+        it 'stores more recent failures at the head' do
+          strategy.record_failure(light, failure)
+          strategy.record_failure(light, another_failure)
+
+          expect(strategy.get_failures(light)).to eq([another_failure, failure])
+        end
+
+        it 'limits the number of stored failures' do
+          light.with_threshold(1)
+          strategy.record_failure(light, another_failure)
+          strategy.record_failure(light, failure)
+
+          expect(strategy.get_failures(light)).to contain_exactly(failure)
+        end
+
+        context 'when failure happened outside of the window' do
+          let(:another_failure) { Stoplight::Failure.new('class', 'message 2', Time.new - window - 1) }
+
+          it 'stores failures only withing window length' do
+            strategy.record_failure(light, failure)
+            strategy.record_failure(light, another_failure)
+            expect(strategy.get_failures(light)).to contain_exactly(failure)
+          end
+        end
+      end
+    end
+
+    describe '#clear_failures' do
+      let(:failure) { Stoplight::Failure.new('class', 'message', Time.new) }
+      let(:another_failure) { Stoplight::Failure.new('class', 'message 2', Time.new - window - 1) }
+
+      before do
+        strategy.record_failure(light, failure)
+        strategy.record_failure(light, another_failure)
+      end
+
+      it 'returns the failures from the window' do
+        expect(strategy.clear_failures(light)).to eq([failure])
+      end
+
+      it 'clears failures' do
+        strategy.clear_failures(light)
+        expect(strategy.get_failures(light)).to eql([])
+      end
+    end
+  end
+
+  describe 'with redis data store' do
+    let(:data_store) { Stoplight::DataStore::Redis.new(redis) }
+    let(:redis) { MockRedis.new }
+
+    it_behaves_like Stoplight::Strategy::RunningWindow
+  end
+
+  describe 'with memory data store' do
+    let(:data_store) { Stoplight::DataStore::Memory.new }
+
+    it_behaves_like Stoplight::Strategy::RunningWindow
+  end
+end

--- a/spec/stoplight/strategy/vintage_spec.rb
+++ b/spec/stoplight/strategy/vintage_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'mock_redis'
+
+RSpec.describe Stoplight::Strategy::Vintage do
+  subject(:strategy) { described_class.new(data_store) }
+
+  shared_examples Stoplight::Strategy::Vintage do
+    let(:light) { Stoplight::Light.new(name) {} }
+    let(:name) { SecureRandom.uuid }
+
+    describe '#get_all' do
+      context 'when there is no failures' do
+        it 'returns no failures and state' do
+          failures, state = strategy.get_all(light)
+          expect(failures).to eql([])
+          expect(state).to eql(Stoplight::State::UNLOCKED)
+        end
+      end
+
+      context 'when there are failures' do
+        let(:failure) { Stoplight::Failure.new('class', 'message', Time.new) }
+
+        before do
+          strategy.record_failure(light, failure)
+        end
+
+        it 'returns failures and state' do
+          failures, state = strategy.get_all(light)
+          expect(failures).to contain_exactly(failure)
+          expect(state).to eql(Stoplight::State::UNLOCKED)
+        end
+      end
+    end
+
+    describe '#get_failures' do
+      subject { strategy.get_failures(light) }
+
+      context 'when there is no failures' do
+        it { is_expected.to be_empty }
+      end
+
+      context 'when there are failures' do
+        let(:failure) { Stoplight::Failure.new('class', 'message', Time.new) }
+
+        before do
+          strategy.record_failure(light, failure)
+        end
+
+        it { is_expected.to contain_exactly(failure) }
+      end
+    end
+
+    describe '#record_failure' do
+      let(:failure) { Stoplight::Failure.new('class', 'message', Time.new) }
+
+      it 'returns the number of failures' do
+        expect(strategy.record_failure(light, failure)).to eql(1)
+      end
+
+      context 'when there are many failures' do
+        let(:another_failure) { Stoplight::Failure.new('class', 'message 2', Time.new - 10) }
+
+        it 'stores more recent failures at the head' do
+          strategy.record_failure(light, failure)
+          strategy.record_failure(light, another_failure)
+
+          expect(strategy.get_failures(light)).to eq([another_failure, failure])
+        end
+
+        it 'limits the number of stored failures' do
+          light.with_threshold(1)
+          strategy.record_failure(light, another_failure)
+          strategy.record_failure(light, failure)
+
+          expect(strategy.get_failures(light)).to contain_exactly(failure)
+        end
+      end
+    end
+
+    describe '#clear_failures' do
+      let(:failure) { Stoplight::Failure.new('class', 'message', Time.new) }
+
+      it 'returns the failures' do
+        strategy.record_failure(light, failure)
+        expect(strategy.clear_failures(light)).to eq([failure])
+      end
+
+      it 'clears the failures' do
+        strategy.record_failure(light, failure)
+        strategy.clear_failures(light)
+        expect(strategy.get_failures(light)).to eql([])
+      end
+    end
+  end
+
+  describe 'with redis data store' do
+    let(:data_store) { Stoplight::DataStore::Redis.new(redis) }
+    let(:redis) { MockRedis.new }
+
+    it_behaves_like Stoplight::Strategy::Vintage
+  end
+
+  describe 'with memory data store' do
+    let(:data_store) { Stoplight::DataStore::Memory.new }
+
+    it_behaves_like Stoplight::Strategy::Vintage
+  end
+end

--- a/spec/support/stoplight/data_store/base.rb
+++ b/spec/support/stoplight/data_store/base.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require_relative 'base/names'
+require_relative 'base/get_all'
+require_relative 'base/get_failures'
+require_relative 'base/record_failures'

--- a/spec/support/stoplight/data_store/base/get_all.rb
+++ b/spec/support/stoplight/data_store/base/get_all.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::DataStore::Base#get_all' do
+  subject(:get_all) { data_store.get_all(light, window: window) }
+
+  let(:light) { Stoplight::Light.new(name) {} }
+  let(:name) { SecureRandom.uuid }
+  let(:failure) { Stoplight::Failure.new('class', 'message', Time.new) }
+
+  shared_examples '#get_all' do
+    context 'when there are no failures' do
+      it 'returns no failures and the state' do
+        failures, state = get_all
+
+        expect(failures).to eql([])
+        expect(state).to eql(Stoplight::State::UNLOCKED)
+      end
+    end
+
+    context 'when there are failures' do
+      before do
+        data_store.record_failure(light, failure)
+      end
+
+      it 'returns the failures and the state' do
+        failures, state = get_all
+
+        expect(failures).to contain_exactly(failure)
+        expect(state).to eql(Stoplight::State::UNLOCKED)
+      end
+    end
+  end
+
+  context 'without window' do
+    let(:window) { nil }
+
+    it_behaves_like '#get_all'
+  end
+
+  context 'with window' do
+    let(:window) { 3600 }
+
+    it_behaves_like '#get_all'
+
+    context 'when there are failures outside of the window' do
+      let(:older_failure) do
+        Stoplight::Failure.new('class', 'older failure', Time.new - window - 1)
+      end
+
+      before do
+        data_store.record_failure(light, older_failure)
+        data_store.record_failure(light, failure)
+      end
+
+      it 'returns the failures within window and the state' do
+        failures, state = get_all
+
+        expect(failures).to contain_exactly(failure)
+        expect(state).to eql(Stoplight::State::UNLOCKED)
+      end
+    end
+  end
+end

--- a/spec/support/stoplight/data_store/base/get_failures.rb
+++ b/spec/support/stoplight/data_store/base/get_failures.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::DataStore::Base#get_failures' do
+  let(:light) { Stoplight::Light.new(name) {} }
+  let(:name) { SecureRandom.uuid }
+  let(:failure) { Stoplight::Failure.new('class', 'message', Time.new) }
+
+  shared_examples '#get_failures' do
+    it 'is initially empty' do
+      expect(data_store.get_failures(light, window: window)).to eql([])
+    end
+  end
+
+  context 'without window' do
+    let(:window) { nil }
+
+    include_examples '#get_failures'
+
+    it 'returns failures' do
+      data_store.record_failure(light, failure)
+
+      expect(data_store.get_failures(light)).to contain_exactly(failure)
+    end
+  end
+
+  context 'with window' do
+    let(:window) { 3600 }
+    let(:older_failure) { Stoplight::Failure.new('class', 'old failure', Time.new - window - 1) }
+
+    include_examples '#get_failures'
+
+    it 'returns failures withing given window' do
+      data_store.record_failure(light, failure, window: window)
+      data_store.record_failure(light, older_failure, window: window)
+
+      expect(data_store.get_failures(light, window: window)).to contain_exactly(failure)
+    end
+  end
+end

--- a/spec/support/stoplight/data_store/base/names.rb
+++ b/spec/support/stoplight/data_store/base/names.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::DataStore::Base#names' do
+  let(:light) { Stoplight::Light.new(name) {} }
+  let(:name) { SecureRandom.uuid }
+  let(:failure) { Stoplight::Failure.new('class', 'message', Time.new) }
+
+  it 'is initially empty' do
+    expect(data_store.names).to eql([])
+  end
+
+  it 'contains the name of a light with a failure' do
+    data_store.record_failure(light, failure)
+    expect(data_store.names).to eql([light.name])
+  end
+
+  it 'contains the name of a light with a set state' do
+    data_store.set_state(light, Stoplight::State::UNLOCKED)
+    expect(data_store.names).to eql([light.name])
+  end
+
+  it 'does not duplicate names' do
+    data_store.record_failure(light, failure)
+    data_store.set_state(light, Stoplight::State::UNLOCKED)
+    expect(data_store.names).to eql([light.name])
+  end
+
+  it 'supports names containing colons' do
+    light = Stoplight::Light.new('http://api.example.com/some/action')
+    data_store.record_failure(light, failure)
+    expect(data_store.names).to eql([light.name])
+  end
+end

--- a/spec/support/stoplight/data_store/base/record_failures.rb
+++ b/spec/support/stoplight/data_store/base/record_failures.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::DataStore::Base#record_failures' do
+  let(:light) { Stoplight::Light.new(name) {} }
+  let(:name) { SecureRandom.uuid }
+  let(:failure) { Stoplight::Failure.new('class', 'message', Time.new) }
+  let(:other_failure) { Stoplight::Failure.new('class', 'message 2', Time.new - 10) }
+
+  shared_examples '#record_failure' do
+    it 'returns the number of failures' do
+      expect(data_store.record_failure(light, failure, window: window)).to eql(1)
+    end
+
+    it 'persists the failure' do
+      data_store.record_failure(light, failure)
+
+      expect(data_store.get_failures(light)).to contain_exactly(failure)
+    end
+
+    context 'when there are multiple failures' do
+      it 'stores more recent failures at the head' do
+        data_store.record_failure(light, failure, window: window)
+        data_store.record_failure(light, other_failure, window: window)
+
+        expect(data_store.get_failures(light, window: window)).to eq([failure, other_failure])
+      end
+
+      it 'limits the number of stored failures' do
+        light.with_threshold(1)
+
+        data_store.record_failure(light, failure, window: window)
+        data_store.record_failure(light, other_failure, window: window)
+
+        expect(data_store.get_failures(light, window: window)).to contain_exactly(failure)
+      end
+    end
+  end
+
+  context 'without a window' do
+    let(:window) { nil }
+
+    include_examples '#record_failure'
+  end
+
+  context 'with a window' do
+    let(:window) { 3600 }
+
+    include_examples '#record_failure'
+
+    context 'when error is outside of the window' do
+      let(:old_failure) { Stoplight::Failure.new('class', 'message 3', Time.new - window - 1) }
+
+      it 'stores failures only withing window length' do
+        data_store.record_failure(light, failure, window: window)
+        data_store.record_failure(light, other_failure, window: window)
+        data_store.record_failure(light, old_failure, window: window)
+
+        expect(data_store.get_failures(light, window: window)).to eq([failure, other_failure])
+      end
+    end
+  end
+end

--- a/stoplight.gemspec
+++ b/stoplight.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |gem|
   ] + Dir.glob(File.join('lib', '**', '*.rb'))
   gem.test_files = Dir.glob(File.join('spec', '**', '*.rb'))
 
-  gem.required_ruby_version = '>= 2.6'
+  gem.required_ruby_version = '>= 2.7'
 
-  gem.add_dependency 'redlock', "~> 1.0"
+  gem.add_dependency 'redlock', '~> 1.0'
 
   gem.add_development_dependency('benchmark-ips', '~> 2.3')
   gem.add_development_dependency('bugsnag', '~> 4.0')


### PR DESCRIPTION
🚧 I decided to split this PR into several smaller and use the `feature/running-window` branch for them.

Fixes #131
Replaces https://github.com/bolshakov/stoplight/pull/133

**Breaking changes**:

* Key format changed
* `Stoplight#data_store` is not a public interface anymore

TODO:
* [ ] What the default strategy should be?
* [ ] What the default window size for the Running Window strategy should be?
* [ ] Any better name for the Vintage strategy?
* [ ] Any better name for "strategy"?
* [ ] Does it break stoplight-admin?
* [ ] Specs for in memory
* [ ] API to switch strategies