### PR TITLE
Improving Configuration and Error Handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,6 @@ Layout/BlockAlignment:
 Metrics/ParameterLists:
   Exclude:
     - 'lib/stoplight/configuration.rb'
+
+Style/CaseEquality:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -111,48 +111,95 @@ check out [the cool off time section][] When stoplights are yellow, they will
 try to run their code. If it fails, they'll switch back to red. If it succeeds,
 they'll switch to green.
 
-### Custom Errors
+### Error Handling
 
-Some errors shouldn't cause your stoplight to move into the red state. Usually
-these are handled elsewhere in your stack and don't represent real failures. A
-good example is `ActiveRecord::RecordNotFound`.
+Stoplight needs to determine which errors should change the light's state 
+and which shouldn't. For this purpose, Stoplight provides two 
+methods: `with_tracked_errors` and `with_skipped_errors`.
 
-To prevent some errors from changing the state of your stoplight, you can
-provide a custom block that will be called with the error and a handler
-`Proc`. It can do one of three things:
+#### Default Behavior
 
-1.  Re-raise the error. This causes Stoplight to ignore the error. Do this for
-    errors like `ActiveRecord::RecordNotFound` that don't represent real
-    failures.
+By default, Stoplight tracks all `StandardError` exceptions, but automatically 
+skips the following errors:
 
-2.  Call the handler with the error. This is the default behavior. Stoplight
-    will only ignore the error if it shouldn't have been caught in the first
-    place. See `Stoplight::Error::AVOID_RESCUING` for a list of errors that
-    will be ignored.
+```
+NoMemoryError,
+ScriptError,
+SecurityError,
+SignalException,
+SystemExit,
+SystemStackError
+```
 
-3.  Do nothing. This is **not recommended**. Doing nothing causes Stoplight to
-    never ignore the error. That means a `NoMemoryError` could change the color
-    of your stoplights.
+#### Custom Error Configuration
+
+Some errors shouldn't cause your Stoplight to move into the red state. Usually 
+these are handled elsewhere in your stack and don't represent real failures. 
+A good example is `ActiveRecord::RecordNotFound`. 
+
+To prevent specific errors from changing the state of your stoplight, use `#with_skipped_errors`:
 
 ```ruby
 light = Stoplight('example-not-found')
-  .with_error_handler do |error, handle|
-    if error.is_a?(ActiveRecord::RecordNotFound)
-      raise error
-    else      
-      handle.call(error)
-    end
-  end
-# => #<Stoplight::CircuitBreaker:...>
+  .with_skipped_errors(ActiveRecord::RecordNotFound)
+# => #<Stoplight::Light:...>
+
 light.run { User.find(123) }
 # ActiveRecord::RecordNotFound: Couldn't find User with ID=123
 light.run { User.find(123) }
 # ActiveRecord::RecordNotFound: Couldn't find User with ID=123
 light.run { User.find(123) }
 # ActiveRecord::RecordNotFound: Couldn't find User with ID=123
+
 light.color
 # => "green"
 ```
