### PR TITLE
Update #names method to retain lights without failures

### DIFF
--- a/lib/stoplight/data_store/base.rb
+++ b/lib/stoplight/data_store/base.rb
@@ -4,8 +4,14 @@ module Stoplight
   module DataStore
     # @abstract
     class Base
-      # @return [Array<String>]
-      def names
+      # @overload names()
+      #   @return [Array<String>]
+      #
+      # @overload names()
+      #   @param used_after [Time]
+      #   @return [Array<String>]
+      #
+      def names(used_after:)
         raise NotImplementedError
       end
 

--- a/lib/stoplight/light/runnable.rb
+++ b/lib/stoplight/light/runnable.rb
@@ -27,6 +27,8 @@ module Stoplight
       # @raise [Error::RedLight]
       def run(&code)
         code = validate_code(&code)
+        record_last_usage
+
         case color
         when Color::GREEN then run_green(&code)
         when Color::YELLOW then run_yellow(&code)
@@ -35,6 +37,10 @@ module Stoplight
       end
 
       private
+
+      def record_last_usage
+        data_store.set_last_used_at(self, Time.now)
+      end
 
       def validate_code(&code)
         raise ArgumentError, <<~ERROR if block_given? && self.code

--- a/spec/stoplight/data_store/base_spec.rb
+++ b/spec/stoplight/data_store/base_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Stoplight::DataStore::Base do
 
   describe '#names' do
     it 'is not implemented' do
-      expect { data_store.names }.to raise_error(NotImplementedError)
+      expect { data_store.names(used_after: Time.now) }.to raise_error(NotImplementedError)
     end
   end
 

--- a/spec/support/data_store/base/names.rb
+++ b/spec/support/data_store/base/names.rb
@@ -5,25 +5,23 @@ RSpec.shared_examples 'Stoplight::DataStore::Base#names' do
     expect(data_store.names).to eql([])
   end
 
-  it 'contains the name of a light with a failure' do
-    data_store.record_failure(light, failure)
+  it 'contains a recently used light' do
+    data_store.set_last_used_at(light, Time.now)
+
     expect(data_store.names).to eql([light.name])
   end
 
-  it 'contains the name of a light with a set state' do
-    data_store.set_state(light, Stoplight::State::UNLOCKED)
-    expect(data_store.names).to eql([light.name])
-  end
+  it 'ignores light used long time ago' do
+    usage_time = Time.now - 100
+    data_store.set_last_used_at(light, usage_time)
 
-  it 'does not duplicate names' do
-    data_store.record_failure(light, failure)
-    data_store.set_state(light, Stoplight::State::UNLOCKED)
-    expect(data_store.names).to eql([light.name])
+    expect(data_store.names(used_after: usage_time + 1)).to be_empty
   end
 
   it 'supports names containing colons' do
     light = Stoplight::Light.new('http://api.example.com/some/action')
-    data_store.record_failure(light, failure)
+    data_store.set_last_used_at(light, Time.now)
+
     expect(data_store.names).to eql([light.name])
   end
 end

--- a/spec/support/light/runnable/run.rb
+++ b/spec/support/light/runnable/run.rb
@@ -15,8 +15,10 @@ RSpec.shared_examples 'Stoplight::Light::Runnable#run' do
   shared_examples 'when the light is green' do
     before { light.data_store.clear_failures(light) }
 
-    it 'runs the code' do
+    it 'runs the code and remembers light name' do
       expect(run).to eql(code_result)
+
+      expect(data_store.names).to include(name)
     end
 
     context 'with some failures' do
@@ -171,8 +173,10 @@ RSpec.shared_examples 'Stoplight::Light::Runnable#run' do
       light.data_store.record_failure(light, failure)
     end
 
-    it 'runs the code' do
+    it 'runs the code and remembers light name' do
       expect(run).to eql(code_result)
+
+      expect(data_store.names).to include(name)
     end
 
     it 'notifies when transitioning to green' do
@@ -194,8 +198,10 @@ RSpec.shared_examples 'Stoplight::Light::Runnable#run' do
       light.data_store.record_failure(light, failure)
     end
 
-    it 'raises an error' do
+    it 'raises an error and remembers light`s name' do
       expect { run }.to raise_error(Stoplight::Error::RedLight)
+
+      expect(data_store.names).to include(name)
     end
 
     it 'uses the name as the error message' do


### PR DESCRIPTION
This commit addresses an issue with the #names method. Previously, the method would only retrieve light names that had failures or been locked. This update ensures that the #names method correctly includes light names without failures and locks as well.

Since Stoplight does not require lights to be registered or unregistered explicitly, we lack a means to understand whether a light is still in use or not. To address this issue, I have added an additional `stoplight:v4:last_used_at` key that stores information about the last time the light was used. This information is updated with every call to Stoplight's #run method.

By default, the `#names` method returns all lights that have been used within the last 7 days. However, if you provide an optional `used_after` argument, you can retrieve lights that were used during a different time period.