### PR TITLE
Fix: Gem Spec configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     stoplight (4.1.1)
+      zeitwerk
 
 GEM
   remote: https://rubygems.org/
@@ -163,7 +164,6 @@ DEPENDENCIES
   standard
   stoplight!
   timecop (~> 0.9)
-  zeitwerk
 
 BUNDLED WITH
    2.3.4

--- a/stoplight.gemspec
+++ b/stoplight.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
     README.md
   ] + Dir.glob(File.join("lib", "**", "*.rb"))
 
-  gem.required_ruby_version = ">= 3.0.6"
+  gem.required_ruby_version = ">= 3.2"
   gem.add_runtime_dependency "zeitwerk"
 end

--- a/stoplight.gemspec
+++ b/stoplight.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |gem|
   ] + Dir.glob(File.join("lib", "**", "*.rb"))
 
   gem.required_ruby_version = ">= 3.0.6"
-  gem.add_development_dependency "zeitwerk"
+  gem.add_runtime_dependency "zeitwerk"
 end


### PR DESCRIPTION
This PR aims to fix Gem Spec configuration:
1. We now require `zeitwerk` as a runtime dependency.
2. The minimum supported Ruby version is now 3.2.