+
+You can add multiple errors to skip:
+
+```ruby
+light = Stoplight('example-custom')
+  .with_skipped_errors(
+    ActiveRecord::RecordNotFound, 
+    ActiveRecord::RecordInvalid,
+    ValidationError
+  )
+```
+
+To explicitly specify which errors should be tracked (those that will 
+change the light's state), use `#with_tracked_errors`:
+
+```ruby
+light = Stoplight('example-api')
+  .with_tracked_errors(
+    NetworkError,
+    Timeout::Error,
+    ApiRateLimitError
+  )
+```
+
+#### Interaction Between Tracked and Skipped Errors
+
+When both `#with_tracked_errors` and `#with_skipped_errors` are used:
+
+* Errors in the `skipped_errors` list take precedence - they will never change the light's color
+* Errors in the `tracked_errors` list will be counted toward changing the light from green to yellow to red
+* Errors in neither list will follow the default behavior (tracked unless they're in the built-in skip list)
+
+#### Advanced Usage: Triple Equals Operator
+
+Both methods use triple equals operator (`===`) for comparison, allowing for flexible error matching:
+
+```ruby
+light = Stoplight('flexible-matching')
+  .with_tracked_errors(
+    ->(e) { e.is_a?(ApiError) && e.status >= 500 },
+    ->(e) { e.message.include?("rate limit exceeded") }
+  )
+```
+
+This allows for complex error classification based on error properties 
+beyond just their class.
 
 ### Custom Fallback
 

--- a/README.md
+++ b/README.md
@@ -162,20 +162,20 @@ fallback that will be called in both of these cases. It will be passed the
 error if the light was green.
 
 ```ruby
+fallback = ->(e) {  e; 'default' }
 light = Stoplight('example-fallback')
-  .with_fallback { |e| p e; 'default' }
 # => #<Stoplight::CircuitBreaker:..>
-light.run { 1 / 0 }
+light.run(fallback) { 1 / 0 }
 # #<ZeroDivisionError: divided by 0>
 # => "default"
-light.run { 1 / 0 }
+light.run(fallback) { 1 / 0 }
 # #<ZeroDivisionError: divided by 0>
 # => "default"
-light.run { 1 / 0 }
+light.run(fallback) { 1 / 0 }
 # Switching example-fallback from green to red because ZeroDivisionError divided by 0
 # #<ZeroDivisionError: divided by 0>
 # => "default"
-light.run { 1 / 0 }
+light.run(fallback) { 1 / 0 }
 # nil
 # => "default"
 ```

--- a/lib/stoplight/builder.rb
+++ b/lib/stoplight/builder.rb
@@ -27,7 +27,6 @@ module Stoplight
     include CircuitBreaker
     extend Forwardable
 
-    def_delegator :build, :error_handler
     def_delegator :build, :color
     def_delegator :build, :name
     def_delegator :build, :state

--- a/lib/stoplight/builder.rb
+++ b/lib/stoplight/builder.rb
@@ -28,8 +28,6 @@ module Stoplight
     extend Forwardable
 
     def_delegator :build, :with_error_handler
-    def_delegator :build, :with_fallback
-    def_delegator :build, :fallback
     def_delegator :build, :error_handler
     def_delegator :build, :color
     def_delegator :build, :name

--- a/lib/stoplight/builder.rb
+++ b/lib/stoplight/builder.rb
@@ -27,7 +27,6 @@ module Stoplight
     include CircuitBreaker
     extend Forwardable
 
-    def_delegator :build, :with_error_handler
     def_delegator :build, :error_handler
     def_delegator :build, :color
     def_delegator :build, :name

--- a/lib/stoplight/circuit_breaker.rb
+++ b/lib/stoplight/circuit_breaker.rb
@@ -104,19 +104,6 @@ module Stoplight
       raise NotImplementedError
     end
 
-    # Configures light with the given fallback block
-    #
-    # @example
-    #   light = Stoplight('example')
-    #   light.with_fallback { |error| e.is_a?()ZeroDivisionError) ? 0 : nil }
-    #   light.run { 1 / 0} #=> 0
-    #
-    # @yieldparam error [Exception, nil]
-    # @return [Stoplight::CircuitBreaker]
-    def with_fallback(&fallback)
-      raise NotImplementedError
-    end
-
     # @return [String] one of +locked_green+, +locked_red+, and +unlocked+
     def state
       raise NotImplementedError
@@ -147,9 +134,14 @@ module Stoplight
     #   light = Stoplight('example')
     #   light.run { 2/0 }
     #
+    # @example Running with fallback
+    #   light = Stoplight('example')
+    #   light.run(->(error) { 0 }) { 1 / 0 } #=> 0
+    #
+    # @param fallback [Proc, nil] (nil) fallback code to run if the circuit breaker is open
     # @raise [Stoplight::Error::RedLight]
     # @return [any]
-    def run(&code)
+    def run(fallback = nil, &code)
       raise NotImplementedError
     end
 

--- a/lib/stoplight/circuit_breaker.rb
+++ b/lib/stoplight/circuit_breaker.rb
@@ -83,6 +83,45 @@ module Stoplight
       reconfigure(configuration.with(error_notifier: error_notifier))
     end
 
+    # Configures a custom list of tracked errors that counts toward the threshold.
+    #
+    # @example
+    #   light = Stoplight('example')
+    #     .with_tracked_errors(TimeoutError, NetworkError)
+    #   light.run { call_external_service }
+    #
+    # In the example above, the +TimeoutError+ and +NetworkError+ exceptions
+    # will be counted towards the threshold for moving the circuit breaker into the red state.
+    # If not configured, the default tracked error is +StandardError+.
+    #
+    # @param tracked_errors [Array<StandardError>]
+    # @return [Stoplight::CircuitBreaker]
+    def with_tracked_errors(*tracked_errors)
+      reconfigure(configuration.with(tracked_errors: tracked_errors.dup.freeze))
+    end
+
+    # Configures a custom list of skipped errors that do not count toward the threshold.
+    # Typically, such errors does not represent a real failure and handled somewhere else
+    # in the code.
+    #
+    # @example
+    #   light = Stoplight('example')
+    #    .with_skipped_errors(ActiveRecord::RecordNotFound)
+    #   light.run { User.find(123) }
+    #
+    # In the example above, the +ActiveRecord::RecordNotFound+ doesn't
+    # move the circuit breaker into the red state.
+    #
+    # The list of skipped errors is always complemented by the default
+    # skipped errors: +NoMemoryError+, +ScriptError+, +SecurityError+, etc.
+    # @see +Stoplight::Default::SKIPPED_ERRORS+
+    #
+    # @param skipped_errors [Array<Exception>]
+    # @return [Stoplight::CircuitBreaker]
+    def with_skipped_errors(*skipped_errors)
+      reconfigure(configuration.with(skipped_errors: skipped_errors))
+    end
+
     # Configures a custom proc that allows you not to handle an error
     # with Stoplight.
     #

--- a/lib/stoplight/circuit_breaker.rb
+++ b/lib/stoplight/circuit_breaker.rb
@@ -122,27 +122,6 @@ module Stoplight
       reconfigure(configuration.with(skipped_errors: skipped_errors))
     end
 
-    # Configures a custom proc that allows you not to handle an error
-    # with Stoplight.
-    #
-    # @example
-    #   light = Stoplight('example')
-    #     .with_error_handler do |error, handler|
-    #       raise error if error.is_a?(ActiveRecord::RecordNotFound)
-    #       handle.call(error)
-    #     end
-    #   light.run { User.find(123) }
-    #
-    # In the example above, the +ActiveRecord::RecordNotFound+ doesn't
-    # move the circuit breaker into the red state.
-    #
-    # @yieldparam error [Exception]
-    # @yieldparam handle [Proc]
-    # @return [Stoplight::CircuitBreaker]
-    def with_error_handler(&error_handler)
-      raise NotImplementedError
-    end
-
     # @return [String] one of +locked_green+, +locked_red+, and +unlocked+
     def state
       raise NotImplementedError

--- a/lib/stoplight/configuration.rb
+++ b/lib/stoplight/configuration.rb
@@ -26,7 +26,7 @@ module Stoplight
           threshold: Default::THRESHOLD,
           window_size: Default::WINDOW_SIZE,
           tracked_errors: Default::TRACKED_ERRORS,
-          skipped_errors: Default::SKIPPED_ERRORS,
+          skipped_errors: Default::SKIPPED_ERRORS
         }
       end
     end
@@ -76,7 +76,8 @@ module Stoplight
     # @param window_size [Numeric]
     # @param tracked_errors [Array<StandardError>]
     # @param skipped_errors [Array<Exception>]
-    def initialize(name:, cool_off_time:, data_store:, error_notifier:, notifiers:, threshold:, window_size:, tracked_errors:, skipped_errors:)
+    def initialize(name:, cool_off_time:, data_store:, error_notifier:, notifiers:, threshold:, window_size:,
+                   tracked_errors:, skipped_errors:)
       @name = name
       @cool_off_time = cool_off_time
       @data_store = data_store
@@ -141,7 +142,7 @@ module Stoplight
         threshold: threshold,
         window_size: window_size,
         tracked_errors: tracked_errors,
-        skipped_errors: skipped_errors,
+        skipped_errors: skipped_errors
       }
     end
   end

