### PR TITLE
Replace data store uses with strategy

### DIFF
--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -15,6 +15,9 @@ require 'stoplight/data_store/base'
 require 'stoplight/data_store/memory'
 require 'stoplight/data_store/redis'
 
+require 'stoplight/strategy/base'
+require 'stoplight/strategy/vintage'
+
 require 'stoplight/notifier'
 require 'stoplight/notifier/base'
 require 'stoplight/notifier/generic'

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -2,6 +2,8 @@
 
 module Stoplight
   module Default
+    Strategy = Stoplight::Strategy::Vintage
+
     COOL_OFF_TIME = 60.0
 
     DATA_STORE = DataStore::Memory.new

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -8,8 +8,8 @@ module Stoplight
     attr_reader :code
     # @return [Float]
     attr_reader :cool_off_time
-    # @return [DataStore::Base]
-    attr_reader :data_store
+    # @return [Strategy::Base]
+    attr_reader :strategy
     # @return [Proc]
     attr_reader :error_handler
     # @return [Proc]
@@ -30,11 +30,14 @@ module Stoplight
       attr_accessor :default_error_notifier
       # @return [Array<Notifier::Base>]
       attr_accessor :default_notifiers
+      # @return [Class<Stoplight::Strategy::Vintage>]
+      attr_accessor :default_strategy
     end
 
     @default_data_store = Default::DATA_STORE
     @default_error_notifier = Default::ERROR_NOTIFIER
     @default_notifiers = Default::NOTIFIERS
+    @default_strategy = Default::Strategy
 
     # @param name [String]
     # @yield []
@@ -42,13 +45,14 @@ module Stoplight
       @name = name
       @code = code
 
-      @cool_off_time = Default::COOL_OFF_TIME
-      @data_store = self.class.default_data_store
-      @error_handler = Default::ERROR_HANDLER
-      @error_notifier = self.class.default_error_notifier
-      @fallback = Default::FALLBACK
-      @notifiers = self.class.default_notifiers
-      @threshold = Default::THRESHOLD
+      @strategy_class = self.class.default_strategy
+      with_cool_off_time(Default::COOL_OFF_TIME)
+      with_data_store(self.class.default_data_store)
+      with_error_handler(&Default::ERROR_HANDLER)
+      with_error_notifier(&self.class.default_error_notifier)
+      with_fallback(&Default::FALLBACK)
+      with_notifiers(self.class.default_notifiers)
+      with_threshold(Default::THRESHOLD)
     end
 
     # @param cool_off_time [Float]
@@ -61,7 +65,7 @@ module Stoplight
     # @param data_store [DataStore::Base]
     # @return [self]
     def with_data_store(data_store)
-      @data_store = data_store
+      @strategy = @strategy_class.new(data_store)
       self
     end
 

--- a/lib/stoplight/light/runnable.rb
+++ b/lib/stoplight/light/runnable.rb
@@ -71,15 +71,15 @@ module Stoplight
       end
 
       def clear_failures
-        safely([]) { data_store.clear_failures(self) }
+        safely([]) { strategy.clear_failures(self) }
       end
 
       def failures_and_state
-        safely([[], State::UNLOCKED]) { data_store.get_all(self) }
+        safely([[], State::UNLOCKED]) { strategy.get_all(self) }
       end
 
       def notify(from_color, to_color, error = nil)
-        data_store.with_notification_lock(self, from_color, to_color) do
+        strategy.with_notification_lock(self, from_color, to_color) do
           notifiers.each do |notifier|
             safely { notifier.notify(self, from_color, to_color, error) }
           end
@@ -88,11 +88,11 @@ module Stoplight
 
       def record_failure(error)
         failure = Failure.from_error(error)
-        safely(0) { data_store.record_failure(self, failure) }
+        safely(0) { strategy.record_failure(self, failure) }
       end
 
       def safely(default = nil, &code)
-        return yield if data_store == Default::DATA_STORE
+        return yield if strategy.data_store == Default::DATA_STORE
 
         self
           .class

