### PR TITLE
Ensure array is returned when cleaning failures in memory

### DIFF
--- a/lib/stoplight/data_store/memory.rb
+++ b/lib/stoplight/data_store/memory.rb
@@ -42,7 +42,7 @@ module Stoplight
       end
 
       def clear_failures(light)
-        synchronize { @failures.delete(light.name) }
+        synchronize { @failures.delete(light.name) || [] }
       end
 
       def get_state(light)

--- a/spec/support/data_store/base/clear_failures.rb
+++ b/spec/support/data_store/base/clear_failures.rb
@@ -9,6 +9,12 @@ RSpec.shared_examples 'Stoplight::DataStore::Base#clear_failures' do
     expect(data_store.clear_failures(light)).to contain_exactly(failure)
   end
 
+  it 'returns an empty array when there are no failures' do
+    data_store.clear_failures(light)
+
+    expect(data_store.clear_failures(light)).to be_empty
+  end
+
   it 'clears the failures' do
     expect do
       data_store.clear_failures(light)


### PR DESCRIPTION
In memory data storage, when cleaning failures when the light name key is missing we returned nil instead of empty array. This caused errors in `on_success` callback checking `.empty?` on failures list.

