### PR TITLE
Fix: Do not raise error in initialization if Redis is unavailable

### DIFF
--- a/lib/stoplight/data_store/redis.rb
+++ b/lib/stoplight/data_store/redis.rb
@@ -79,12 +79,6 @@ module Stoplight
       def initialize(redis, warn_on_clock_skew: true)
         @warn_on_clock_skew = warn_on_clock_skew
         @redis = redis
-      rescue => e
-        warn <<~WARNING
-          Stoplight could not establish connection to Redis to set up lua scripts.
-          If it happened outside of support scripts (e.g., `rake assets:precompile`), it will not work correctly.
-          Error message: #{e.message}.
-        WARNING
       end
 
       def names

--- a/lib/stoplight/data_store/redis.rb
+++ b/lib/stoplight/data_store/redis.rb
@@ -94,6 +94,12 @@ module Stoplight
             pipeline.script("load", Lua::TRANSITION_TO_GREEN)
           end
         end
+      rescue => e
+        warn <<~WARNING
+          Stoplight could not establish connection to Redis to set up lua scripts.
+          If it happened outside of support scripts (e.g., `rake assets:precompile`), it will not work correctly.
+          Error message: #{e.message}.
+        WARNING
       end
 
       def names

--- a/spec/stoplight/data_store/redis_spec.rb
+++ b/spec/stoplight/data_store/redis_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe Stoplight::DataStore::Redis, :redis do
   let(:window_size) { Stoplight::Default::WINDOW_SIZE }
   let(:cool_off_time) { Stoplight::Default::COOL_OFF_TIME }
 
+  describe ".new" do
+    context "when redis is unavailable" do
+      before do
+        allow(redis).to receive(:then).and_raise(StandardError)
+      end
+
+      it "does not raise exception" do
+        expect { described_class.new(redis) }.not_to raise_error
+      end
+    end
+  end
+
   describe ".buckets_for_window" do
     subject(:buckets) { described_class.buckets_for_window(light_name, metric:, window_end:, window_size:) }
 

--- a/spec/stoplight/data_store/redis_spec.rb
+++ b/spec/stoplight/data_store/redis_spec.rb
@@ -11,18 +11,6 @@ RSpec.describe Stoplight::DataStore::Redis, :redis do
   let(:window_size) { Stoplight::Default::WINDOW_SIZE }
   let(:cool_off_time) { Stoplight::Default::COOL_OFF_TIME }
 
-  describe ".new" do
-    context "when redis is unavailable" do
-      before do
-        allow(redis).to receive(:then).and_raise(StandardError)
-      end
-
-      it "does not raise exception" do
-        expect { described_class.new(redis) }.not_to raise_error
-      end
-    end
-  end
-
   describe ".buckets_for_window" do
     subject(:buckets) { described_class.buckets_for_window(light_name, metric:, window_end:, window_size:) }
 


### PR DESCRIPTION
This PR aims to fix an issue with Redis being unavailable during Stoplight initialization.
Sometimes we use an application to run tasks w/o a data layer (e.g., `rake assets: precompile`). However, Stoplight expects to have Redis available during initialization since [we upload Lua scripts](https://github.com/bolshakov/stoplight/blob/da05dcc380d2fe4d8c84d1f7e0cb98a82e4e9308/lib/stoplight/data_store/redis.rb#L79-L103) to it.

Now we lazily load scripts into Redis when we need them.