--- a/lib/stoplight/strategy/base.rb
+++ b/lib/stoplight/strategy/base.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module Stoplight
+  module Strategy
+    # @abstract
+    class Base
+      extend Forwardable
+
+      # @!attribute data_store
+      #   @return [Stoplight::DataStore::Base]
+      attr_reader :data_store
+
+      # private :data_store
+
+      # @param data_store [Stoplight::DataStore::Base]
+      def initialize(data_store)
+        @data_store = data_store
+      end
+
+      # @param _light [Light]
+      # @return [Array(Array<Failure>, String)]
+      def get_all(_light)
+        raise NotImplementedError
+      end
+
+      # @param _light [Light]
+      # @return [Array<Failure>]
+      def get_failures(_light)
+        raise NotImplementedError
+      end
+
+      # @param _light [Light]
+      # @param _failure [Failure]
+      # @return [Fixnum]
+      def record_failure(_light, _failure)
+        raise NotImplementedError
+      end
+
+      # @param _light [Light]
+      # @return [Array<Failure>]
+      def clear_failures(_light)
+        raise NotImplementedError
+      end
+
+      def_delegator :data_store, :clear_state
+      def_delegator :data_store, :get_state
+      def_delegator :data_store, :names
+      def_delegator :data_store, :set_state
+      def_delegator :data_store, :with_notification_lock
+    end
+  end
+end

--- a/lib/stoplight/strategy/vintage.rb
+++ b/lib/stoplight/strategy/vintage.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module Stoplight
+  module Strategy
+    # Vintage strategy is the old good strategy
+    # that Stoplight have been using since the beginning.
+    # It does not take into account the time when an error
+    # happens.
+    #
+    class Vintage < Base
+      extend Forwardable
+
+      def_delegator :data_store, :clear_failures
+      def_delegator :data_store, :get_all
+      def_delegator :data_store, :get_failures
+      def_delegator :data_store, :record_failure
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require 'simplecov'
 require 'stoplight'
 require 'timecop'
 require_relative 'support/data_store/base'
+require_relative 'support/strategy//base'
+require_relative 'support/strategy//vintage'
 
 Timecop.safe_mode = true
 

--- a/spec/stoplight/light_spec.rb
+++ b/spec/stoplight/light_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Stoplight::Light do
 
   describe '#data_store' do
     it 'is initially the default' do
-      expect(light.data_store).to eql(described_class.default_data_store)
+      expect(light.strategy).to be_kind_of(described_class.default_strategy)
     end
   end
 
@@ -134,7 +134,7 @@ RSpec.describe Stoplight::Light do
     it 'sets the data store' do
       data_store = Stoplight::DataStore::Memory.new
       light.with_data_store(data_store)
-      expect(light.data_store).to eql(data_store)
+      expect(light.strategy.data_store).to eql(data_store)
     end
   end
 

--- a/spec/stoplight/strategy/base_spec.rb
+++ b/spec/stoplight/strategy/base_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Stoplight::Strategy::Base do
+  it_behaves_like Stoplight::Strategy::Base do
+    let(:data_store) { Stoplight::DataStore::Memory.new }
+
+    describe '#get_all' do
+      it 'is not implemented' do
+        expect { strategy.get_all(nil) }.to raise_error(NotImplementedError)
+      end
+    end
+
+    describe '#get_failures' do
+      it 'is not implemented' do
+        expect { strategy.get_failures(nil) }
+          .to raise_error(NotImplementedError)
+      end
+    end
+
+    describe '#record_failure' do
+      it 'is not implemented' do
+        expect { strategy.record_failure(nil, nil) }
+          .to raise_error(NotImplementedError)
+      end
+    end
+
+    describe '#clear_failures' do
+      it 'is not implemented' do
+        expect { strategy.clear_failures(nil) }
+          .to raise_error(NotImplementedError)
+      end
+    end
+  end
+end