--- a/lib/stoplight/configuration.rb
+++ b/lib/stoplight/configuration.rb
@@ -24,7 +24,9 @@ module Stoplight
           error_notifier: Stoplight.default_error_notifier,
           notifiers: Stoplight.default_notifiers,
           threshold: Default::THRESHOLD,
-          window_size: Default::WINDOW_SIZE
+          window_size: Default::WINDOW_SIZE,
+          tracked_errors: Default::TRACKED_ERRORS,
+          skipped_errors: Default::SKIPPED_ERRORS,
         }
       end
     end
@@ -57,6 +59,14 @@ module Stoplight
     #   @return [Numeric]
     attr_reader :window_size
 
+    # @!attribute [r] tracked_errors
+    #   @return [Set<StandardError>]
+    attr_reader :tracked_errors
+
+    # @!attribute [r] skipped_errors
+    #  @return [Set<Exception>]
+    attr_reader :skipped_errors
+
     # @param name [String]
     # @param cool_off_time [Numeric]
     # @param data_store [Stoplight::DataStore::Base]
@@ -64,7 +74,9 @@ module Stoplight
     # @param notifiers [Stoplight::Notifier::Base]
     # @param threshold [Numeric]
     # @param window_size [Numeric]
-    def initialize(name:, cool_off_time:, data_store:, error_notifier:, notifiers:, threshold:, window_size:)
+    # @param tracked_errors [Array<StandardError>]
+    # @param skipped_errors [Array<Exception>]
+    def initialize(name:, cool_off_time:, data_store:, error_notifier:, notifiers:, threshold:, window_size:, tracked_errors:, skipped_errors:)
       @name = name
       @cool_off_time = cool_off_time
       @data_store = data_store
