### PR TITLE
🔒 Harden Release Process Against Supply Chain Attacks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Docker 🐳
+name: Release 🚀
 on:
   release:
     types: [published]
@@ -12,9 +12,33 @@ permissions:  # added using https://github.com/step-security/secure-repo
   contents: read
 
 jobs:
-  build:
-    name: Build 🔧
+  gem:
+    name: Ruby Gem 📦
     runs-on: ubuntu-latest
+    environment: releases
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      - name: Release Gem
+        uses: rubygems/release-gem@ebe1ec66bd8d2c709ac29aa2b43438d450e7a0a6 # v1
+
+  docker:
+    name: Docker Image 🐳
+    depends-on: gem
+    runs-on: ubuntu-latest
+    environment: releases
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0


### PR DESCRIPTION
This PR improves our release security posture by implementing environment-based protections and removing individual developer access tokens. All releases now require explicit approval from maintainers.

- All releases now require approval from @Lokideos  or @bolshakov 
- 15-minute wait timer provides window to cancel accidental releases  
- Docker Hub credentials moved to environment-scoped secrets
- Docker build waits for gem release to complete

### New Release Process

1. **Create release** as usual (tag + publish on GitHub)
2. **Wait for approval notification** - Lokideos or bolshakov must approve
3. **15-minute delay** then workflow executes automatically

### Security Benefits

- ✅ No more individual push tokens - all revoked
- ✅ All releases require explicit maintainer approval  
- ✅ Audit trail of who approved what
- ✅ Time to catch mistakes before publishing

### Action Required After Merge:

- [ ] Revoke existing Docker Hub/RubyGems tokens from individuals
- [ ] Test approval flow with a test release