### PR TITLE
Centralize Configuration Transformations

### DIFF
--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -26,7 +26,7 @@ module Stoplight # rubocop:disable Style/Documentation
     # It raises an error if called more than once.
     #
     # @yield [config] Provides a configuration object to the block.
-    # @yieldparam config [Stoplight::Config::ProgrammaticConfig] The configuration object.
+    # @yieldparam config [Stoplight::Config::UserDefaultConfig] The configuration object.
     # @raise [Stoplight::Error::ConfigurationError] If the library is already configured.
     # @return [void]
     #
@@ -118,6 +118,6 @@ end
 #   light = Stoplight("Payment API", skipped_errors: [ActiveRecord::RecordNotFound])
 #
 def Stoplight(name, **settings) # rubocop:disable Naming/MethodName
-  config = Stoplight.config_provider.provide(name, **settings)
+  config = Stoplight.config_provider.provide(name, settings)
   Stoplight::Light.new(config)
 end

--- a/lib/stoplight/config/config_provider.rb
+++ b/lib/stoplight/config/config_provider.rb
@@ -10,6 +10,8 @@ module Stoplight
     # 4. **Library-Level Default Settings**: Default settings defined in the +Stoplight::Config::UserDefaultConfig+ module.
     #
     # The settings are merged in this order, with higher-precedence settings overriding lower-precedence ones.
+    # After merging settings, the configuration transformations are applied such as wrapping data stores and notifiers
+    # with fail-safe mechanism, type conversion, etc. Each transformation must be idempotent.
     #
     # @api private
     class ConfigProvider
@@ -38,13 +40,28 @@ module Stoplight
       #   @see +Stoplight()+
       # @return [Stoplight::Light::Config] The configuration for the specified light.
       # @raise [Error::ConfigurationError]
-      def provide(light_name, **settings_overrides)
+      def provide(light_name, settings_overrides = {})
         raise Error::ConfigurationError, <<~ERROR if settings_overrides.has_key?(:name)
           The +name+ setting cannot be overridden in the configuration.
         ERROR
 
         settings = default_settings.merge(settings_overrides, {name: light_name})
-        Light::Config.new(**settings)
+        Light::Config.new(**transform_settings(settings))
+      end
+
+      # Creates a configuration from a given +Stoplight::Light::Config+ object extending it
+      # with additional settings overrides.
+      #
+      # @param config [Stoplight::Light::Config] The configuration object to extend.
+      # @param settings_overrides [Hash] The settings to override.
+      # @return [Stoplight::Light::Config] The new extended configuration object.
+      def from_prototype(config, settings_overrides)
+        config.to_h.then do |settings|
+          current_name = settings.delete(:name)
+          name = settings_overrides.delete(:name) || current_name
+
+          provide(name, **settings.merge(settings_overrides))
+        end
       end
 
       def inspect
@@ -56,6 +73,38 @@ module Stoplight
           "skipped_errors=#{default_settings[:skipped_errors].join(",")}, " \
           "data_store=#{default_settings[:data_store].class.name}" \
         ">"
+      end
+
+      private
+
+      def transform_settings(settings)
+        settings.merge(
+          data_store: build_data_store(settings.fetch(:data_store)),
+          notifiers: build_notifiers(settings.fetch(:notifiers, [])),
+          tracked_errors: build_tracked_errors(settings.fetch(:tracked_errors)),
+          skipped_errors: build_skipped_errors(settings.fetch(:skipped_errors)),
+          cool_off_time: build_cool_off_time(settings.fetch(:cool_off_time))
+        )
+      end
+
+      def build_data_store(data_store)
+        DataStore::FailSafe.wrap(data_store)
+      end
+
+      def build_notifiers(notifiers)
+        notifiers.map { |notifier| Notifier::FailSafe.wrap(notifier) }
+      end
+
+      def build_tracked_errors(tracked_error)
+        Array(tracked_error)
+      end
+
+      def build_skipped_errors(skipped_errors)
+        Array(skipped_errors)
+      end
+
+      def build_cool_off_time(cool_off_time)
+        cool_off_time.to_i
       end
     end
   end

