### PR TITLE
Limit Stoplight error tracking to StandardError exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ light = Stoplight('payment-service')
 ## Error Handling
 
 By default, Stoplight tracks all `StandardError` exceptions.
+Note: System-level exceptions (e.g., `NoMemoryError`, `SignalException`) are not tracked, as they are not subclasses of `StandardError`.
 
 ### Custom Error Configuration
 

--- a/README.md
+++ b/README.md
@@ -193,11 +193,7 @@ light = Stoplight('payment-service')
 
 ## Error Handling
 
-By default, Stoplight tracks all `StandardError` exceptions, except for:
-
-```
-NoMemoryError, ScriptError, SecurityError, SignalException, SystemExit, SystemStackError
-```
+By default, Stoplight tracks all `StandardError` exceptions.
 
 ### Custom Error Configuration
 
@@ -223,8 +219,7 @@ Stoplight uses an in-memory data store out of the box:
 
 ```ruby
 require 'stoplight'
-# => true
-Stoplight.default_data_store
+Stoplight::Default::DATA_STORE
 # => #<Stoplight::DataStore::Memory:...>
 ```
 

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -23,14 +23,7 @@ module Stoplight
     WINDOW_SIZE = nil
 
     TRACKED_ERRORS = [StandardError].freeze
-    SKIPPED_ERRORS = [
-      NoMemoryError,
-      ScriptError,
-      SecurityError,
-      SignalException,
-      SystemExit,
-      SystemStackError
-    ].freeze
+    SKIPPED_ERRORS = [].freeze
 
     TRAFFIC_CONTROL = TrafficControl::ConsecutiveFailures.new
     TRAFFIC_RECOVERY = TrafficRecovery::SingleSuccess.new

--- a/lib/stoplight/light/config.rb
+++ b/lib/stoplight/light/config.rb
@@ -70,7 +70,7 @@ module Stoplight
         @threshold = threshold
         @window_size = window_size
         @tracked_errors = Array(tracked_errors)
-        @skipped_errors = Set[*skipped_errors, *Stoplight::Default::SKIPPED_ERRORS].to_a
+        @skipped_errors = Array(skipped_errors)
         @traffic_control = traffic_control
         @traffic_recovery = traffic_recovery
       end

--- a/lib/stoplight/light/runnable/green_run_strategy.rb
+++ b/lib/stoplight/light/runnable/green_run_strategy.rb
@@ -19,7 +19,7 @@ module Stoplight
         def execute(fallback, &code)
           # TODO: Consider implementing sampling rate to limit the memory footprint
           code.call.tap { record_success }
-        rescue Exception => error # rubocop: disable Lint/RescueException
+        rescue => error
           if config.track_error?(error)
             record_error(error)
 

--- a/lib/stoplight/light/runnable/yellow_run_strategy.rb
+++ b/lib/stoplight/light/runnable/yellow_run_strategy.rb
@@ -20,7 +20,7 @@ module Stoplight
         def execute(fallback, &code)
           # TODO: We need to employ a probabilistic approach here to avoid "thundering herd" problem
           code.call.tap { record_recovery_probe_success }
-        rescue Exception => error # rubocop: disable Lint/RescueException
+        rescue => error
           if config.track_error?(error)
             record_recovery_probe_failure(error)
 


### PR DESCRIPTION
Stoplight is designed to handle transient failures and provide graceful degradation. System-level exceptions like `NoMemoryError`, `SystemExit`, and `SignalException` typically indicate unrecoverable conditions where the application should terminate rather than attempt recovery through fallback logic.

This PR changes Stoplight's behavior to capture only `StandardError` exceptions, simplifying error handling logic and aligning with Ruby best practices. While this appears to be a breaking change, there are no practical applications where Stoplight should handle such system-level errors (most of which were previously included in the default skip list anyway).

