### PR TITLE
Fix: Stop sending reconfigure notifications for fail safe

### DIFF
--- a/lib/stoplight/data_store/fail_safe.rb
+++ b/lib/stoplight/data_store/fail_safe.rb
@@ -14,10 +14,6 @@ module Stoplight
       #   @return [Stoplight::DataStore::Base] The underlying data store being wrapped.
       protected attr_reader :data_store
 
-      # @!attribute [r] circuit_breaker
-      #   @return [Stoplight] The circuit breaker used to handle failures.
-      private attr_reader :circuit_breaker
-
       class << self
         # Wraps a data store with fail-safe mechanisms.
         #
@@ -37,7 +33,6 @@ module Stoplight
       # @param data_store [Stoplight::DataStore::Base]
       def initialize(data_store)
         @data_store = data_store
-        @circuit_breaker = Stoplight("stoplight:data_store:fail_safe:#{data_store.class.name}", data_store: Default::DATA_STORE)
       end
 
       def names
@@ -101,6 +96,12 @@ module Stoplight
         end
 
         circuit_breaker.run(fallback, &code)
+      end
+
+      # @!attribute [r] circuit_breaker
+      #   @return [Stoplight] The circuit breaker used to handle failures.
+      private def circuit_breaker
+        @circuit_breaker ||= Stoplight("stoplight:data_store:fail_safe:#{data_store.class.name}", data_store: Default::DATA_STORE)
       end
     end
   end


### PR DESCRIPTION
This PR aims to stop sending reconfigure notifications for fail-safe, like [we do for notifiers](https://github.com/bolshakov/stoplight/blob/3e769f0f332c74d1d8acae1520805665f144ca51/lib/stoplight/notifier/fail_safe.rb#L62-L64).

Although later changes fix this problem, I'd like to hotfix it and release it with `v5.0.2` along with the lazy loading scripts SHAs in #357 