### PR TITLE
Allow passing configuration options to Stoplight() method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
-  gem "standard"
   gem "benchmark-ips", "~> 2.14"
   gem "database_cleaner-redis", "~> 2.0"
   gem "debug"
@@ -15,5 +14,6 @@ group :development do
   gem "ruby-prof"
   gem "simplecov", "~> 0.22"
   gem "simplecov-lcov", "~> 0.8"
+  gem "standard"
   gem "timecop", "~> 0.9"
 end

--- a/README.md
+++ b/README.md
@@ -307,6 +307,34 @@ the cool off to `Float::INFINITY`. To make automatic recovery instantaneous,
 set the cool off to `0` seconds. Note that this is not recommended, as it
 effectively replaces the red state with yellow.
 
+### Direct Usage
+
+In addition to the builder interface, you can directly create a stoplight using 
+the `Stoplight()` method. This method allows you to configure the stoplight with a name and 
+optional settings in a single step.
+
+```ruby
+light = Stoplight('example-direct', cool_off_time: 10, threshold: 5)
+
+light.run { 1 / 0 }
+# ZeroDivisionError: divided by 0
+light.color
+# => "red"
+```
+
+The `Stoplight()` method accepts the following settings:
+
+* `:cool_off_time` - The time to wait before resetting the circuit breaker.
+* `:data_store` - The data store to use for storing state.
+* `:error_notifier` - A proc to handle error notifications.
+* `:notifiers` - A list of notifiers to use.
+* `:threshold` - The failure threshold to trip the circuit breaker.
+* `:window_size` - The size of the rolling window for failure tracking.
+* `:tracked_errors` - A list of errors to track.
+* `:skipped_errors` - A list of errors to skip.
+
+This approach is useful for quickly setting up a stoplight without chaining multiple configuration methods.
+
 ### Rails
 
 Stoplight was designed to wrap Rails actions with minimal effort. Here's an

--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -50,8 +50,22 @@ require "stoplight/light/lockable"
 require "stoplight/light/runnable"
 require "stoplight/light"
 
-# @return [Stoplight::CircuitBreaker]
-def Stoplight(name) # rubocop:disable Naming/MethodName
-  config = Stoplight::Light::Config.new(name: name)
+# Creates a new Stoplight circuit breaker with the given name and settings.
+#
+# @param name [String] The name of the circuit breaker.
+# @param settings [Hash] Optional settings to configure the circuit breaker.
+#   @option settings [Numeric] :cool_off_time The time to wait before resetting the circuit breaker.
+#   @option settings [Stoplight::DataStore::Base] :data_store The data store to use for storing state.
+#   @option settings [Proc] :error_notifier A proc to handle error notifications.
+#   @option settings [Array<Stoplight::Notifier::Base>] :notifiers A list of notifiers to use.
+#   @option settings [Numeric] :threshold The failure threshold to trip the circuit breaker.
+#   @option settings [Numeric] :window_size The size of the rolling window for failure tracking.
+#   @option settings [Array<StandardError>] :tracked_errors A list of errors to track.
+#   @option settings [Array<Exception>] :skipped_errors A list of errors to skip.
+#
+# @return [Stoplight::CircuitBreaker] A new circuit breaker instance.
+# @raise [ArgumentError] If an unknown option is provided in the settings.
+def Stoplight(name, **settings) # rubocop:disable Naming/MethodName
+  config = Stoplight::Light::Config.new(name: name, **settings)
   Stoplight::Light.new(config)
 end

--- a/spec/stoplight_spec.rb
+++ b/spec/stoplight_spec.rb
@@ -48,4 +48,39 @@ RSpec.describe "Stoplight" do
       expect(light.name).to eql(name)
     end
   end
+
+  context "with settings" do
+    subject(:light) { Stoplight(name, **settings) }
+
+    let(:settings) do
+      {
+        cool_off_time: 1,
+        data_store: data_store,
+        error_notifier: error_notifier,
+        notifiers: notifiers,
+        threshold: 4,
+        window_size: 5,
+        tracked_errors: [StandardError],
+        skipped_errors: [KeyError]
+      }
+    end
+    let(:data_store) { Stoplight::DataStore::Memory.new }
+    let(:error_notifier) { ->(error) { warn error } }
+    let(:notifiers) { Stoplight::Notifier::IO.new($stdout) }
+
+    it "instantiates with the correct settings" do
+      config = Stoplight::Light::Config.new(name: name, **settings)
+      expect(light).to eq(Stoplight::Light.new(config))
+    end
+
+    context "when unknown option is given" do
+      let(:settings) do
+        super().merge(unknown_option: "unknown")
+      end
+
+      it "raises an ArgumentError" do
+        expect { light }.to raise_error(ArgumentError, /unknown_option/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
In addition to the builder interface, you can directly create a stoplight using the `Stoplight()` method. This method allows you to configure the stoplight with a name and optional settings in a single step.

```ruby
light = Stoplight('example-direct', cool_off_time: 10, threshold: 5)

light.run { 1 / 0 }
light.color
```

The `Stoplight()` method accepts the following settings:

* `:cool_off_time` - The time to wait before resetting the circuit breaker.
* `:data_store` - The data store to use for storing state.
* `:error_notifier` - A proc to handle error notifications.
* `:notifiers` - A list of notifiers to use.
* `:threshold` - The failure threshold to trip the circuit breaker.
* `:window_size` - The size of the rolling window for failure tracking.
* `:tracked_errors` - A list of errors to track.
* `:skipped_errors` - A list of errors to skip.

This approach is useful for quickly setting up a stoplight without chaining multiple configuration methods.