### PR TITLE
Stoplight 4.0 🎉

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1' ]
-        redis: ['6.2', '7.0']
+        ruby: ['3.0', '3.1', '3.2']
+        redis: ['6.2', '7.2']
     name: Ruby ${{ matrix.ruby }}, Redis ${{ matrix.redis }}
 
     services:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 Metrics/BlockLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,17 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :development do
+  gem 'benchmark-ips', '~> 2.3'
+  gem 'database_cleaner-redis', '~> 2.0'
+  gem 'debug'
+  gem 'fakeredis', '~> 0.8'
+  gem 'rake', '~> 13.0'
+  gem 'redis', '~> 4.1'
+  gem 'rspec', '~> 3.11'
+  gem 'rubocop', '~> 1.0.0'
+  gem 'simplecov', '~> 0.21'
+  gem 'simplecov-lcov', '~> 0.8'
+  gem 'timecop', '~> 0.9'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stoplight (3.0.1)
+    stoplight (4.0.0)
       redlock (~> 1.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ stoplight = Stoplight("test-#{rand}")
 
 Stoplight supports the latest three minor versions of Ruby, which currently are: `3.0.x`, `3.1.x`, and `3.2.x`. Changing
 the minimum supported Ruby version is not considered a breaking change.
-We support the current stable Redis version (`7.2`) and the latest release of the previous major version (`7.0.9`)
+We support the current stable Redis version (`7.2`) and the latest release of the previous major version (`6.2.9`)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -19,56 +19,57 @@ the rest of your application.
 Check out [stoplight-admin][] for controlling your stoplights.
 
 - [Installation](#installation)
-- [Basic usage](#basic-usage)
-  - [Custom errors](#custom-errors)
-  - [Custom fallback](#custom-fallback)
-  - [Custom threshold](#custom-threshold)
-  - [Custom cool off time](#custom-cool-off-time)
+- [Basic Usage](#basic-usage)
+  - [Custom Errors](#custom-errors)
+  - [Custom Fallback](#custom-fallback)
+  - [Custom Threshold](#custom-threshold)
+  - [Custom Window Size](#custom-window-size)
+  - [Custom Cool Off Time](#custom-cool-off-time)
   - [Rails](#rails)
 - [Setup](#setup)
-  - [Data store](#data-store)
+  - [Data Store](#data-store)
     - [Redis](#redis)
   - [Notifiers](#notifiers)
     - [IO](#io)
     - [Logger](#logger)
-    - [Community-supported notifiers](#community-supported-notifiers)
-    - [How to implement your own notifier?](#how-to-implement-your-own-notifier)
+    - [Community-supported Notifiers](#community-supported-notifiers)
+    - [How to Implement Your Own Notifier?](#how-to-implement-your-own-notifier)
   - [Rails](#rails-1)
-- [Advanced usage](#advanced-usage)
+- [Advanced Usage](#advanced-usage)
   - [Locking](#locking)
   - [Testing](#testing)
-- [Maintenance policy][#maintenance-policy]
+- [Maintenance Policy][#maintenance-policy]
 - [Credits](#credits)
 
 ## Installation
 
 Add it to your Gemfile:
 
-``` rb
+```ruby
 gem 'stoplight'
 ```
 
 Or install it manually:
 
-``` sh
+```sh
 $ gem install stoplight
 ```
 
 Stoplight uses [Semantic Versioning][]. Check out [the change log][] for a
 detailed list of changes.
 
-## Basic usage
+## Basic Usage
 
 To get started, create a stoplight:
 
-``` rb
+```ruby
 light = Stoplight('example-pi')
 ```
 
 Then you can run it with a block of code and it will return the result of calling the block. This is
 the green state. (The green state corresponds to the closed state for circuit breakers.)
 
-``` rb
+```ruby
 light.run { 22.0 / 7 }
 # => 3.142857142857143
 light.color
@@ -83,7 +84,7 @@ running it a few times, the stoplight will stop trying and fail fast. This is
 the red state. (The red state corresponds to the open state for circuit
 breakers.)
 
-``` rb
+```ruby
 light = Stoplight('example-zero')
 # => #<Stoplight::CircuitBreaker:...>
 light.run { 1 / 0 }
@@ -99,7 +100,7 @@ light.color
 # => "red"
 ```
 
-When the stoplight changes from green to red, it will notify every configured
+When the Stoplight changes from green to red, it will notify every configured
 notifier. See [the notifiers section][] to learn more about notifiers.
 
 The stoplight will move into the yellow state after being in the red state for
@@ -109,7 +110,7 @@ check out [the cool off time section][] When stoplights are yellow, they will
 try to run their code. If it fails, they'll switch back to red. If it succeeds,
 they'll switch to green.
 
-### Custom errors
+### Custom Errors
 
 Some errors shouldn't cause your stoplight to move into the red state. Usually
 these are handled elsewhere in your stack and don't represent real failures. A
@@ -132,11 +133,14 @@ provide a custom block that will be called with the error and a handler
     never ignore the error. That means a `NoMemoryError` could change the color
     of your stoplights.
 
-``` rb
+```ruby
 light = Stoplight('example-not-found')
   .with_error_handler do |error, handle|
-    raise error if error.is_a?(ActiveRecord::RecordNotFound)
-    handle.call(error)
+    if error.is_a?(ActiveRecord::RecordNotFound)
+      raise error
+    else      
+      handle.call(error)
+    end
   end
 # => #<Stoplight::CircuitBreaker:...>
 light.run { User.find(123) }
@@ -149,14 +153,14 @@ light.color
 # => "green"
 ```
 
-### Custom fallback
+### Custom Fallback
 
 By default, stoplights will re-raise errors when they're green. When they're
 red, they'll raise a `Stoplight::Error::RedLight` error. You can provide a
 fallback that will be called in both of these cases. It will be passed the
 error if the light was green.
 
-``` rb
+```ruby
 light = Stoplight('example-fallback')
   .with_fallback { |e| p e; 'default' }
 # => #<Stoplight::CircuitBreaker:..>
@@ -175,12 +179,12 @@ light.run { 1 / 0 }
 # => "default"
 ```
 
-### Custom threshold
+### Custom Threshold
 
 Some bits of code might be allowed to fail more or less frequently than others.
 You can configure this by setting a custom threshold.
 
-``` rb
+```ruby
 light = Stoplight('example-threshold')
   .with_threshold(1)
 # => #<Stoplight::CircuitBreaker:...>
@@ -193,39 +197,47 @@ light.run { fail }
 
 The default threshold is `3`.
 
-### Custom window size
+### Custom Window Size
 
 By default, all recorded failures, regardless of the time these happen, will count to reach
 the threshold (hence turning the light to red). If needed, a window size can be set,
 meaning you can control how many errors per period of time will count to reach the red
 state.
 
- ``` rb
+By default, every recorded failure contributes to reaching the threshold, regardless of when it occurs, 
+causing the stoplight to turn red. By configuring a custom window size, you control how errors are 
+counted within a specified time frame. Here's how it works:
+
+Let's say you set the window size to 2 seconds:
+
+ ```ruby
 window_size_in_seconds = 2
 
 light = Stoplight('example-threshold')
   .with_window_size(window_size_in_seconds)
-  .with_threshold(1)
- # => #<Stoplight::CircuitBreaker:...>
+  .with_threshold(1) #=> #<Stoplight::CircuitBreaker:...>
 
-light.run { 1 / 0 }
-# #<ZeroDivisionError: divided by 0>
-# => "default"
+light.run { 1 / 0 } #=> #<ZeroDivisionError: divided by 0>
 sleep(3)
 light.run { 1 / 0 }
-# #<ZeroDivisionError: divided by 0>
-# => "default"
  ```
+
+Without the window size configuration, the second `light.run { 1 / 0 }` call will result in a
+`Stoplight::Error::RedLight` exception being raised, as the stoplight transitions to the red state 
+after the first call. With a sliding window of 2 seconds, only the errors that occur within the latest
+2 seconds are considered. The first error causes the stoplight to turn red, but after 3 seconds 
+(when the second error occurs), the window has shifted, and the stoplight switches to green state 
+causing the error to raise again. This provides a way to focus on the most recent errors.
 
 The default window size is infinity, so all failures counts.
 
-### Custom cool off time
+### Custom Cool Off Time
 
 Stoplights will automatically attempt to recover after a certain amount of
 time. A light in the red state for longer than the cool off period will
 transition to the yellow state. This cool off time is customizable.
 
-``` rb
+```ruby
 light = Stoplight('example-cool-off')
   .with_cool_off_time(1)
 # => #<Stoplight::CircuitBreaker:...>
@@ -254,7 +266,7 @@ effectively replaces the red state with yellow.
 Stoplight was designed to wrap Rails actions with minimal effort. Here's an
 example configuration:
 
-``` rb
+```ruby
 class ApplicationController < ActionController::Base
   around_action :stoplight
 
@@ -277,7 +289,7 @@ end
 
 Stoplight uses an in-memory data store out of the box.
 
-``` rb
+```ruby
 require 'stoplight'
 # => true
 Stoplight.default_data_store
@@ -289,10 +301,9 @@ the only supported persistent data store is Redis.
 
 #### Redis
 
-Make sure you have [the Redis gem][] (`~> 3.2`) installed before configuring
-Stoplight.
+Make sure you have [the Redis gem][] installed before configuring Stoplight.
 
-``` rb
+```ruby
 require 'redis'
 # => true
 redis = Redis.new
@@ -319,15 +330,15 @@ If you want to send notifications elsewhere, you'll have to set them up.
 Stoplight can notify not only into STDOUT, but into any IO object. You can configure 
 the `Stoplight::Notifier::IO` notifier for that.
 
-``` rb
+```ruby
 require 'stringio'
 
 io = StringIO.new
 # => #<StringIO:...>
 notifier = Stoplight::Notifier::IO.new(io)
-# => #<Stoplight::Notifier::Logger:...>
+# => #<Stoplight::Notifier::IO:...>
 Stoplight.default_notifiers += [notifier]
-# => [#<Stoplight::Notifier::IO:...>  
+# => [#<Stoplight::Notifier::IO:...>, #<Stoplight::Notifier::IO:...>]
 ```
 
 #### Logger
@@ -335,7 +346,7 @@ Stoplight.default_notifiers += [notifier]
 Stoplight can be configured to use [the Logger class][] from the standard
 library.
 
-``` rb
+```ruby
 require 'logger'
 # => true
 logger = Logger.new(STDERR)
@@ -346,7 +357,7 @@ Stoplight.default_notifiers += [notifier]
 # => [#<Stoplight::Notifier::IO:...>, #<Stoplight::Notifier::Logger:...>]
 ```
 
-#### Community-supported notifiers
+#### Community-supported Notifiers
 
 * [stoplight-sentry]
 
@@ -386,7 +397,7 @@ in-memory data store, you don't need to do anything special. If you want to use
 a persistent data store, you'll need to configure it. Create an initializer for
 Stoplight:
 
-``` rb
+```ruby
 # config/initializers/stoplight.rb
 require 'stoplight'
 Stoplight.default_data_store = Stoplight::DataStore::Redis.new(...)
@@ -401,14 +412,14 @@ Although stoplights can operate on their own, occasionally you may want to
 override the default behavior. You can lock a light using `#lock(color)` method.
 Color should be either `Stoplight::Color::GREEN` or ``Stoplight::Color::RED``.
 
-``` rb
+```ruby
 light = Stoplight('example-locked')
 # => #<Stoplight::CircuitBreaker:..>
 light.run { true }
 # => true
 light.lock(Stoplight::Color::RED)
 # => #<Stoplight::CircuitBreaker:..>
-light.run { true }
+light.run { true } 
 # Stoplight::Error::RedLight: example-locked
 ```
 
@@ -419,7 +430,7 @@ locked state of any stoplights.
 
 You can go back to using the default behavior by unlocking the stoplight using `#unlock`.
 
-``` rb
+```ruby
 light.unlock
 # => #<Stoplight::CircuitBreaker:..>
 ```
@@ -431,7 +442,7 @@ However there are a few things you can do to make them behave better. If your
 stoplights are spewing messages into your test output, you can silence them
 with a couple configuration changes.
 
-``` rb
+```ruby
 Stoplight.default_error_notifier = -> _ {}
 Stoplight.default_notifiers = []
 ```
@@ -440,7 +451,7 @@ If your tests mysteriously fail because stoplights are the wrong color, you can
 try resetting the data store before each test case. For example, this would
 give each test case a fresh data store with RSpec.
 
-``` rb
+```ruby
 before(:each) do
   Stoplight.default_data_store = Stoplight::DataStore::Memory.new
 end
@@ -449,14 +460,15 @@ end
 Sometimes you may want to test stoplights directly. You can avoid resetting the
 data store by giving each stoplight a unique name.
 
-``` rb
+```ruby
 stoplight = Stoplight("test-#{rand}")
 ```
 
-## Maintenance policy
+## Maintenance Policy
 
-We support the last three minor ruby versions. Currently, they're: `2.7.x`, `3.0.x`, and `3.1.x`.
-We support the current stable Redis version (`7.0`) and the latest release of the previous major version (`6.2.8`)
+Stoplight supports the latest three minor versions of Ruby, which currently are: `3.0.x`, `3.1.x`, and `3.2.x`. Changing
+the minimum supported Ruby version is not considered a breaking change.
+We support the current stable Redis version (`7.2`) and the latest release of the previous major version (`7.0.9`)
 
 ## Credits
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,6 @@
 ## Stoplight 4.0
 
-### Notifiers have been dropped
+### Notifiers have dropped!
 
 With this release, we've officially moved all third-party notifiers out of Stoplight.
 The only notifiers that remain to be in the Stoplight distribution are:
@@ -25,7 +25,7 @@ We've taken this decision for the following technical reasons:
 Unfortunately, we cannot support all the possible notifiers. 
 
 * All the notifiers relying on third-party services have been dropped.
-* We implemented the Sentry notifier as an external [stoplight-sentry] gem.
+* We implemented the Sentry notifier as an external [stoplight-sentry] gem. You can use it as a reference implementation.
 * We added a [Community-supported notifiers] section and encourage you to contribute by adding your notifiers.
 
 #### All right! What should I change in my code immediately after upgrading?
@@ -69,7 +69,8 @@ light.color
 
 #### So, what does this mean for me?
 
-The old interface is deprecated. To update to the next major version, you will need to switch to a new syntax.
+Stoplight 4.0 supports both an old and a new interface. However, the old interface is deprecated. To 
+update to Stoplight 5.0, you will need to switch to the new syntax.
  
 ```diff
 - Stoplight('example') { 1 / 0 }.run
@@ -78,18 +79,18 @@ The old interface is deprecated. To update to the next major version, you will n
 
 ### Stoplight::Light becomes private
 
-This class has always considered private but some people preferred to use `Stoplight::Light#new` instead of 
+This class has always considered private but some developers preferred to use `Stoplight::Light#new` instead of 
 `Stoplight()`. In the next major release the use of `Stoplight::Light#new` will be forbidden. 
 
 #### Why was this decision made?
 
-We want to provide a simple, concise Stoplight interface. Having a single interface guarantees users 
+We want to provide a simple, concise Stoplight interface. Having a single public interface guarantees users 
 use it the right way.
 
 #### So, what does this mean for me?
 
-Any use of `Stoplight::Light` outside of Stoplight itself is deprecated. To update to the next major version, you 
-will need to change a few things:
+Any use of `Stoplight::Light` outside of Stoplight itself is deprecated in Stoplight 4.0. To update to the 
+next major version (Stoplight 5.0), you will need to change a few things:
 
 ```diff
 - Stoplight::Light.default_data_store = data_store
@@ -110,12 +111,32 @@ In case you prefer to check types in your specs, you may need to switch it from 
 to `Stoplight::CircuitBreaker`. The `Stoplight::CircuitBreaker` abstract module considered the only public interface. 
 
 Under the hood, we use two slightly different implementations to provide a smooth transition to the new interface 
-and to make it possible to pass Stoplight as a dependency.   
+and to make it possible to pass Stoplight as a dependency.
 
+#### All right! What should I change in my code immediately after upgrading?
 
+You might encounter a few deprecation warnings, but you do not need to changes anything in your code in this release. 
+
+### Change in Redis Data Structures
+
+Redis Data store in Stoplight 4.0 uses a new data structure under the hood. 
+
+#### Why was this decision made?
+
+This decision was made to enable the implementation of error counting using a [sliding window] approach. This feature 
+allows Stoplight to count only errors that have occurred recently.
+
+#### So, what does this mean for me?
+
+After upgrading to this version, Stoplight will not be aware of errors that occurred before the update.
+
+#### All right! What should I change in my code immediately after upgrading?
+
+Nothing. Stoplight will function as usual.
 
 [stoplight-sentry]: https://github.com/bolshakov/stoplight-sentry
 [Community-supported notifiers]: https://github.com/bolshakov/stoplight/tree/master#community-supported-notifiers
 [How to implement your own notifier?]: https://github.com/bolshakov/stoplight/tree/master#how-to-implement-your-own-notifier
 [dropped notifiers]: https://github.com/bolshakov/stoplight/tree/v3.0.1/lib/stoplight/notifier
 [without passing an empty block]: https://github.com/bolshakov/stoplight-admin/blob/9c9848eb94410e46b20972548f0863db224cb6da/lib/sinatra/stoplight_admin.rb#L30
+[sliding window]: https://github.com/bolshakov/stoplight#custom-window-size

--- a/lib/stoplight/version.rb
+++ b/lib/stoplight/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stoplight
-  VERSION = Gem::Version.new('3.0.1')
+  VERSION = Gem::Version.new('4.0.0')
 end

--- a/stoplight.gemspec
+++ b/stoplight.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   ] + Dir.glob(File.join('lib', '**', '*.rb'))
   gem.test_files = Dir.glob(File.join('spec', '**', '*.rb'))
 
-  gem.required_ruby_version = '>= 2.7'
+  gem.required_ruby_version = '>= 3.0.6'
 
   gem.add_dependency 'redlock', '~> 1.0'
 

--- a/stoplight.gemspec
+++ b/stoplight.gemspec
@@ -32,16 +32,4 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 3.0.6'
 
   gem.add_dependency 'redlock', '~> 1.0'
-
-  gem.add_development_dependency('benchmark-ips', '~> 2.3')
-  gem.add_development_dependency('database_cleaner-redis', '~> 2.0')
-  gem.add_development_dependency('debug')
-  gem.add_development_dependency('fakeredis', '~> 0.8')
-  gem.add_development_dependency('rake', '~> 13.0')
-  gem.add_development_dependency('redis', '~> 4.1')
-  gem.add_development_dependency('rspec', '~> 3.11')
-  gem.add_development_dependency('rubocop', '~> 1.0.0')
-  gem.add_development_dependency('simplecov', '~> 0.21')
-  gem.add_development_dependency('simplecov-lcov', '~> 0.8')
-  gem.add_development_dependency('timecop', '~> 0.9')
 end


### PR DESCRIPTION
# Stoplight 4.0 🎉

The next major release has been published, bringing a number of improvements and new features! However, it also introduces breaking changes. As a result, we removed certain notifiers. However, upgrading from Stoplight 3.x to Stoplight 4.0 need not be difficult. In fact, we have listed all the necessary steps in the [UPGRADING.md] documentation.

## New Features

### Stoplight() interface has changed

We aim to make Stoplight's configuration sharable across the code. The following change, enables Stoplight to run different code blocks with the same configuration:

```ruby
light = Stoplight('http-api').with_cool_off_time(300)
light.run { call_this }
light.run { call_that }
```

The `Stoplight()` returns an immutable `Stoplight::CircuitBreaker` object that can be safely reconfigured. It makes it compatible with various Dependency Injections systems:

```ruby 
notifier = Stoplight::Sentry::Notifier.new(Sentry)
API_STOPLIGHT = Stoplight('http-api')
  .with_notifiers([notifier])
  .with_threshold(10)

class GetChangeOrdersApi
  def initialize(circuit_breaker: API_STOPLIGHT)
    @circuit_breaker = circuit_breaker.with_fallback { [] }
  end
  
  def call(order_id:)
    @circuit_breaker.run do 
      # calls HTTP API 
    end
  end
end

class GetOrderApi
  def initialize(circuit_breaker: API_STOPLIGHT)
    @circuit_breaker = circuit_breaker.with_fallback { NullOrder.new }
  end

  def call(order_id:)
    @circuit_breaker.run do
      # calls HTTP API 
    end
  end
end
```

Another benefit is that now you can easily inspect the status of the circuit breaker [without passing an empty block]:

```ruby
light.color 
```

### Introducing Sliding Window Error Counting

By default, every recorded failure contributes to reaching the threshold, regardless of when it occurs, causing the Stoplight to turn red. In this release, to provide more flexibility, we've introduced a sliding window configuration using the `#with_window_size` method (#172) that allows you to control how errors are counted within a specified time frame. Here's how it works:

Let's say you set the window size to 2 seconds:

```ruby
window_size_in_seconds = 2

light = Stoplight('example-threshold')
  .with_window_size(window_size_in_seconds)
  .with_threshold(1)
# => #<Stoplight::CircuitBreaker:...>

light.run { 1 / 0 }#=> #<ZeroDivisionError: divided by 0>
sleep(3) 
light.run { 1 / 0 }
```

Without the window size configuration, the second `light.run { 1 / 0 }` call will result in a `Stoplight::Error::RedLight` exception being raised, as the Stoplight transitions to the red state after the first call. With a sliding window of 2 seconds, only the errors that occur within the latest 2 seconds are considered. The first error causes the Stoplight to turn red, but after 3 seconds (when the second error occurs), the window has shifted, and the Stoplight switches to green state causing the error to raise again. This provides a way to focus on the most recent errors.

It's worth noting that the default window size is set to infinity, meaning that all failures are counted regardless of timing.

### Stoplight Gains an Interface for Locking Lights

In earlier versions, when you wanted to lock lights, you had to access Stoplight's internals. Stoplight 4.0 brings a new user-friendly interface to both lock and unlock lights:

```ruby
light.lock('red')
light.unlock
light.lock('green')
```

## What's Changed
* Use actions/setup-ruby@v1 by ruby/setup-ruby@v1 by @bolshakov in https://github.com/bolshakov/stoplight/pull/164
* Move data store specs into shared examples by @bolshakov in https://github.com/bolshakov/stoplight/pull/166
* Update rubocop by @bolshakov in https://github.com/bolshakov/stoplight/pull/167
* Use Redis in specs by @bolshakov in https://github.com/bolshakov/stoplight/pull/173
* Add .idea to gitignore by @bolshakov in https://github.com/bolshakov/stoplight/pull/175
* Shared specs for Stoplight::Light::Runnable by @bolshakov in https://github.com/bolshakov/stoplight/pull/176
* Do not use the same error instance for tests by @bolshakov in https://github.com/bolshakov/stoplight/pull/177
* Drop branded notifiers by @bolshakov in https://github.com/bolshakov/stoplight/pull/174
* Test against different redis versions by @bolshakov in https://github.com/bolshakov/stoplight/pull/179
* Implement window size by @bolshakov in https://github.com/bolshakov/stoplight/pull/172
* feat | Light lock interface improvement by @Lokideos in https://github.com/bolshakov/stoplight/pull/170
* Update gemfile lock by @bolshakov in https://github.com/bolshakov/stoplight/pull/181
* Add stoplight-sentry by @bolshakov in https://github.com/bolshakov/stoplight/pull/182
* Chore | Fix documentation for lockable methods by @Lokideos in https://github.com/bolshakov/stoplight/pull/183
* Interface rework by @bolshakov in https://github.com/bolshakov/stoplight/pull/180
* Update issue templates by @bolshakov in https://github.com/bolshakov/stoplight/pull/189
* Create SECURITY.md by @bolshakov in https://github.com/bolshakov/stoplight/pull/190
* Update rubocop.yml by @bolshakov in https://github.com/bolshakov/stoplight/pull/191
* Update supported ruby version in ruby by @bolshakov in https://github.com/bolshakov/stoplight/pull/193
* Update docs by @bolshakov in https://github.com/bolshakov/stoplight/pull/194
* Specs for the circuit breaker module by @bolshakov in https://github.com/bolshakov/stoplight/pull/195

**Full Changelog**: https://github.com/bolshakov/stoplight/compare/v3.0.1...v4.0.0

[UPGRADING.md]: https://github.com/bolshakov/stoplight/blob/master/UPGRADING.md
[without passing an empty block]: https://github.com/bolshakov/stoplight-admin/blob/9c9848eb94410e46b20972548f0863db224cb6da/lib/sinatra/stoplight_admin.rb#L30