@@ -72,6 +84,8 @@ module Stoplight
       @notifiers = notifiers
       @threshold = threshold
       @window_size = window_size
+      @tracked_errors = Set.new(tracked_errors)
+      @skipped_errors = Set.new(skipped_errors + Stoplight::Default::SKIPPED_ERRORS)
     end
 
     # @param other [any]
@@ -87,6 +101,8 @@ module Stoplight
     # @param notifiers [Array<Stoplight::Notifier::Base>]
     # @param threshold [Numeric]
     # @param window_size [Numeric]
+    # @param tracked_errors [Array<StandardError>]
+    # @param skipped_errors [Array<Exception>]
     # @return [Stoplight::Configuration]
     def with(
       cool_off_time: self.cool_off_time,
@@ -95,7 +111,9 @@ module Stoplight
       name: self.name,
       notifiers: self.notifiers,
       threshold: self.threshold,
-      window_size: self.window_size
+      window_size: self.window_size,
+      tracked_errors: self.tracked_errors,
+      skipped_errors: self.skipped_errors
     )
       Configuration.new(
         cool_off_time: cool_off_time,
@@ -104,7 +122,9 @@ module Stoplight
         name: name,
         notifiers: notifiers,
         threshold: threshold,
-        window_size: window_size
+        window_size: window_size,
+        tracked_errors: tracked_errors,
+        skipped_errors: skipped_errors
       )
     end
 
@@ -119,7 +139,9 @@ module Stoplight
         name: name,
         notifiers: notifiers,
         threshold: threshold,
-        window_size: window_size
+        window_size: window_size,
+        tracked_errors: tracked_errors,
+        skipped_errors: skipped_errors,
       }
     end
   end

--- a/lib/stoplight/configuration.rb
+++ b/lib/stoplight/configuration.rb
@@ -117,14 +117,8 @@ module Stoplight
       skipped_errors: self.skipped_errors
     )
       Configuration.new(
-        cool_off_time: cool_off_time,
-        data_store: data_store,
-        error_notifier: error_notifier,
-        name: name,
-        notifiers: notifiers,
-        threshold: threshold,
-        window_size: window_size,
-        tracked_errors: tracked_errors,
+        cool_off_time: cool_off_time, data_store: data_store, error_notifier: error_notifier, name: name,
+        notifiers: notifiers, threshold: threshold, window_size: window_size, tracked_errors: tracked_errors,
         skipped_errors: skipped_errors
       )
     end
@@ -134,14 +128,8 @@ module Stoplight
     # @return [Hash]
     def settings
       {
-        cool_off_time: cool_off_time,
-        data_store: data_store,
-        error_notifier: error_notifier,
-        name: name,
-        notifiers: notifiers,
-        threshold: threshold,
-        window_size: window_size,
-        tracked_errors: tracked_errors,
+        cool_off_time: cool_off_time, data_store: data_store, error_notifier: error_notifier, name: name,
+        notifiers: notifiers, threshold: threshold, window_size: window_size, tracked_errors: tracked_errors,
         skipped_errors: skipped_errors
       }
     end

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -6,8 +6,6 @@ module Stoplight
 
     DATA_STORE = DataStore::Memory.new
 
-    ERROR_HANDLER = ->(error, handler) { handler.call(error) }
-
     ERROR_NOTIFIER = ->(error) { warn error }
 
     FORMATTER = lambda do |light, from_color, to_color, error|

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -29,7 +29,7 @@ module Stoplight
       SecurityError,
       SignalException,
       SystemExit,
-      SystemStackError,
+      SystemStackError
     ].freeze
   end
 end

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -10,8 +10,6 @@ module Stoplight
 
     ERROR_NOTIFIER = ->(error) { warn error }
 
