### PR TITLE
feat: Add Valkey Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
     strategy:
       matrix:
         data_store: [ 'Memory', "Redis" ]
+        redis_url: [ '"redis://127.0.0.1:6379/0"', '"redis://127.0.0.1:6380/0"']
     services:
       redis:
         image: redis:7.4
@@ -44,6 +45,15 @@ jobs:
           --health-retries 5
         ports:
           - 6379:6379
+      valkey:
+        image: valkey/valkey:8-alpine
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6380:6379
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -62,7 +72,7 @@ jobs:
       - name: Run Features
         run: bundle exec cucumber features/stoplight
         env:
-          STOPLIGHT_REDIS_URL: "redis://127.0.0.1:6379/0"
+          STOPLIGHT_REDIS_URL: ${{ matrix.redis_url }}
           STOPLIGHT_DATA_STORE: ${{ matrix.data_store }}
           CUCUMBER_PUBLISH_ENABLED: true
 
@@ -76,6 +86,8 @@ jobs:
       matrix:
         ruby: [ '3.2', '3.3', '3.4' ]
         redis: [ '6.2', '7.4']
+        valkey: [ '8-alpine' ]
+        redis_url: [ '"redis://127.0.0.1:6379/0"', '"redis://127.0.0.1:6380/0"']
     services:
       redis:
         image: redis:${{ matrix.redis }}
@@ -86,6 +98,15 @@ jobs:
           --health-retries 5
         ports:
           - 6379:6379
+      valkey:
+        image: valkey/valkey:${{ matrix.valkey }}
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6380:6379
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -104,7 +125,7 @@ jobs:
       - name: Run Tests
         run: bundle exec rake spec
         env:
-          STOPLIGHT_REDIS_URL: "redis://127.0.0.1:6379/0"
+          STOPLIGHT_REDIS_URL: ${{ matrix.redis_url }}
       - name: Coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:


### PR DESCRIPTION
This PR aims to add support for Valkey for Stoplight.
As it stands now, Valkey should be a drop-in replacement for Redis and should work with the following configuration:

```ruby
# Rails app example
# config/initializers/stoplight.rb

valkey = Redis.new(url: "redis://127.0.0.1:6380")
notifier = Stoplight::Notifier::Logger.new(Rails.logger)

Stoplight.configure do |config|
  config.data_store = Stoplight::DataStore::Redis.new(valkey)
  config.notifiers = [notifier]
  config.skipped_errors = [ActiveRecord::RecordNotFound]
end
```