--- a/spec/stoplight/strategy/vintage_spec.rb
+++ b/spec/stoplight/strategy/vintage_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'mock_redis'
+
+RSpec.describe Stoplight::Strategy::Vintage do
+  describe 'with redis data store' do
+    let(:data_store) { Stoplight::DataStore::Redis.new(redis) }
+    let(:redis) { MockRedis.new }
+
+    it_behaves_like Stoplight::Strategy::Vintage
+  end
+
+  describe 'with memory data store' do
+    let(:data_store) { Stoplight::DataStore::Memory.new }
+
+    it_behaves_like Stoplight::Strategy::Vintage
+  end
+end

--- a/spec/support/data_store/base/get_failures.rb
+++ b/spec/support/data_store/base/get_failures.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples 'Stoplight::DataStore::Base#get_failures' do
       expect(data_store.get_failures(light, window: window)).to eql([])
     end
 
-    it 'handles invalid JSON' do
+    it 'returns failures' do
       expect { data_store.record_failure(light, failure, window: window) }
         .to change { data_store.get_failures(light, window: window) }
         .from(be_empty)

--- a/spec/support/strategy/base.rb
+++ b/spec/support/strategy/base.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative 'base/clear_failures'
+require_relative 'base/get_all'
+require_relative 'base/get_failures'
+require_relative 'base/record_failures'
+
+RSpec.shared_examples Stoplight::Strategy::Base do
+  subject(:strategy) { described_class.new(data_store) }
+
+  describe '#names' do
+    let(:names) { ['foo'] }
+
+    it 'delegates to the data store' do
+      expect(data_store).to receive(:names).and_return(names)
+
+      expect(strategy.names).to eq(names)
+    end
+  end
+
+  describe '#get_state' do
+    let(:state) { Stoplight::State::UNLOCKED }
+    let(:light) { instance_double(Stoplight::Light) }
+
+    it 'delegates to the data store' do
+      expect(data_store).to receive(:get_state).with(light).and_return(state)
+
+      expect(strategy.get_state(light)).to eq(state)
+    end
+  end
+
+  describe '#set_state' do
+    let(:state) { Stoplight::State::UNLOCKED }
+    let(:light) { instance_double(Stoplight::Light) }
+
+    it 'delegates to the data store' do
+      expect(data_store).to receive(:set_state).with(light, state).and_return(state)
+
+      expect(strategy.set_state(light, state)).to eq(state)
+    end
+  end
+
+  describe '#clear_state' do
+    let(:state) { Stoplight::State::UNLOCKED }
+    let(:light) { instance_double(Stoplight::Light) }
+
+    it 'delegates to the data store' do
+      expect(data_store).to receive(:clear_state).with(light).and_return(state)
+
+      expect(strategy.clear_state(light)).to eq(state)
+    end
+  end
+
+  describe '#with_notification_lock' do
+    let(:from) { Stoplight::Color::GREEN }
+    let(:to) { Stoplight::Color::RED }
+    let(:light) { instance_double(Stoplight::Light) }
+
+    it 'delegates to the data store' do
+      expect(data_store).to receive(:with_notification_lock).with(light, from, to).and_return(42)
+
+      expect(strategy.with_notification_lock(light, from, to)).to eq(42)
+    end
+  end
+end

--- a/spec/support/strategy/base/clear_failures.rb
+++ b/spec/support/strategy/base/clear_failures.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::Strategy::Base#clear_failures' do
+  before do
+    strategy.record_failure(light, failure)
+  end
+
+  it 'returns the failures' do
+    expect(strategy.clear_failures(light)).to contain_exactly(failure)
+  end
+
+  it 'clears the failures' do
+    expect do
+      strategy.clear_failures(light)
+    end.to change { strategy.get_failures(light) }
+      .from([failure]).to(be_empty)
+  end
+end