-    FALLBACK = nil
-
     FORMATTER = lambda do |light, from_color, to_color, error|
       words = ['Switching', light.name, 'from', from_color, 'to', to_color]
       words += ['because', error.class, error.message] if error

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -23,5 +23,15 @@ module Stoplight
     THRESHOLD = 3
 
     WINDOW_SIZE = Float::INFINITY
+
+    TRACKED_ERRORS = [StandardError].freeze
+    SKIPPED_ERRORS = [
+      NoMemoryError,
+      ScriptError,
+      SecurityError,
+      SignalException,
+      SystemExit,
+      SystemStackError,
+    ].freeze
   end
 end

--- a/lib/stoplight/error.rb
+++ b/lib/stoplight/error.rb
@@ -12,7 +12,7 @@ module Stoplight
       SecurityError,
       SignalException,
       SystemExit,
-      SystemStackError
+      SystemStackError,
     ].freeze
 
     Base = Class.new(StandardError)

--- a/lib/stoplight/error.rb
+++ b/lib/stoplight/error.rb
@@ -2,15 +2,6 @@
 
 module Stoplight
   module Error
-    AVOID_RESCUING = [
-      NoMemoryError,
-      ScriptError,
-      SecurityError,
-      SignalException,
-      SystemExit,
-      SystemStackError
-    ].freeze
-
     Base = Class.new(StandardError)
     IncorrectColor = Class.new(Base)
     RedLight = Class.new(Base)

--- a/lib/stoplight/error.rb
+++ b/lib/stoplight/error.rb
@@ -2,17 +2,13 @@
 
 module Stoplight
   module Error
-    HANDLER = lambda do |error|
-      raise error if AVOID_RESCUING.any? { |klass| error.is_a?(klass) }
-    end
-
     AVOID_RESCUING = [
       NoMemoryError,
       ScriptError,
       SecurityError,
       SignalException,
       SystemExit,
-      SystemStackError,
+      SystemStackError
     ].freeze
 
     Base = Class.new(StandardError)

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -50,14 +50,6 @@ module Stoplight
       @error_handler = Default::ERROR_HANDLER
     end
 
-    # @yieldparam error [Exception]
-    # @yieldparam handle [Proc]
-    # @return [Stoplight::CircuitBreaker]
-    def with_error_handler(&error_handler)
-      @error_handler = error_handler
-      self
-    end
-
     private
 
     def reconfigure(configuration)

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -35,8 +35,6 @@ module Stoplight
 
     # @return [String]
     attr_reader :name
-    # @return [Proc]
-    attr_reader :error_handler
     # @return [Stoplight::Configuration]
     # @api private
     attr_reader :configuration
@@ -47,7 +45,6 @@ module Stoplight
     def initialize(name, configuration)
       @configuration = configuration
       @name = name
-      @error_handler = Default::ERROR_HANDLER
     end
 
     private

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -37,8 +37,6 @@ module Stoplight
     attr_reader :name
     # @return [Proc]
     attr_reader :error_handler
-    # @return [Proc, nil]
-    attr_reader :fallback
     # @return [Stoplight::Configuration]
     # @api private
     attr_reader :configuration
@@ -50,7 +48,6 @@ module Stoplight
       @configuration = configuration
       @name = name
       @error_handler = Default::ERROR_HANDLER
-      @fallback = Default::FALLBACK
     end
 
     # @yieldparam error [Exception]
@@ -58,13 +55,6 @@ module Stoplight
     # @return [Stoplight::CircuitBreaker]
     def with_error_handler(&error_handler)
       @error_handler = error_handler
-      self
-    end
-
-    # @yieldparam error [Exception, nil]
-    # @return [Stoplight::CircuitBreaker]
-    def with_fallback(&fallback)
-      @fallback = fallback
       self
     end
 

--- a/lib/stoplight/light/runnable.rb
+++ b/lib/stoplight/light/runnable.rb
@@ -73,7 +73,8 @@ module Stoplight
       end
 
       def handle_error(error, on_failure, fallback)
-        error_handler(error)
+        raise error unless handle_error?(error)
+
         size = record_failure(error)
         on_failure&.call(size, error)
         raise error unless fallback
@@ -81,8 +82,11 @@ module Stoplight
         fallback.call(error)
       end
 
