### PR TITLE
Refactor stoplight failure retention to support reusable circuit breakers

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ after the first call. With a sliding window of 2 seconds, only the errors that o
 (when the second error occurs), the window has shifted, and the stoplight switches to green state 
 causing the error to raise again. This provides a way to focus on the most recent errors.
 
-The default window size is infinity, so all failures counts.
+The default window size is 1 month, so all failures within this period counts.
 
 ### Custom Cool Off Time
 

--- a/lib/stoplight/data_store/base.rb
+++ b/lib/stoplight/data_store/base.rb
@@ -69,6 +69,19 @@ module Stoplight
       def with_deduplicated_notification(_config, _from_color, _to_color, &_block)
         raise NotImplementedError
       end
+
+      class << self
+        # Failures retention period in seconds.
+        #
+        # This is the time period during which failures are retained in the data store. You cannot have window_size
+        # greater than this value.
+        #
+        # @return [Numeric]
+        # @api private
+        def failures_retention_period = Stoplight::Default::WINDOW_SIZE
+      end
+
+      private def failures_retention_period = self.class.failures_retention_period
     end
   end
 end

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -20,7 +20,7 @@ module Stoplight
 
     THRESHOLD = 3
 
-    WINDOW_SIZE = 30 * 24 * 60 * 60 # 14 days
+    WINDOW_SIZE = 30 * 24 * 60 * 60 # 30 days
 
     TRACKED_ERRORS = [StandardError].freeze
     SKIPPED_ERRORS = [

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -20,7 +20,7 @@ module Stoplight
 
     THRESHOLD = 3
 
-    WINDOW_SIZE = Float::INFINITY
+    WINDOW_SIZE = 30 * 24 * 60 * 60 # 14 days
 
     TRACKED_ERRORS = [StandardError].freeze
     SKIPPED_ERRORS = [

--- a/lib/stoplight/light/config.rb
+++ b/lib/stoplight/light/config.rb
@@ -52,6 +52,10 @@ module Stoplight
       # @param skipped_errors [Array<Exception>]
       def initialize(name: nil, cool_off_time: nil, data_store: nil, error_notifier: nil, notifiers: nil, threshold: nil, window_size: nil,
         tracked_errors: nil, skipped_errors: nil)
+        if window_size && window_size > DataStore::Base.failures_retention_period
+          raise Error::ConfigurationError, "window_size must be less than or equal to #{DataStore::Base.failures_retention_period}"
+        end
+
         @name = name
         @cool_off_time = cool_off_time
         @data_store = data_store

--- a/spec/stoplight/light/config_spec.rb
+++ b/spec/stoplight/light/config_spec.rb
@@ -97,6 +97,14 @@ RSpec.describe Stoplight::Light::Config do
     it "returns the same value" do
       is_expected.to eq(window_size)
     end
+
+    context "when window_size is greater than failures_retention_period" do
+      let(:window_size) { Stoplight::DataStore::Base.failures_retention_period + 1 }
+
+      it "raises a ConfigurationError" do
+        expect { config }.to raise_error(Stoplight::Error::ConfigurationError, /window_size must be less than or equal to/)
+      end
+    end
   end
 
   describe "#tracked_errors" do

--- a/spec/support/data_store/base/record_failures.rb
+++ b/spec/support/data_store/base/record_failures.rb
@@ -26,7 +26,7 @@ RSpec.shared_examples "Stoplight::DataStore::Base#record_failure" do
     end
   end
 
-  shared_examples "with_threshold" do
+  context "with threshold" do
     context "when the number of errors is bigger then threshold" do
       let(:config) { super().with(threshold: 1) }
 
@@ -34,17 +34,15 @@ RSpec.shared_examples "Stoplight::DataStore::Base#record_failure" do
         data_store.record_failure(config, failure)
       end
 
-      it "limits the number of stored failures" do
+      it "returns all stored failures" do
         expect do
           data_store.record_failure(config, other)
         end.to change { data_store.get_failures(config) }
           .from([failure])
-          .to([other])
+          .to([other, failure])
       end
     end
   end
-
-  it_behaves_like "with_threshold"
 
   context "with window_size" do
     let(:window_size) { 3600 }
@@ -62,7 +60,5 @@ RSpec.shared_examples "Stoplight::DataStore::Base#record_failure" do
         expect(data_store.get_failures(config)).to eq([other, failure])
       end
     end
-
-    it_behaves_like "with_threshold"
   end
 end


### PR DESCRIPTION
This PR separates the concept of failure retention from threshold counting to better support reusable circuit breaker configurations that share the same name but have different thresholds and window sizes.

Previously, our cleanup policy kept at most `threshold` failures within the `window_size` period. This approach created conflicts when multiple circuit breakers shared the same name but had different configurations. For example:

```ruby
light = Stoplight("api")
users_api = light.with(threshold: 10, window_size: 100)
payment_api = light.with(threshold: 20, window_size: 300)
```

When a failure occurred in the `users_api`, its cleanup policy would limit stored failures based on its own threshold (10), potentially removing failures that would still be relevant for the `payment_api` configuration with its higher threshold (20).

* Introduced a global `failures_retention_period` concept (set to 1 month by default)
* Changed failure cleanup to preserve all failures within this retention period
* Adjusted failure counting to only consider failures within each light's configured `window_size`
* Added validation to ensure `window_size` cannot exceed `failures_retention_period`

This approach ensures that all circuit breakers sharing the same name have access to the complete failure history they need, while still respecting their individual window size configurations when determining circuit state.