### PR TITLE
Introduce Metadata#color

### DIFF
--- a/lib/stoplight/data_store/fail_safe.rb
+++ b/lib/stoplight/data_store/fail_safe.rb
@@ -45,7 +45,7 @@ module Stoplight
       end
 
       def get_metadata(config)
-        with_fallback(Metadata.empty, config) do
+        with_fallback(Metadata.new, config) do
           data_store.get_metadata(config)
         end
       end

--- a/lib/stoplight/data_store/memory.rb
+++ b/lib/stoplight/data_store/memory.rb
@@ -16,7 +16,7 @@ module Stoplight
         @recovery_probe_failures = Hash.new { |h, k| h[k] = [] }
         @recovery_probe_successes = Hash.new { |h, k| h[k] = [] }
 
-        @metadata = Hash.new { |h, k| h[k] = Metadata.empty }
+        @metadata = Hash.new { |h, k| h[k] = Metadata.new }
         super # MonitorMixin
       end
 

--- a/lib/stoplight/light/runnable.rb
+++ b/lib/stoplight/light/runnable.rb
@@ -19,20 +19,10 @@ module Stoplight
       #
       # @return [String] returns current light color
       def color
-        metadata = config.data_store.get_metadata(config)
-
-        current_time = Time.now
-        if metadata.locked_state == State::LOCKED_GREEN
-          Color::GREEN
-        elsif metadata.locked_state == State::LOCKED_RED
-          Color::RED
-        elsif (metadata.recovery_scheduled_after && metadata.recovery_scheduled_after < current_time) || metadata.recovery_started_at
-          Color::YELLOW
-        elsif metadata.breached_at
-          Color::RED
-        else
-          Color::GREEN
-        end
+        config
+          .data_store
+          .get_metadata(config)
+          .color
       end
 
       # Runs the given block of code with this circuit breaker

--- a/lib/stoplight/metadata.rb
+++ b/lib/stoplight/metadata.rb
@@ -18,31 +18,11 @@ module Stoplight
     :recovery_started_at,
     :recovered_at
   ) do
-    class << self
-      def empty
-        new(
-          successes: nil,
-          failures: nil,
-          recovery_probe_successes: nil,
-          recovery_probe_failures: nil,
-          last_failure_at: nil,
-          last_success_at: nil,
-          consecutive_failures: 0,
-          consecutive_successes: 0,
-          last_failure: nil,
-          breached_at: nil,
-          locked_state: nil,
-          recovery_started_at: nil,
-          recovery_scheduled_after: nil,
-          recovered_at: nil
-        )
-      end
-    end
     def initialize(
-      successes:,
-      failures:,
-      recovery_probe_successes:,
-      recovery_probe_failures:,
+      successes: nil,
+      failures: nil,
+      recovery_probe_successes: nil,
+      recovery_probe_failures: nil,
       last_failure_at: nil,
       last_success_at: nil,
       consecutive_failures: 0,
@@ -70,6 +50,22 @@ module Stoplight
         recovery_started_at: (Time.at(Integer(recovery_started_at)) if recovery_started_at),
         recovered_at: (Time.at(Integer(recovered_at)) if recovered_at),
       )
+    end
+
+    # @param at [Time] (Time.now) the moment of time when the color is determined
+    # @return [String] one of +Color::GREEN+, +Color::RED+, or +Color::YELLOW+
+    def color(at: Time.now)
+      if locked_state == State::LOCKED_GREEN
+        Color::GREEN
+      elsif locked_state == State::LOCKED_RED
+        Color::RED
+      elsif (recovery_scheduled_after && recovery_scheduled_after < at) || recovery_started_at
+        Color::YELLOW
+      elsif breached_at
+        Color::RED
+      else
+        Color::GREEN
+      end
     end
   end
 end

--- a/spec/stoplight/data_store/fail_safe_spec.rb
+++ b/spec/stoplight/data_store/fail_safe_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
 
     context "when data_store returns all data" do
       let(:metadata) do
-        Stoplight::Metadata.empty.with(failures: 4)
+        Stoplight::Metadata.new.with(failures: 4)
       end
 
       it "returns all data from data_store" do
@@ -54,7 +54,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
         expect(error_notifier).to receive(:call).with(error)
         expect(data_store).to receive(:get_metadata).with(config) { raise error }
 
-        is_expected.to eq(Stoplight::Metadata.empty)
+        is_expected.to eq(Stoplight::Metadata.new)
       end
     end
   end

--- a/spec/stoplight/metadata_spec.rb
+++ b/spec/stoplight/metadata_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Stoplight::Metadata do
+  describe "#color" do
+    subject(:color) { metadata.color(at: current_time) }
+
+    let(:metadata) do
+      Stoplight::Metadata.new(
+        locked_state:,
+        recovery_scheduled_after:,
+        recovery_started_at:,
+        breached_at:
+      )
+    end
+    let(:current_time) { Time.now }
+    let(:recovery_scheduled_after) { nil }
+    let(:locked_state) { nil }
+    let(:recovery_started_at) { nil }
+    let(:breached_at) { nil }
+
+    it { is_expected.to be(Stoplight::Color::GREEN) }
+
+    context "when locked green" do
+      let(:locked_state) { Stoplight::State::LOCKED_GREEN }
+
+      it { is_expected.to be(Stoplight::Color::GREEN) }
+    end
+
+    context "when locked red" do
+      let(:locked_state) { Stoplight::State::LOCKED_RED }
+
+      it { is_expected.to be(Stoplight::Color::RED) }
+    end
+
+    context "when recovery scheduled before current time" do
+      let(:recovery_scheduled_after) { current_time - 1 }
+
+      it { is_expected.to be(Stoplight::Color::YELLOW) }
+    end
+
+    context "when recovery has started" do
+      let(:recovery_started_at) { Time.now - 3 }
+
+      it { is_expected.to be(Stoplight::Color::YELLOW) }
+    end
+
+    context "when threshold breached" do
+      let(:breached_at) { Time.now - 3 }
+
+      it { is_expected.to be(Stoplight::Color::RED) }
+    end
+  end
+end


### PR DESCRIPTION
`Light#color` method now solely relies on metadata. I moved it to the `Medatada#color` class so that now it uses only local metadata's properties.