### PR TITLE
Prevent Stoplight failures when Redis is not reachable

### DIFF
--- a/lib/stoplight/data_store/fail_safe.rb
+++ b/lib/stoplight/data_store/fail_safe.rb
@@ -48,13 +48,13 @@ module Stoplight
       end
 
       def get_metadata(config)
-        with_fallback(Metadata.new, config) do
+        with_fallback(EmptyMetadata, config) do
           data_store.get_metadata(config)
         end
       end
 
       def record_failure(config, failure)
-        with_fallback(nil, config) do
+        with_fallback(EmptyMetadata, config) do
           data_store.record_failure(config, failure)
         end
       end
@@ -66,13 +66,13 @@ module Stoplight
       end
 
       def record_recovery_probe_success(config, **args)
-        with_fallback(nil, config) do
+        with_fallback(EmptyMetadata, config) do
           data_store.record_recovery_probe_success(config, **args)
         end
       end
 
       def record_recovery_probe_failure(config, failure)
-        with_fallback(nil, config) do
+        with_fallback(EmptyMetadata, config) do
           data_store.record_recovery_probe_failure(config, failure)
         end
       end

--- a/lib/stoplight/empty_metadata.rb
+++ b/lib/stoplight/empty_metadata.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Stoplight
+  EmptyMetadata = Metadata.new
+end

--- a/lib/stoplight/metadata.rb
+++ b/lib/stoplight/metadata.rb
@@ -19,10 +19,10 @@ module Stoplight
     :recovered_at
   ) do
     def initialize(
-      successes: nil,
-      errors: nil,
-      recovery_probe_successes: nil,
-      recovery_probe_errors: nil,
+      successes: 0,
+      errors: 0,
+      recovery_probe_successes: 0,
+      recovery_probe_errors: 0,
       last_error_at: nil,
       last_success_at: nil,
       consecutive_errors: 0,
@@ -35,14 +35,14 @@ module Stoplight
       recovered_at: nil
     )
       super(
-        recovery_probe_successes:,
-        recovery_probe_errors:,
-        successes:,
-        errors:,
+        recovery_probe_successes: recovery_probe_successes.to_i,
+        recovery_probe_errors: recovery_probe_errors.to_i,
+        successes: successes.to_i,
+        errors: errors.to_i,
         last_error_at: (Time.at(Integer(last_error_at)) if last_error_at),
         last_success_at: (Time.at(Integer(last_success_at)) if last_success_at),
-        consecutive_errors: Integer(consecutive_errors),
-        consecutive_successes: Integer(consecutive_successes),
+        consecutive_errors: consecutive_errors.to_i,
+        consecutive_successes: consecutive_successes.to_i,
         last_error:,
         breached_at: (Time.at(Integer(breached_at)) if breached_at),
         locked_state: locked_state || State::UNLOCKED,
@@ -72,7 +72,7 @@ module Stoplight
     #
     # @return [Float]
     def error_rate
-      if successes.nil? || errors.nil? || (successes + errors).zero?
+      if (successes + errors).zero?
         0.0
       else
         errors.fdiv(successes + errors)


### PR DESCRIPTION
Fixes #413

Example scenario:

```ruby
redis = Redis.new(url: "redis://561922f7-6b30-49d3-8148-324922d590d2:6379/0")
light = Stoplight('bug-report-2025-08-22', data_store: Stoplight::DataStore::Redis.new(redis))
light.run { raise 'foo' }
```

It raises "foo" error. Before the fix, it exhibited unexpected behavior.

💡Fixing this, I realized we could behave better when the data store is failing. Currently, we protect the underlying Redis data store with an in-memory-based circuit breaker. While it works for protecting the Redis data store itself, when Redis itself fails, the protected service becomes unprotected. **We should think of how to switch to in-Memory data store for protecting the service in such situations**