### PR TITLE
Chore | Fix documentation for lockable methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ light = Stoplight('example-locked') { true }
 light.run
 # => true
 light.lock(Stoplight::Color::RED)
-# => "locked_red"
+# => #<Stoplight::Light:..>
 light.run
 # Stoplight::Error::RedLight: example-locked
 ```
@@ -428,6 +428,7 @@ You can go back to using the default behavior by unlocking the stoplight using `
 
 ``` rb
 light.unlock
+# => #<Stoplight::Light:..>
 ```
 
 ### Testing

--- a/lib/stoplight/light/lockable.rb
+++ b/lib/stoplight/light/lockable.rb
@@ -12,11 +12,11 @@ module Stoplight
     #   light.run
     #   # => true
     #   light.lock(Stoplight::Color::RED)
-    #   # => "locked_red"
+    #   # => #<Stoplight::Light:..>
     #   light.run
     #   # => Stoplight::Error::RedLight: example-locked
     #   light.unlock
-    #   # => "unlocked"
+    #   # => #<Stoplight::Light:..>
     #   light.run
     #   # => true
     module Lockable
@@ -26,7 +26,7 @@ module Stoplight
       #   light = Stoplight('example-locked') { true }
       #   # => #<Stoplight::Light:..>
       #   light.lock(Stoplight::Color::RED)
-      #   # => "locked_red"
+      #   # => #<Stoplight::Light:..>
       #
       # @param color [String] should be either Color::RED or Color::GREEN
       # @return [Stoplight::Light] returns locked light
@@ -50,7 +50,7 @@ module Stoplight
       #   light.lock(Stoplight::Color::RED)
       #   # => "locked_red"
       #   light.unlock
-      #   # => "unlocked"
+      #   # => #<Stoplight::Light:..>
       #
       # @return [Stoplight::Light] returns unlocked light
       def unlock


### PR DESCRIPTION
This ticket aims to fix documentation for the `Light#lock`, and `Light#unlock` methods.
At the moment, in the documentation, we show that we return a light state instead of light in the `Light#lock` and `Light#unlock` methods. We decided to return the light itself and would like to reflect this in the documentation.