-      def error_handler(error)
-        Error::HANDLER.call(error)
+      def handle_error?(error)
+        skip = configuration.skipped_errors.any? { |klass| klass === error }
+        track = configuration.tracked_errors.any? { |klass| klass === error }
+
+        !skip && track
       end
 
       def clear_failures

--- a/lib/stoplight/light/runnable.rb
+++ b/lib/stoplight/light/runnable.rb
@@ -73,12 +73,16 @@ module Stoplight
       end
 
       def handle_error(error, on_failure, fallback)
-        error_handler.call(error, Error::HANDLER)
+        error_handler(error)
         size = record_failure(error)
         on_failure&.call(size, error)
         raise error unless fallback
 
         fallback.call(error)
+      end
+
+      def error_handler(error)
+        Error::HANDLER.call(error)
       end
 
       def clear_failures

--- a/spec/stoplight/builder_spec.rb
+++ b/spec/stoplight/builder_spec.rb
@@ -81,17 +81,6 @@ RSpec.describe Stoplight::Builder do
       end
     end
 
-    describe '#with_fallback' do
-      subject(:light) { builder.with_fallback(&fallback) }
-
-      let(:fallback) { ->(error) {} }
-
-      it 'returns an instance of the Light class with this configuration set' do
-        expect(light.configuration).to be(configuration)
-        expect(light.fallback).to eq(fallback)
-      end
-    end
-
     describe '#run' do
       it 'yields the block' do
         expect do |code|

--- a/spec/stoplight/builder_spec.rb
+++ b/spec/stoplight/builder_spec.rb
@@ -70,17 +70,6 @@ RSpec.describe Stoplight::Builder do
       )
     end
 
-    describe '#with_error_handler' do
-      subject(:light) { builder.with_error_handler(&error_handler) }
-
-      let(:error_handler) { ->(error, handle) {} }
-
-      it 'returns an instance of the Light class with this configuration set' do
-        expect(light.configuration).to be(configuration)
-        expect(light.error_handler).to eq(error_handler)
-      end
-    end
-
     describe '#run' do
       it 'yields the block' do
         expect do |code|

--- a/spec/stoplight/circuit_breaker_spec.rb
+++ b/spec/stoplight/circuit_breaker_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe Stoplight::CircuitBreaker do
     Class.new { include Stoplight::CircuitBreaker }
   end
 
-  specify '#with_error_handler' do
-    expect { circuit_breaker.with_error_handler {} }.to raise_error(NotImplementedError)
-  end
-
   specify '#color' do
     expect { circuit_breaker.color }.to raise_error(NotImplementedError)
   end

--- a/spec/stoplight/circuit_breaker_spec.rb
+++ b/spec/stoplight/circuit_breaker_spec.rb
@@ -13,10 +13,6 @@ RSpec.describe Stoplight::CircuitBreaker do
     expect { circuit_breaker.with_error_handler {} }.to raise_error(NotImplementedError)
   end
 
-  specify '#with_fallback' do
-    expect { circuit_breaker.with_fallback {} }.to raise_error(NotImplementedError)
-  end
-
   specify '#color' do
     expect { circuit_breaker.color }.to raise_error(NotImplementedError)
   end

--- a/spec/stoplight/default_spec.rb
+++ b/spec/stoplight/default_spec.rb
@@ -19,16 +19,6 @@ RSpec.describe Stoplight::Default do
     end
   end
 
-  describe '::ERROR_HANDLER' do
-    it 'is a proc' do
-      expect(Stoplight::Default::ERROR_HANDLER).to be_a(Proc)
-    end
-
-    it 'has an arity of 2' do
-      expect(Stoplight::Default::ERROR_HANDLER.arity).to eql(2)
-    end
-  end
-
   describe '::ERROR_NOTIFIER' do
     it 'is a proc' do
       expect(Stoplight::Default::ERROR_NOTIFIER).to be_a(Proc)

--- a/spec/stoplight/default_spec.rb
+++ b/spec/stoplight/default_spec.rb
@@ -39,12 +39,6 @@ RSpec.describe Stoplight::Default do
     end
   end
 
-  describe '::FALLBACK' do
-    it 'is nil' do
-      expect(Stoplight::Default::FALLBACK).to eql(nil)
-    end
-  end
-
   describe '::FORMATTER' do
     it 'is a proc' do
       expect(Stoplight::Default::FORMATTER).to be_a(Proc)

