### PR TITLE
Add link for Honeybadger Notifiers gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ Stoplight.default_notifiers += [notifier]
 #### Community-supported Notifiers
 
 * [stoplight-sentry]
+* [stoplight-honeybadger](https://github.com/qoqa/stoplight-honeybadger)
 
 You you want to implement your own notifier, the following section contains all the required information.
 


### PR DESCRIPTION
We use Honeybadger and Stoplight. We will migrate to the V4 soon so we decide to develop the gem to be able to notify HB. as it's not support anymore with the new version.