### PR TITLE
Add support for Redis connection pooling

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,1 @@
+ruby_version: 3.2

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
+  gem "connection_pool"
   gem "concurrent-ruby-ext"
   gem "benchmark-ips", "~> 2.14"
   gem "database_cleaner-redis", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,7 @@ PLATFORMS
 DEPENDENCIES
   benchmark-ips (~> 2.14)
   concurrent-ruby-ext
+  connection_pool
   database_cleaner-redis (~> 2.0)
   debug
   rake (~> 13.2)

--- a/README.md
+++ b/README.md
@@ -386,6 +386,30 @@ Stoplight.configure do |config|
 end
 ```
 
+##### Connection Pooling
+
+For high traffic applications, it's recommended to use connection pooling with Redis. Stoplight supports the
+[connection_pool] gem:
+
+```ruby
+require 'redis'
+require 'connection_pool'
+
+# Create a connection pool
+pool = ConnectionPool.new(size: 5, timeout: 3) do
+  Redis.new
+end
+
+# Use the pool with Stoplight
+data_store = Stoplight::DataStore::Redis.new(pool)
+
+Stoplight.configure do |config|
+  config.data_store = data_store
+end
+```
+
+Using a connection pool helps manage Redis connections efficiently in multithreaded environments and prevents connection exhaustion.
+
 ### Notifiers
 
 Stoplight sends notifications to standard error by default.
@@ -617,3 +641,4 @@ Stoplight is licensed under [the MIT License][].
 [CircuitBreaker]: http://martinfowler.com/bliki/CircuitBreaker.html
 [the MIT license]: LICENSE.md
 [stoplight-sentry]: https://github.com/bolshakov/stoplight-sentry
+[connection_pool]: https://github.com/mperham/connection_pool

--- a/spec/stoplight/data_store/redis_spec.rb
+++ b/spec/stoplight/data_store/redis_spec.rb
@@ -1,36 +1,47 @@
 # frozen_string_literal: true
 
+require "connection_pool"
 require "spec_helper"
 
 RSpec.describe Stoplight::DataStore::Redis, :redis do
-  let(:data_store) { described_class.new(redis) }
   let(:config) { Stoplight.config_provider.provide(name) }
   let(:name) { ("a".."z").to_a.shuffle.join }
   let(:failure) { Stoplight::Failure.new("class", "message", Time.new - 60) }
   let(:other) { Stoplight::Failure.new("class", "message 2", Time.new) }
 
-  it_behaves_like "Stoplight::DataStore::Base"
-  it_behaves_like "Stoplight::DataStore::Base#names"
-  it_behaves_like "Stoplight::DataStore::Base#get_all"
-  it_behaves_like "Stoplight::DataStore::Base#record_failure"
-  it_behaves_like "Stoplight::DataStore::Base#clear_failures"
-  it_behaves_like "Stoplight::DataStore::Base#get_state"
-  it_behaves_like "Stoplight::DataStore::Base#set_state"
-  it_behaves_like "Stoplight::DataStore::Base#clear_state"
+  shared_examples Stoplight::DataStore::Redis do
+    it_behaves_like "Stoplight::DataStore::Base"
+    it_behaves_like "Stoplight::DataStore::Base#names"
+    it_behaves_like "Stoplight::DataStore::Base#get_all"
+    it_behaves_like "Stoplight::DataStore::Base#record_failure"
+    it_behaves_like "Stoplight::DataStore::Base#clear_failures"
+    it_behaves_like "Stoplight::DataStore::Base#get_state"
+    it_behaves_like "Stoplight::DataStore::Base#set_state"
+    it_behaves_like "Stoplight::DataStore::Base#clear_state"
 
-  it_behaves_like "Stoplight::DataStore::Base#get_failures" do
-    context "when JSON is invalid" do
-      let(:config) { Stoplight.config_provider.provide(name, error_notifier: ->(_error) {}) }
+    it_behaves_like "Stoplight::DataStore::Base#get_failures" do
+      context "when JSON is invalid" do
+        let(:config) { Stoplight.config_provider.provide(name, error_notifier: ->(_error) {}) }
 
-      it "handles it without an error" do
-        expect(failure).to receive(:to_json).and_return("invalid JSON")
+        it "handles it without an error" do
+          expect(failure).to receive(:to_json).and_return("invalid JSON")
 
-        expect { data_store.record_failure(config, failure) }
-          .to change { data_store.get_failures(config) }
-          .to([have_attributes(error_class: "JSON::ParserError")])
+          expect { data_store.record_failure(config, failure) }
+            .to change { data_store.get_failures(config) }
+            .to([have_attributes(error_class: "JSON::ParserError")])
+        end
       end
     end
+
+    it_behaves_like "Stoplight::DataStore::Base#with_deduplicated_notification"
   end
 
-  it_behaves_like "Stoplight::DataStore::Base#with_deduplicated_notification"
+  it_behaves_like Stoplight::DataStore::Redis do
+    let(:data_store) { described_class.new(redis) }
+  end
+
+  it_behaves_like Stoplight::DataStore::Redis do
+    let(:data_store) { described_class.new(pool) }
+    let(:pool) { ConnectionPool.new(size: 1, timeout: 5, &redis_client_factory) }
+  end
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -7,7 +7,8 @@ cleaning_strategy = DatabaseCleaner::Redis::Deletion.new(only: ["#{Stoplight::Da
 DatabaseCleaner.strategy = cleaning_strategy
 
 RSpec.shared_context :redis, :redis do
-  let(:redis) { Redis.new(url: ENV.fetch("STOPLIGHT_REDIS_URL", "redis://127.0.0.1:6379/0")) }
+  let(:redis) { redis_client_factory.call }
+  let(:redis_client_factory) { -> { Redis.new(url: ENV.fetch("STOPLIGHT_REDIS_URL", "redis://127.0.0.1:6379/0")) } }
 
   before do
     DatabaseCleaner[:redis].db = redis


### PR DESCRIPTION
Adds support for using connection pools with the Redis data store. This allows Stoplight to efficiently manage Redis connections in multi-threaded environments, preventing connection exhaustion in high-traffic applications.

* Added connection_pool gem to development dependencies
* Modified the Redis data store to accept either a direct Redis client or a ConnectionPool instance
* Used `.then` method to safely access the Redis client from either source
* Updated specs to test both direct Redis client and ConnectionPool scenarios
* Added documentation for connection pooling usage

The `Stoplight::DataStore::Redis` class now accepts either a `Redis` client or a `ConnectionPool` of Redis clients in its constructor. It then uses the `.then` method to handle both cases uniformly:

```ruby
@redis.hset(states_key, config.name, state)

@redis.then { |client| client.hset(states_key, config.name, state) }
```

This change is backward compatible and should not affect existing code. Users who want to take advantage of connection pooling will need to add the connection_pool gem to their dependencies and update their configuration as shown in the documentation.

#285 