--- a/spec/stoplight_spec.rb
+++ b/spec/stoplight_spec.rb
@@ -53,12 +53,4 @@ RSpec.describe 'Stoplight' do
       expect(light.error_handler).to eql(Stoplight::Default::ERROR_HANDLER)
     end
   end
-
-  describe '#with_error_handler' do
-    it 'sets the error handler' do
-      error_handler = ->(_, _) {}
-      with_error_handler = light.with_error_handler(&error_handler)
-      expect(with_error_handler.error_handler).to eql(error_handler)
-    end
-  end
 end

--- a/spec/stoplight_spec.rb
+++ b/spec/stoplight_spec.rb
@@ -47,10 +47,4 @@ RSpec.describe 'Stoplight' do
       expect(light.name).to eql(name)
     end
   end
-
-  describe '#error_handler' do
-    it 'it initially the default' do
-      expect(light.error_handler).to eql(Stoplight::Default::ERROR_HANDLER)
-    end
-  end
 end

--- a/spec/stoplight_spec.rb
+++ b/spec/stoplight_spec.rb
@@ -48,12 +48,6 @@ RSpec.describe 'Stoplight' do
     end
   end
 
-  describe '#fallback' do
-    it 'is initially the default' do
-      expect(light.fallback).to eql(Stoplight::Default::FALLBACK)
-    end
-  end
-
   describe '#error_handler' do
     it 'it initially the default' do
       expect(light.error_handler).to eql(Stoplight::Default::ERROR_HANDLER)
@@ -65,14 +59,6 @@ RSpec.describe 'Stoplight' do
       error_handler = ->(_, _) {}
       with_error_handler = light.with_error_handler(&error_handler)
       expect(with_error_handler.error_handler).to eql(error_handler)
-    end
-  end
-
-  describe '#with_fallback' do
-    it 'sets the fallback' do
-      fallback = ->(_) {}
-      with_fallback = light.with_fallback(&fallback)
-      expect(with_fallback.fallback).to eql(fallback)
     end
   end
 end

--- a/spec/support/circuit_breaker.rb
+++ b/spec/support/circuit_breaker.rb
@@ -85,7 +85,8 @@ RSpec.shared_examples Stoplight::CircuitBreaker do
     end
 
     it 'configures skipped errors' do
-      expect(with_attribute.configuration.skipped_errors).to contain_exactly(*skipped_errors, *Stoplight::Default::SKIPPED_ERRORS)
+      expect(with_attribute.configuration.skipped_errors).to contain_exactly(*skipped_errors,
+                                                                             *Stoplight::Default::SKIPPED_ERRORS)
     end
   end
 end

--- a/spec/support/circuit_breaker.rb
+++ b/spec/support/circuit_breaker.rb
@@ -64,4 +64,28 @@ RSpec.shared_examples Stoplight::CircuitBreaker do
       expect(with_attribute.configuration.error_notifier).to eq(error_notifier)
     end
   end
+
+  describe '#with_tracked_errors' do
+    let(:tracked_errors) { [RuntimeError, KeyError] }
+
+    subject(:with_attribute) do
+      circuit_breaker.with_tracked_errors(*tracked_errors)
+    end
+
+    it 'configures tracked errors' do
+      expect(with_attribute.configuration.tracked_errors).to contain_exactly(*tracked_errors)
+    end
+  end
+
+  describe '#with_skipped_errors' do
+    let(:skipped_errors) { [RuntimeError, KeyError] }
+
+    subject(:with_attribute) do
+      circuit_breaker.with_skipped_errors(*skipped_errors)
+    end
+
+    it 'configures skipped errors' do
+      expect(with_attribute.configuration.skipped_errors).to contain_exactly(*skipped_errors, *Stoplight::Default::SKIPPED_ERRORS)
+    end
+  end
 end

--- a/spec/support/light/runnable/run.rb
+++ b/spec/support/light/runnable/run.rb
@@ -97,35 +97,6 @@ end
         expect(io.string).to_not eql('')
       end
 
-      context 'with an error handler' do
-        let(:result) do
-          run
-          expect(false).to be(true)
-        rescue error.class
-          expect(true).to be(true)
-        end
-
-        it 'records the failure when the handler does nothing' do
-          light.with_error_handler { |_error, _handler| }
-          expect { result }
-            .to change { light.configuration.data_store.get_failures(light).size }
-            .by(1)
-        end
-
-        it 'records the failure when the handler calls handle' do
-          light.with_error_handler { |error, handle| handle.call(error) }
-          expect { result }
-            .to change { light.configuration.data_store.get_failures(light).size }
-            .by(1)
-        end
-
-        it 'does not record the failure when the handler raises' do
-          light.with_error_handler { |error, _handle| raise error }
-          expect { result }
-            .to_not change { light.configuration.data_store.get_failures(light).size }
-        end
-      end
-
       context 'with a fallback' do
         it 'runs the fallback' do
           expect(run(fallback)).to eql(fallback_result)