--- a/lib/stoplight/config/config_provider.rb
+++ b/lib/stoplight/config/config_provider.rb
@@ -80,7 +80,7 @@ module Stoplight
       def transform_settings(settings)
         settings.merge(
           data_store: build_data_store(settings.fetch(:data_store)),
-          notifiers: build_notifiers(settings.fetch(:notifiers, [])),
+          notifiers: build_notifiers(settings.fetch(:notifiers)),
           tracked_errors: build_tracked_errors(settings.fetch(:tracked_errors)),
           skipped_errors: build_skipped_errors(settings.fetch(:skipped_errors)),
           cool_off_time: build_cool_off_time(settings.fetch(:cool_off_time))

--- a/lib/stoplight/config/user_default_config.rb
+++ b/lib/stoplight/config/user_default_config.rb
@@ -20,9 +20,9 @@ module Stoplight
       #   @return [Proc, nil] The default error notifier (callable object).
       attr_writer :error_notifier
 
-      # @!attribute [r] notifiers
+      # @!attribute [rw] notifiers
       #   @return [Array<Stoplight::Notifier::Base>] The default list of notifiers.
-      attr_reader :notifiers
+      attr_accessor :notifiers
 
       # @!attribute [w] threshold
       #   @return [Integer, nil] The default failure threshold to trip the circuit breaker.
@@ -40,22 +40,14 @@ module Stoplight
       #   @return [Array<Class>, nil] The default list of errors to skip.
       attr_writer :skipped_errors
 
+      # @!attribute [w] data_store
+      #   @return [Stoplight::DataStore::Base] The default data store instance.
+      attr_writer :data_store
+
       def initialize
         # This allows users appending notifiers to the default list,
         # while still allowing them to override the default list.
         @notifiers = Default::NOTIFIERS
-      end
-
-      # @param value [Stoplight::DataStore::Base]
-      # @return [Stoplight::DataStore::Base] The default data store instance.
-      def data_store=(value)
-        @data_store = DataStore::FailSafe.wrap(value)
-      end
-
-      # @param value [Array<Stoplight::Notifier::Base>]
-      # @return [Array<Stoplight::Notifier::FailSafe>]
-      def notifiers=(value)
-        @notifiers = value.map { |notifier| Notifier::FailSafe.wrap(notifier) }
       end
 
       # Converts the user-defined configuration to a hash.
@@ -67,7 +59,7 @@ module Stoplight
           cool_off_time: @cool_off_time,
           data_store: @data_store,
           error_notifier: @error_notifier,
-          notifiers: (@notifiers == Default::NOTIFIERS) ? nil : @notifiers, # This is to avoid conflicts with legacy config
+          notifiers: @notifiers,
           threshold: @threshold,
           window_size: @window_size,
           tracked_errors: @tracked_errors,

--- a/lib/stoplight/data_store/fail_safe.rb
+++ b/lib/stoplight/data_store/fail_safe.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "securerandom"
+
 module Stoplight
   module DataStore
     # A wrapper around a data store that provides fail-safe mechanisms using a

--- a/lib/stoplight/default.rb
+++ b/lib/stoplight/default.rb
@@ -14,9 +14,7 @@ module Stoplight
       words.join(" ")
     end
 
-    NOTIFIERS = [
-      Notifier::FailSafe.wrap(Notifier::IO.new($stderr))
-    ].freeze
+    NOTIFIERS = [Notifier::IO.new($stderr)].freeze
 
     THRESHOLD = 3
 

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -150,7 +150,9 @@ module Stoplight
     #   payment_light.run(->(error) { nil }) { call_payment_api }
     # @see +Stoplight()+
     def with(**settings)
-      reconfigure(config.with(**settings))
+      reconfigure(
+        Stoplight.config_provider.from_prototype(config, settings)
+      )
     end
 
     private

--- a/lib/stoplight/light/config.rb
+++ b/lib/stoplight/light/config.rb
@@ -63,14 +63,14 @@ module Stoplight
       def initialize(name:, cool_off_time:, data_store:, error_notifier:, notifiers:, threshold:, window_size:,
         tracked_errors:, skipped_errors:, traffic_control:, traffic_recovery:)
         @name = name
-        @cool_off_time = cool_off_time.to_i
-        @data_store = DataStore::FailSafe.wrap(data_store)
+        @cool_off_time = cool_off_time
+        @data_store = data_store
         @error_notifier = error_notifier
-        @notifiers = notifiers.map { |notifier| Notifier::FailSafe.wrap(notifier) }
+        @notifiers = notifiers
         @threshold = threshold
         @window_size = window_size
-        @tracked_errors = Array(tracked_errors)
-        @skipped_errors = Array(skipped_errors)
+        @tracked_errors = tracked_errors
+        @skipped_errors = skipped_errors
         @traffic_control = traffic_control
         @traffic_recovery = traffic_recovery
       end

--- a/lib/stoplight/light/config.rb
+++ b/lib/stoplight/light/config.rb
@@ -3,115 +3,62 @@
 module Stoplight
   class Light
     # A +Stoplight::Light+ configuration object.
+    #
+    # # @!attribute [r] name
+    #   @return [String]
+    #
+    # @!attribute [r] cool_off_time
+    #   @return [Numeric]
+    #
+    # @!attribute [r] data_store
+    #   @return [Stoplight::DataStore::Base]
+    #
+    # @!attribute [r] error_notifier
+    #   @return [StandardError => void]
+    #
+    # @!attribute [r] notifiers
+    #   @return [Array<Stoplight::Notifier::Base>]
+    #
+    # @!attribute [r] threshold
+    #   @return [Numeric]
+    #
+    # @!attribute [r] window_size
+    #   @return [Numeric]
+    #
+    # @!attribute [r] tracked_errors
+    #   @return [Array<StandardError>]
+    #
+    # @!attribute [r] skipped_errors
+    #  @return [Array<Exception>]
+    #
+    # @!attribute [r] traffic_control
+    #  @return [Stoplight::TrafficControl::Base]
+    #
+    # @!attribute [r] traffic_recovery
+    #   @return [Stoplight::TrafficRecovery::Base]
     # @api private
-    class Config
-      # @!attribute [r] name
-      #   @return [String]
-      attr_reader :name
-
-      # @!attribute [r] cool_off_time
-      #   @return [Numeric]
-      attr_reader :cool_off_time
-
-      # @!attribute [r] data_store
-      #   @return [Stoplight::DataStore::Base]
-      attr_reader :data_store
-
-      # @!attribute [r] error_notifier
-      #   @return [StandardError => void]
-      attr_reader :error_notifier
-
-      # @!attribute [r] notifiers
-      #   @return [Array<Stoplight::Notifier::Base>]
-      attr_reader :notifiers
-
-      # @!attribute [r] threshold
-      #   @return [Numeric]
-      attr_reader :threshold
-
-      # @!attribute [r] window_size
-      #   @return [Numeric]
-      attr_reader :window_size
-
-      # @!attribute [r] tracked_errors
-      #   @return [Array<StandardError>]
-      attr_reader :tracked_errors
-
-      # @!attribute [r] skipped_errors
-      #  @return [Array<Exception>]
-      attr_reader :skipped_errors
-
-      # @!attribute [r] traffic_control
-      #  @return [Stoplight::TrafficControl::Base]
-      attr_reader :traffic_control
-
-      # @!attribute [r] traffic_recovery
-      #   @return [Stoplight::TrafficRecovery::Base]
-      attr_reader :traffic_recovery
-
-      # @param name [String]
-      # @param cool_off_time [Numeric]
-      # @param data_store [Stoplight::DataStore::Base]
-      # @param error_notifier [Proc]
-      # @param notifiers [Array<Stoplight::Notifier::Base>]
-      # @param threshold [Numeric]
-      # @param window_size [Numeric]
-      # @param tracked_errors [Array<StandardError>]
-      # @param skipped_errors [Array<Exception>]
-      # @param traffic_control [Stoplight::TrafficControl::Base]
-      # @param traffic_recovery [Stoplight::TrafficRecovery::Base]
-      def initialize(name:, cool_off_time:, data_store:, error_notifier:, notifiers:, threshold:, window_size:,
-        tracked_errors:, skipped_errors:, traffic_control:, traffic_recovery:)
-        @name = name
-        @cool_off_time = cool_off_time
-        @data_store = data_store
-        @error_notifier = error_notifier
-        @notifiers = notifiers
-        @threshold = threshold
-        @window_size = window_size
-        @tracked_errors = tracked_errors
-        @skipped_errors = skipped_errors
-        @traffic_control = traffic_control
-        @traffic_recovery = traffic_recovery
-      end
-
-      # @param other [any]
-      # @return [Boolean]
-      def ==(other)
-        other.is_a?(self.class) && to_h == other.to_h
-      end
-
-      # @param error [Exception]
+    Config = Data.define(
+      :name,
+      :cool_off_time,
+      :data_store,
+      :error_notifier,
+      :notifiers,
+      :threshold,
+      :window_size,
+      :tracked_errors,
+      :skipped_errors,
+      :traffic_control,
+      :traffic_recovery
+    ) do
+      # Checks if the given error should be tracked
+      #
+      # @param error [#==] The error to check, e.g. an Exception, Class or Proc
       # @return [Boolean]
       def track_error?(error)
         skip = skipped_errors.any? { |klass| klass === error }
         track = tracked_errors.any? { |klass| klass === error }
 
         !skip && track
-      end
-
-      # Updates the configuration with new settings and returns a new instance.
-      #
-      # @return [Stoplight::Light::Config]
-      def with(**settings)
-        self.class.new(**to_h.merge(settings))
-      end
-
-      # @return [Hash]
-      def to_h
-        {
-          cool_off_time:,
-          data_store:,
-          error_notifier:,
-          name:,
-          notifiers:,
-          threshold:,
-          window_size:,
-          tracked_errors:,
-          skipped_errors:,
-          traffic_control:,
-          traffic_recovery:
-        }
       end
     end
   end

--- a/lib/stoplight/traffic_control/base.rb
+++ b/lib/stoplight/traffic_control/base.rb
@@ -30,6 +30,12 @@ module Stoplight
       def stop_traffic?(config, metadata)
         raise NotImplementedError
       end
+
+      # @param other [any]
+      # @return [Boolean]
+      def ==(other)
+        other.is_a?(self.class)
+      end
     end
   end
 end

--- a/spec/stoplight/config/config_provider_spec.rb
+++ b/spec/stoplight/config/config_provider_spec.rb
@@ -97,5 +97,55 @@ RSpec.describe Stoplight::Config::ConfigProvider do
         end
       end
     end
+
+    describe "data_store" do
+      subject { config_provider.provide("name", data_store:).data_store }
+
+      let(:data_store) { instance_double(Stoplight::DataStore::Base) }
+
+      it "wraps data store with fail safe" do
+        is_expected.to eq(Stoplight::DataStore::FailSafe.new(data_store))
+      end
+    end
+
+    describe "notifiers" do
+      subject { config_provider.provide("name", notifiers: [notifier]).notifiers }
+
+      let(:notifier) { instance_double(Stoplight::Notifier::Base) }
+
+      it "wraps notifiers with fail safe" do
+        is_expected.to contain_exactly(Stoplight::Notifier::FailSafe.new(notifier))
+      end
+    end
+
+    describe "tracked_errors" do
+      subject { config_provider.provide("name", tracked_errors: tracked_error).tracked_errors }
+
+      let(:tracked_error) { KeyError }
+
+      it "wraps tracked errors into an array" do
+        is_expected.to contain_exactly(KeyError)
+      end
+    end
+
+    describe "skipped_errors" do
+      subject { config_provider.provide("name", skipped_errors: skipped_error).skipped_errors }
+
+      let(:skipped_error) { KeyError }
+
+      it "wraps skipped errors into an array" do
+        is_expected.to contain_exactly(KeyError)
+      end
+    end
+
+    describe "cool_off_time" do
+      subject { config_provider.provide("name", cool_off_time:).cool_off_time }
+
+      let(:cool_off_time) { 60.0 }
+
+      it "converts to integer" do
+        is_expected.to be(60)
+      end
+    end
   end
 end

--- a/spec/stoplight/light/config_spec.rb
+++ b/spec/stoplight/light/config_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Stoplight::Light::Config do
   let(:config) { described_class.new(**settings) }
 
@@ -33,22 +31,16 @@ RSpec.describe Stoplight::Light::Config do
   let(:traffic_control) { Stoplight::Default::TRAFFIC_CONTROL }
   let(:traffic_recovery) { Stoplight::Default::TRAFFIC_RECOVERY }
 
-  describe "#cool_off_time" do
-    subject { config.cool_off_time }
+  describe "#initialize" do
+    describe "traffic_control" do
+      subject(:traffic_control_out) { config.traffic_control }
 
-    context "when set to a float number" do
-      let(:cool_off_time) { 66.4 }
+      let(:settings) { super().merge(traffic_control: traffic_control_in) }
 
-      it "returns the integer value" do
-        is_expected.to eq(66)
-      end
-    end
+      context "when traffic_control is a Stoplight::TrafficControl::Base instance" do
+        let(:traffic_control_in) { Stoplight::TrafficControl::ConsecutiveFailures.new }
 
-    context "when set to an integer number" do
-      let(:cool_off_time) { 66 }
-
-      it "returns the value" do
-        is_expected.to eq(66)
+        it { is_expected.to eq(traffic_control_in) }
       end
     end
   end
@@ -70,17 +62,6 @@ RSpec.describe Stoplight::Light::Config do
 
     it "returns the same value" do
       is_expected.to be(error_notifier)
-    end
-  end
-
-  describe "#notifiers" do
-    subject { config.notifiers }
-
-    let(:notifiers) { [Stoplight::Notifier::IO.new($stderr)] }
-    let(:fail_safe_notifiers) { notifiers.map { |x| Stoplight::Notifier::FailSafe.wrap(x) } }
-
-    it "returns the same value" do
-      is_expected.to contain_exactly(*fail_safe_notifiers)
     end
   end
 
@@ -160,7 +141,7 @@ RSpec.describe Stoplight::Light::Config do
         is_expected.to have_attributes(
           **new_settings.merge(
             skipped_errors: [KeyError, *Stoplight::Default::SKIPPED_ERRORS],
-            notifiers: [Stoplight::Notifier::FailSafe.wrap(notifier)]
+            notifiers: [notifier]
           )
         )
       end
@@ -182,7 +163,7 @@ RSpec.describe Stoplight::Light::Config do
       it "returns a new config with the updated settings" do
         is_expected.to be_a(described_class)
         is_expected.to have_attributes(
-          **settings.merge(new_settings).merge(notifiers: [Stoplight::Notifier::FailSafe.wrap(notifier)])
+          **settings.merge(new_settings).merge(notifiers: [notifier])
         )
       end
     end

--- a/spec/stoplight/light/green_run_strategy_spec.rb
+++ b/spec/stoplight/light/green_run_strategy_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Stoplight::Light::GreenRunStrategy do
   subject(:strategy) { described_class.new(config) }
 
@@ -37,9 +35,7 @@ RSpec.describe Stoplight::Light::GreenRunStrategy do
       let(:metadata) { instance_double(Stoplight::Metadata) }
 
       context "when error is tracked" do
-        before do
-          allow(config).to receive(:track_error?).with(error).and_return(true)
-        end
+        let(:config) { super().with(tracked_errors: [error]) }
 
         context "when fallback is not provided" do
           let(:fallback) { nil }
@@ -131,10 +127,7 @@ RSpec.describe Stoplight::Light::GreenRunStrategy do
 
       context "when error is not tracked" do
         let(:fallback) { nil }
-
-        before do
-          allow(config).to receive(:track_error?).with(error).and_return(false)
-        end
+        let(:config) { super().with(skipped_errors: [error]) }
 
         it "raises the error" do
           expect(data_store).to receive(:record_success)

--- a/spec/stoplight/light/yellow_run_strategy_spec.rb
+++ b/spec/stoplight/light/yellow_run_strategy_spec.rb
@@ -139,9 +139,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
       let(:code) { -> { raise error } }
 
       context "when error is tracked" do
-        before do
-          allow(config).to receive(:track_error?).with(error).and_return(true)
-        end
+        let(:config) { super().with(tracked_errors: [error]) }
 
         context "when fallback is not provided" do
           let(:fallback) { nil }
@@ -290,10 +288,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
       context "when error is not tracked" do
         let(:fallback) { nil }
-
-        before do
-          allow(config).to receive(:track_error?).with(error).and_return(false)
-        end
+        let(:config) { super().with(skipped_errors: [error]) }
 
         it_behaves_like "recovery success"
       end


### PR DESCRIPTION
The current configuration system has several issues that lead to unpredictable behavior and potential bugs:

1. Configuration transformations (fail-safe wrapping, type conversions) were scattered across multiple locations. Some transformations happened in constructors, others in setters, making the system unpredictable
2. Data structure logic was intertwined with transformation logic in both `Light::Config` and `UserDefaultConfig`

This PR centralizes all configuration transformations into a single, idempotent pipeline within `ConfigProvider`:

* Move all transformations (fail-safe wrapping, type conversions, array normalization) to `ConfigProvider#transform_settings`
* Remove transformation logic from `Light::Config` constructor and `UserDefaultConfig` setters
* `light.with(**settings)` now properly applies all transformations through the centralized pipeline
* Convert `Light::Config` from a regular class to `Data.define` for immutability