### PR TITLE
Handle concurrent recovery completion in consecutive successes strategy

### DIFF
--- a/features/stoplight/step_definitions/assertions_steps.rb
+++ b/features/stoplight/step_definitions/assertions_steps.rb
@@ -29,7 +29,7 @@ Then(/^(?:the light|it) fails with error:$/) do |table|
       exception_class = Object.const_get(value)
       expect(last_exception)
         .to be_kind_of(exception_class),
-          "Expected exception to be of type #{value}, but got #{last_exception.class}"
+          "Expected exception to be of type #{value}, but got #{last_exception.inspect}"
     when "Message"
       expect(last_exception.message)
         .to eq(value),

--- a/lib/stoplight/light/yellow_run_strategy.rb
+++ b/lib/stoplight/light/yellow_run_strategy.rb
@@ -51,24 +51,26 @@ module Stoplight
         recovery_result = config.traffic_recovery.determine_color(config, metadata)
 
         case recovery_result
-        when Color::GREEN
+        when TrafficRecovery::GREEN
           if data_store.transition_to_color(config, Color::GREEN)
             config.notifiers.each do |notifier|
               notifier.notify(config, Color::YELLOW, Color::GREEN, nil)
             end
           end
-        when Color::YELLOW
+        when TrafficRecovery::YELLOW
           if data_store.transition_to_color(config, Color::YELLOW)
             config.notifiers.each do |notifier|
               notifier.notify(config, Color::GREEN, Color::YELLOW, nil)
             end
           end
-        when Color::RED
+        when TrafficRecovery::RED
           if data_store.transition_to_color(config, Color::RED)
             config.notifiers.each do |notifier|
               notifier.notify(config, Color::YELLOW, Color::RED, nil)
             end
           end
+        when TrafficRecovery::PASS
+          # No state change, do nothing
         else
           raise "recovery strategy returned an expected color: #{recovery_result}"
         end

--- a/lib/stoplight/metadata.rb
+++ b/lib/stoplight/metadata.rb
@@ -52,6 +52,16 @@ module Stoplight
       )
     end
 
+    # Creates a new Metadata instance with updated attributes. This method overrides
+    # the default +with+ method provided by +Data.define+ to ensure constructor
+    # logic is applied.
+    #
+    # @param kwargs [Hash{Symbol => Object}]
+    # @return [Metadata]
+    def with(**kwargs)
+      self.class.new(**to_h.merge(kwargs))
+    end
+
     # @param at [Time] (Time.now) the moment of time when the color is determined
     # @return [String] one of +Color::GREEN+, +Color::RED+, or +Color::YELLOW+
     def color(at: Time.now)

--- a/lib/stoplight/traffic_recovery.rb
+++ b/lib/stoplight/traffic_recovery.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module TrafficRecovery
+    Decision = Data.define(:decision)
+    GREEN = Decision.new("green")
+    YELLOW = Decision.new("yellow")
+    RED = Decision.new("red")
+    PASS = Decision.new("pass")
+  end
+end

--- a/lib/stoplight/traffic_recovery/base.rb
+++ b/lib/stoplight/traffic_recovery/base.rb
@@ -49,10 +49,7 @@ module Stoplight
       #
       # @param config [Stoplight::Light::Config]
       # @param metadata [Stoplight::Metadata]
-      # @return [String] One of the Stoplight::Color constants:
-      #   - Stoplight::Color::RED: Recovery failed, block all traffic
-      #   - Stoplight::Color::YELLOW: Continue recovery process
-      #   - Stoplight::Color::GREEN: Recovery successful, return to normal traffic flow
+      # @return [TrafficRecovery::Decision]
       def determine_color(config, metadata)
         raise NotImplementedError
       end

--- a/lib/stoplight/traffic_recovery/consecutive_successes.rb
+++ b/lib/stoplight/traffic_recovery/consecutive_successes.rb
@@ -49,16 +49,18 @@ module Stoplight
       #
       # @param config [Stoplight::Light::Config]
       # @param metadata [Stoplight::Metadata]
-      # @return [String]
+      # @return [TrafficRecovery::Decision]
       def determine_color(config, metadata)
+        return TrafficRecovery::PASS if metadata.color != Color::YELLOW
+
         recovery_started_at = metadata.recovery_started_at || metadata.recovery_scheduled_after
 
         if metadata.last_error_at && metadata.last_error_at >= recovery_started_at
-          Color::RED
+          TrafficRecovery::RED
         elsif [metadata.consecutive_successes, metadata.recovery_probe_successes].min >= config.recovery_threshold