### PR DESCRIPTION
This PR introduces significant improvements to the Stoplight gem API, making it more flexible and easier to use. Note that this is a breaking change that addresses design limitations in the current implementation.

## Problems with the Current Design

### Stateful Configuration Issues

The current approach using `#with_error_handler` and `#with_fallback` creates several problems:

1. **Configuration Leakage**: Both `#with_error_handler` and `#with_fallback` were slightly different from other configuration options, it was possible to define them on the `Stoplight::Light` lever which was a mutable instance. It was implemented this way for the sake of backward compatibility.

   ```ruby
   # This light is used across different services
   shared_light = Stoplight("payment")
     .with_threshold(5)
     .with_fallback { |error| log_and_return_empty_array(error) }
   
   # Later in code path A - modifies the global light object
   shared_light.with_error_handler { |error, handler| .... l }.run { ... }
   
   # Later in code path B - now has the error handler from code path A!
   shared_light.run { fetch_data } # Uses the fallback from path A if it fails
   ```

2. **Block-based Chain Breaking**: The block-based API breaks the natural method chaining:

   ```ruby
   # Awkward nesting required when combining multiple blocks
   Stoplight("example").with_fallback do |e| 
      handle(e) 
   end.run { code }
   ```

### Error Handler Complexity

The current `#with_error_handler` design is confusing:

```ruby
light.with_error_handler do |error, handle|
  if error.is_a?(ActiveRecord::RecordNotFound)
    raise error  # Skip this error
  else      
    handle.call(error)  # Default behavior
  end
end
```

This pattern:
- Requires understanding a complex behavioral contract
- Creates confusing control flow where raising an error is the mechanism to skip it
- Makes it easy to introduce bugs by forgetting to call the handler

## Improvements in this PR

### 1. Runtime Fallbacks

Fallbacks are now provided directly to the `#run` method as a parameter:

```ruby
light = Stoplight("payment-gateway")

# Different operations with operation-specific fallbacks
light.run(-> { [] }) { get_invoices }
light.run(-> { 0 }) { get_credits }
```

Benefits:
- **Operation-specific fallbacks**: Each protected operation can have its own appropriate fallback
- **Shared configuration**: Core circuit breaker settings can be reused without fallback contamination
- **Clear intent**: Makes it obvious which fallback belongs to which operation

### 2. Simplified Error Handling

Replaced the complex `#with_error_handler` approach with two declarative methods:

```ruby
light = Stoplight('api-service')
  .with_tracked_errors(NetworkError, Timeout::Error)
  .with_skipped_errors(ActiveRecord::RecordNotFound)
```

Benefits:
- **Declarative over imperative**: Simply list error types instead of writing custom handler logic
- **Easier to understand**: Clear separation between "count this error" and "ignore this error"
- **Reduced chance of bugs**: No possibility of forgetting to call the handler or raise the error

## Migration Path

Since this is a breaking change, existing code will need updates:

```ruby
# Old code
light = Stoplight('example')
  .with_error_handler do |error, handle|
    if error.is_a?(ActiveRecord::RecordNotFound)
      raise error
    else      
      handle.call(error)
    end
  end
  .with_fallback { |error| [] }

# New code
light = Stoplight('example')
  .with_skipped_errors(ActiveRecord::RecordNotFound)

light.run(->() { [] }) { code_to_protect }
```

We recommend updating in stages:
1. First migrate error handlers to the new pattern
2. Then update run calls to include fallbacks

## Why This Breaking Change is Necessary

The limitations of the current design cannot be addressed without breaking changes because:

1. The mutable, stateful nature of lights is fundamental to the current implementation
2. The block-based API for error handling and fallbacks can't be cleanly replaced without a new interface
3. The improved approach simplifies code, reduces bugs, and enables important use cases that were impossible before

While we recognize this is a breaking change, the significantly improved API and resolved design problems justify the transition. Getting rid of mutable state from `Stoplight::Light` instances allows us to perform massive refactoring unifying several internal entities (Bulder, Light, CircuitBreaker) into one. This simplifies the code and therefore maintenance 