--- a/spec/support/strategy/base/get_all.rb
+++ b/spec/support/strategy/base/get_all.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::Strategy::Base#get_all' do
+  context 'when there are no failures' do
+    it 'returns the failures and the state' do
+      failures, state = strategy.get_all(light)
+
+      expect(failures).to eql([])
+      expect(state).to eql(Stoplight::State::UNLOCKED)
+    end
+  end
+
+  context 'when there are failures' do
+    before do
+      strategy.record_failure(light, failure)
+    end
+
+    it 'returns the failures and the state' do
+      failures, state = strategy.get_all(light)
+
+      expect(failures).to eq([failure])
+      expect(state).to eql(Stoplight::State::UNLOCKED)
+    end
+  end
+end

--- a/spec/support/strategy/base/get_failures.rb
+++ b/spec/support/strategy/base/get_failures.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::Strategy::Base#get_failures' do
+  it 'is initially empty' do
+    expect(strategy.get_failures(light)).to eql([])
+  end
+
+  it 'returns failures' do
+    expect { strategy.record_failure(light, failure) }
+      .to change { strategy.get_failures(light) }
+      .from(be_empty)
+      .to(contain_exactly(failure))
+  end
+end

--- a/spec/support/strategy/base/record_failures.rb
+++ b/spec/support/strategy/base/record_failures.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Stoplight::Strategy::Base#record_failure' do
+  def failures
+    strategy.get_failures(light)
+  end
+
+  it 'returns the number of failures' do
+    expect(strategy.record_failure(light, failure)).to eql(1)
+  end
+
+  context 'when there is an error' do
+    before do
+      strategy.record_failure(light, failure)
+    end
+
+    it 'persists the failure' do
+      expect(failures).to eq([failure])
+    end
+  end
+
+  context 'when there is are several errors' do
+    before do
+      strategy.record_failure(light, failure)
+      strategy.record_failure(light, other)
+    end
+
+    it 'stores more recent failures at the head' do
+      expect(failures).to eq([other, failure])
+    end
+  end
+
+  context 'when the number of errors is bigger then threshold' do
+    before do
+      light.with_threshold(1)
+
+      strategy.record_failure(light, failure)
+    end
+
+    it 'limits the number of stored failures' do
+      expect do
+        strategy.record_failure(light, other)
+      end.to change { failures }
+        .from([failure])
+        .to([other])
+    end
+  end
+end

--- a/spec/support/strategy/vintage.rb
+++ b/spec/support/strategy/vintage.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples Stoplight::Strategy::Vintage do
+  subject(:strategy) { described_class.new(data_store) }
+  let(:light) { Stoplight::Light.new(name) {} }
+  let(:name) { ('a'..'z').to_a.shuffle.join }
+  let(:failure) { Stoplight::Failure.new('class', 'message', Time.new - 10) }
+  let(:other) { Stoplight::Failure.new('class', 'message 2', Time.new) }
+
+  it_behaves_like Stoplight::Strategy::Base
+  it_behaves_like 'Stoplight::Strategy::Base#clear_failures'
+  it_behaves_like 'Stoplight::Strategy::Base#get_all'
+  it_behaves_like 'Stoplight::Strategy::Base#get_failures'
+  it_behaves_like 'Stoplight::Strategy::Base#record_failure'
+end


### PR DESCRIPTION
This second refactoring step aimed to introduce the running window behavior for counting errors. 

The `Stoplight::Strategy::Base:` is the interface that each strategy should implement. The interface is the same as  `Stoplight::DataStore::Base`.

The `Stoplight::Strategy::Vintage` implements the old-fashioned strategy that Stoplight implements today. 

All the `Stoplight::Light#data_store` usages were replaced with `Stoplight::Light#strategy` usages. 

This PR also introduces a breaking change: the public `Stoplight#data_store` accessor is not available anymore (which may affect end users, e.g., stoplight-admin) 

The PR targets the [feature/running-window](https://github.com/bolshakov/stoplight/tree/feature/running-window) branch and I suggest accepting this breaking change for now. Before the release, we may reconsider this decision 