-          Color::GREEN
+          TrafficRecovery::GREEN
         else
-          Color::YELLOW
+          TrafficRecovery::YELLOW
         end
       end
     end

--- a/spec/stoplight/light/yellow_run_strategy_spec.rb
+++ b/spec/stoplight/light/yellow_run_strategy_spec.rb
@@ -22,8 +22,20 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
         expect(traffic_recovery).to receive(:determine_color).with(config, metadata).and_return(recovery_result)
       end
 
+      context "when recovery strategy returns PASS" do
+        let(:recovery_result) { Stoplight::TrafficRecovery::PASS }
+
+        it "does not make any recovery decisions" do
+          expect(data_store).not_to receive(:transition_to_color)
+          expect(notifier).not_to receive(:notify)
+          allow(data_store).to receive(:record_recovery_probe_success).with(config).and_return(metadata)
+
+          suppress(StandardError) { result }
+        end
+      end
+
       context "when recovery strategy returns GREEN" do
-        let(:recovery_result) { Stoplight::Color::GREEN }
+        let(:recovery_result) { Stoplight::TrafficRecovery::GREEN }
 
         context "when switched to GREEN" do
           before do
@@ -53,7 +65,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
       end
 
       context "when recovery strategy returns RED" do
-        let(:recovery_result) { Stoplight::Color::RED }
+        let(:recovery_result) { Stoplight::TrafficRecovery::RED }
 
         context "when switched to RED" do
           before do
@@ -83,7 +95,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
       end
 
       context "when recovery strategy returns YELLOW" do
-        let(:recovery_result) { Stoplight::Color::YELLOW }
+        let(:recovery_result) { Stoplight::TrafficRecovery::YELLOW }
 
         context "when switched to YELLOW" do
           before do
@@ -150,7 +162,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
           end
 
           context "when recovery strategy returns GREEN" do
-            let(:recovery_result) { Stoplight::Color::GREEN }
+            let(:recovery_result) { Stoplight::TrafficRecovery::GREEN }
 
             context "when switched to GREEN" do
               before do
@@ -188,7 +200,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
           end
 
           context "when recovery strategy returns RED" do
-            let(:recovery_result) { Stoplight::Color::RED }
+            let(:recovery_result) { Stoplight::TrafficRecovery::RED }
 
             context "when switched to RED" do
               before do
@@ -226,7 +238,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
           end
 
           context "when recovery strategy returns YELLOW" do
-            let(:recovery_result) { Stoplight::Color::YELLOW }
+            let(:recovery_result) { Stoplight::TrafficRecovery::YELLOW }
 
             context "when switched to YELLOW" do
               before do
@@ -274,7 +286,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
           it "records a failed recovery probe and returns fallback" do
             allow(notifier).to receive(:notify)
-            expect(traffic_recovery).to receive(:determine_color).with(config, metadata).and_return(Stoplight::Color::YELLOW)
+            expect(traffic_recovery).to receive(:determine_color).with(config, metadata).and_return(Stoplight::TrafficRecovery::YELLOW)
 
             Timecop.freeze do
               failure = Stoplight::Failure.from_error(error)

--- a/spec/stoplight/metadata_spec.rb
+++ b/spec/stoplight/metadata_spec.rb
@@ -78,4 +78,14 @@ RSpec.describe Stoplight::Metadata do
       end
     end
   end
+
+  describe "#with" do
+    subject { metadata.with(successes: "42") }
+
+    let(:metadata) { Stoplight::Metadata.new }
+
+    it "applies constructor logic" do
+      is_expected.to have_attributes(successes: 42)
+    end
+  end
 end

--- a/spec/stoplight/traffic_recovery/consecutive_successes_spec.rb
+++ b/spec/stoplight/traffic_recovery/consecutive_successes_spec.rb
@@ -35,16 +35,17 @@ RSpec.describe Stoplight::TrafficRecovery::ConsecutiveSuccesses do
     let(:recovery_threshold) { 2 }
 
     let(:metadata) do
