### PR TITLE
Fix docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,6 @@ on:
   push:
     branches: [ main ]
 
-env:
-  version: ${{ github.event.release.tag_name }}
-  docker_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-  docker_password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
 jobs:
   gem:
     name: Ruby Gem 📦
@@ -16,6 +11,8 @@ jobs:
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
       contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -34,11 +31,16 @@ jobs:
       - name: Release Gem
         uses: rubygems/release-gem@ebe1ec66bd8d2c709ac29aa2b43438d450e7a0a6 # v1
 
+      - name: Get version from gemspec
+        id: version
+        run: |
+          VERSION=$(ruby -e "puts Gem::Specification.load('stoplight.gemspec').version")
+          echo "version=v$VERSION" >> $GITHUB_OUTPUT
+
   docker:
     name: Docker Image 🐳
     needs: [gem]
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: read
     steps:
@@ -53,18 +55,18 @@ jobs:
       - name: Checkout release
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
-          ref: refs/tags/${{ env.version }}
+          ref: refs/tags/${{ needs.gem.outputs.version }}
       - name: Login to Docker Hub
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
-          username: ${{ env.docker_username }}
-          password: ${{ env.docker_password }}
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           push: true
           tags: |
-            bolshakov/stoplight-admin:${{ env.version }}
+            bolshakov/stoplight-admin:${{ needs.gem.outputs.version }}
             bolshakov/stoplight-admin:latest
           platforms: linux/amd64, linux/arm64
           context: .


### PR DESCRIPTION
* Do not require release approval from Docker build since it already depend on the gem build which requires approval
* Read docker tag from gempsec