### PR TITLE
Improve Stoplight initialization performance by optimizing config merging

### DIFF
--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -12,6 +12,9 @@ module Stoplight # rubocop:disable Style/Documentation
   private_constant :CONFIG_MUTEX
 
   class << self
+    ALREADY_CONFIGURED_ERROR = "Stoplight must be configured only once"
+    private_constant :ALREADY_CONFIGURED_ERROR
+
     # Sets the default error notifier.
     #
     # @param value [#call]
@@ -20,6 +23,8 @@ module Stoplight # rubocop:disable Style/Documentation
     def default_error_notifier=(value)
       warn "[DEPRECATED] `Stoplight.default_error_notifier=` is deprecated. " \
         "Please use `Stoplight.configure { |config| config.error_notifier= }` instead."
+      raise Error::ConfigurationError, ALREADY_CONFIGURED_ERROR if @config_provider
+
       @default_error_notifier = value
     end
 
@@ -40,6 +45,8 @@ module Stoplight # rubocop:disable Style/Documentation
     def default_notifiers=(value)
       warn "[DEPRECATED] `Stoplight.default_notifiers=` is deprecated. " \
         "Please use `Stoplight.configure { |config| config.notifiers= }` instead."
+      raise Error::ConfigurationError, ALREADY_CONFIGURED_ERROR if @config_provider
+
       @default_notifiers = value
     end
 
@@ -60,6 +67,8 @@ module Stoplight # rubocop:disable Style/Documentation
     def default_data_store=(value)
       warn "[DEPRECATED] `Stoplight.default_data_store=` is deprecated. " \
         "Please use `Stoplight.configure { |config| config.data_store= }` instead."
+      raise Error::ConfigurationError, ALREADY_CONFIGURED_ERROR if @config_provider
+
       @default_data_store = value
     end
 
@@ -91,7 +100,7 @@ module Stoplight # rubocop:disable Style/Documentation
     #   end
     #
     def configure
-      raise Error::ConfigurationError, "Stoplight must be configured only once" if @config_provider
+      raise Error::ConfigurationError, ALREADY_CONFIGURED_ERROR if @config_provider
 
       user_defaults = Config::UserDefaultConfig.new
       yield(user_defaults) if block_given?

--- a/lib/stoplight/config/config_provider.rb
+++ b/lib/stoplight/config/config_provider.rb
@@ -13,17 +13,9 @@ module Stoplight
     #
     # @api private
     class ConfigProvider
-      # @!attribute [r] user_default_config
-      #   @return [Stoplight::Config::UserDefaultConfig]
-      private attr_reader :user_default_config
-
-      # @!attribute [r] legacy_config
-      #   @return [Stoplight::Config::LegacyConfig]
-      private attr_reader :legacy_config
-
-      # @!attribute [r] library_default_config
-      #   @return [Stoplight::Config::LibraryDefaultConfig]
-      private attr_reader :library_default_config
+      # @!attribute [r] default_settings
+      #   @return [Hash]
+      private attr_reader :default_settings
 
       CONFIGURATION_ERROR = <<~ERROR
         Configuration conflict detected!
@@ -46,9 +38,10 @@ module Stoplight
           raise Error::ConfigurationError, CONFIGURATION_ERROR
         end
 
-        @user_default_config = user_default_config
-        @legacy_config = legacy_config
-        @library_default_config = library_default_config
+        @default_settings = library_default_config.to_h.merge(
+          user_default_config.to_h,
+          legacy_config.to_h
+        )
       end
 
       # Returns a configuration for a specific light with the given name and settings overrides.
@@ -63,26 +56,9 @@ module Stoplight
           The +name+ setting cannot be overridden in the configuration.
         ERROR
 
-        settings = library_default_settings.merge(
-          user_default_settings,
-          legacy_settings,
-          settings_overrides,
-          {name: light_name}
-        )
+        settings = default_settings.merge(settings_overrides, {name: light_name})
 
         Light::Config.new(**settings)
-      end
-
-      private def user_default_settings
-        user_default_config.to_h
-      end
-
-      private def library_default_settings
-        library_default_config.to_h
-      end
-
-      private def legacy_settings
-        legacy_config.to_h
       end
     end
   end

--- a/spec/stoplight_spec.rb
+++ b/spec/stoplight_spec.rb
@@ -22,8 +22,15 @@ RSpec.describe Stoplight do
   end
 
   describe ".default_error_notifier" do
-    before { Stoplight.instance_variable_set(:@default_error_notifier, nil) }
-    after { Stoplight.instance_variable_set(:@default_error_notifier, nil) }
+    around do |example|
+      Stoplight.reset_config!
+      Stoplight.instance_variable_set(:@default_error_notifier, nil)
+
+      example.run
+
+      Stoplight.reset_config!
+      Stoplight.instance_variable_set(:@default_error_notifier, nil)
+    end
 
     it "returns the default error notifier when not set" do
       expect(Stoplight.default_error_notifier).to eq(Stoplight::Default::ERROR_NOTIFIER)
@@ -37,8 +44,15 @@ RSpec.describe Stoplight do
   end
 
   describe ".default_data_store" do
-    before { Stoplight.instance_variable_set(:@default_data_store, nil) }
-    after { Stoplight.instance_variable_set(:@default_data_store, nil) }
+    around do |example|
+      Stoplight.reset_config!
+      Stoplight.instance_variable_set(:@default_data_store, nil)
+
+      example.run
+
+      Stoplight.reset_config!
+      Stoplight.instance_variable_set(:@default_data_store, nil)
+    end
 
     it "returns the default data store when not set" do
       expect(Stoplight.default_data_store).to eq(Stoplight::Default::DATA_STORE)
@@ -52,8 +66,15 @@ RSpec.describe Stoplight do
   end
 
   describe ".default_notifiers" do
-    before { Stoplight.instance_variable_set(:@default_notifiers, nil) }
-    after { Stoplight.instance_variable_set(:@default_notifiers, nil) }
+    around do |example|
+      Stoplight.reset_config!
+      Stoplight.instance_variable_set(:@default_notifiers, nil)
+
+      example.run
+
+      Stoplight.reset_config!
+      Stoplight.instance_variable_set(:@default_notifiers, nil)
+    end
 
     it "returns the default notifiers when not set" do
       expect(Stoplight.default_notifiers).to eq(Stoplight::Default::NOTIFIERS)


### PR DESCRIPTION
This change improves Stoplight initialization performance by approximately 12% by optimizing how configuration settings are merged during object creation.

The performance gain is achived by computing default settings once during `ConfigProvider` initialization instead of merging them on every light creation

Before:
```
Create Before Refactoring: 270,049.2 i/s (3.70 μs/i)
```
After:
```
Create After Refactoring: 301,795.9 i/s (3.31 μs/i)
```

Performance improvement: 12% faster initialization

#285