-      instance_double(
-        Stoplight::Metadata,
+      Stoplight::Metadata.new(
         consecutive_successes:,
         recovery_probe_successes:,
         last_error_at:,
-        recovery_started_at:
+        recovery_started_at:,
+        recovery_scheduled_after:
       )
     end
     let(:last_error_at) { recovery_started_at - 60 }
     let(:recovery_started_at) { Time.now }
+    let(:recovery_scheduled_after) { nil }
 
     context "when the last error happened after the recovery started" do
       let(:last_error_at) { recovery_started_at + 2 }
@@ -52,7 +53,7 @@ RSpec.describe Stoplight::TrafficRecovery::ConsecutiveSuccesses do
       let(:consecutive_successes) { 0 }
       let(:recovery_probe_successes) { 1 }
 
-      it { is_expected.to be(Stoplight::Color::RED) }
+      it { is_expected.to be(Stoplight::TrafficRecovery::RED) }
     end
 
     context "when the number of consecutive successes is greater than the threshold" do
@@ -61,19 +62,19 @@ RSpec.describe Stoplight::TrafficRecovery::ConsecutiveSuccesses do
       context "when the number of successes is less than the threshold" do
         let(:recovery_probe_successes) { recovery_threshold - 1 }
 
-        it { is_expected.to be(Stoplight::Color::YELLOW) }
+        it { is_expected.to be(Stoplight::TrafficRecovery::YELLOW) }
       end
 
       context "when the number of successes is equal to the threshold" do
         let(:recovery_probe_successes) { recovery_threshold }
 
-        it { is_expected.to be(Stoplight::Color::GREEN) }
+        it { is_expected.to be(Stoplight::TrafficRecovery::GREEN) }
       end
 
       context "when the number of successes is bigger to the threshold" do
         let(:recovery_probe_successes) { recovery_threshold + 1 }
 
-        it { is_expected.to be(Stoplight::Color::GREEN) }
+        it { is_expected.to be(Stoplight::TrafficRecovery::GREEN) }
       end
     end
 
@@ -83,19 +84,19 @@ RSpec.describe Stoplight::TrafficRecovery::ConsecutiveSuccesses do
       context "when the number of successes is less than the threshold" do
         let(:recovery_probe_successes) { recovery_threshold - 1 }
 
-        it { is_expected.to be(Stoplight::Color::YELLOW) }
+        it { is_expected.to be(Stoplight::TrafficRecovery::YELLOW) }
       end
 
       context "when the number of successes is equal to the threshold" do
         let(:recovery_probe_successes) { recovery_threshold }
 
-        it { is_expected.to be(Stoplight::Color::GREEN) }
+        it { is_expected.to be(Stoplight::TrafficRecovery::GREEN) }
       end
 
       context "when the number of successes is bigger to the threshold" do
         let(:recovery_probe_successes) { recovery_threshold + 1 }
 
-        it { is_expected.to be(Stoplight::Color::GREEN) }
+        it { is_expected.to be(Stoplight::TrafficRecovery::GREEN) }
       end
     end
 
@@ -105,20 +106,29 @@ RSpec.describe Stoplight::TrafficRecovery::ConsecutiveSuccesses do
       context "when the number of successes is less than the threshold" do
         let(:recovery_probe_successes) { recovery_threshold - 1 }
 
-        it { is_expected.to be(Stoplight::Color::YELLOW) }
+        it { is_expected.to be(Stoplight::TrafficRecovery::YELLOW) }
       end
 
       context "when the number of successes is equal to the threshold" do
         let(:recovery_probe_successes) { recovery_threshold }
 
-        it { is_expected.to be(Stoplight::Color::YELLOW) }
+        it { is_expected.to be(Stoplight::TrafficRecovery::YELLOW) }
       end
 
       context "when the number of successes is bigger to the threshold" do
         let(:recovery_probe_successes) { recovery_threshold + 1 }
 
-        it { is_expected.to be(Stoplight::Color::YELLOW) }
+        it { is_expected.to be(Stoplight::TrafficRecovery::YELLOW) }
       end
+    end
+
+    context "when already recovered on another Stoplight instance" do
+      let(:last_error_at) { Time.now - 60 }
+      let(:recovery_started_at) { nil }
+      let(:consecutive_successes) { 1 }
+      let(:recovery_probe_successes) { 0 }
+
+      it { is_expected.to be(Stoplight::TrafficRecovery::PASS) }
     end
   end
 end


### PR DESCRIPTION
Fixes #426 

Fixes a race condition where multiple Stoplight instances could interfere with each other's recovery process. When one instance successfully completes recovery and clears the`recovery_started_at` timestamp, other instances would get `nil` and incorrectly determine circuit state.

Refactor traffic recovery to use dedicated decision types instead of reusing Color constants, improving type safety and semantic clarity.

- Add `TrafficRecovery::Decision` enum with GREEN, YELLOW, RED, PASS states
- Replace Color constants with TrafficRecovery decisions in recovery strategies
- Introduce PASS decision for the concurrent recovery completion scenariou