### PR TITLE
Send notification about YELLOW color transitions

### DIFF
--- a/features/stoplight/traffic_control/consecutive_errors.feature
+++ b/features/stoplight/traffic_control/consecutive_errors.feature
@@ -35,10 +35,12 @@ Feature: Consecutive Errors Traffic Control Strategy
 
   Scenario: Light transitions to red after failure in yellow state
     Given the protected service starts failing with "connection-timeout"
+    And the light enters the red state
+    Then notification about transition from green to red is sent
     And the light enters the yellow state
     When I make 1 request to the service
     Then the light color is red
-    And notification about transition from green to red is sent
+    And notification about transition from yellow to red is sent
 
   Scenario: Light resets failure count after success
     Given the protected service starts failing with "connection-timeout"

--- a/features/stoplight/traffic_control/error_rate.feature
+++ b/features/stoplight/traffic_control/error_rate.feature
@@ -38,10 +38,12 @@ Feature: Error Rate Traffic Control Strategy
 
   Scenario: Light transitions to red after failure in yellow state
     Given the protected service starts failing with "connection-timeout"
+    And the light enters the red state
+    Then notification about transition from green to red is sent
     And the light enters the yellow state
     When I make 1 request to the service
     Then the light color is red
-    And notification about transition from green to red is sent
+    And notification about transition from yellow to red is sent
 
   Scenario: Light does not transition to to red after successful call
     Given the protected service starts failing with "connection-timeout"

--- a/lib/stoplight/data_store/fail_safe.rb
+++ b/lib/stoplight/data_store/fail_safe.rb
@@ -48,13 +48,13 @@ module Stoplight
       end
 
       def get_metadata(config)
-        with_fallback(EmptyMetadata, config) do
+        with_fallback(EmptyMetadata.new, config) do
           data_store.get_metadata(config)
         end
       end
 
       def record_failure(config, failure)
-        with_fallback(EmptyMetadata, config) do
+        with_fallback(EmptyMetadata.new, config) do
           data_store.record_failure(config, failure)
         end
       end
@@ -66,13 +66,13 @@ module Stoplight
       end
 
       def record_recovery_probe_success(config, **args)
-        with_fallback(EmptyMetadata, config) do
+        with_fallback(EmptyMetadata.new, config) do
           data_store.record_recovery_probe_success(config, **args)
         end
       end
 
       def record_recovery_probe_failure(config, failure)
-        with_fallback(EmptyMetadata, config) do
+        with_fallback(EmptyMetadata.new, config) do
           data_store.record_recovery_probe_failure(config, failure)
         end
       end

--- a/lib/stoplight/data_store/fail_safe.rb
+++ b/lib/stoplight/data_store/fail_safe.rb
@@ -48,13 +48,13 @@ module Stoplight
       end
 
       def get_metadata(config)
-        with_fallback(EmptyMetadata.new, config) do
+        with_fallback(Metadata.new, config) do
           data_store.get_metadata(config)
         end
       end
 
       def record_failure(config, failure)
-        with_fallback(EmptyMetadata.new, config) do
+        with_fallback(Metadata.new, config) do
           data_store.record_failure(config, failure)
         end
       end
@@ -66,13 +66,13 @@ module Stoplight
       end
 
       def record_recovery_probe_success(config, **args)
-        with_fallback(EmptyMetadata.new, config) do
+        with_fallback(Metadata.new, config) do
           data_store.record_recovery_probe_success(config, **args)
         end
       end
 
       def record_recovery_probe_failure(config, failure)
-        with_fallback(EmptyMetadata.new, config) do
+        with_fallback(Metadata.new, config) do
           data_store.record_recovery_probe_failure(config, failure)
         end
       end

--- a/lib/stoplight/data_store/memory.rb
+++ b/lib/stoplight/data_store/memory.rb
@@ -16,7 +16,7 @@ module Stoplight
         @recovery_probe_errors = Hash.new { |h, k| h[k] = [] }
         @recovery_probe_successes = Hash.new { |h, k| h[k] = [] }
 
-        @metadata = Hash.new { |h, k| h[k] = Metadata.new(current_time: Time.now) }
+        @metadata = Hash.new { |h, k| h[k] = Metadata.new }
         super # MonitorMixin
       end
 

--- a/lib/stoplight/data_store/memory.rb
+++ b/lib/stoplight/data_store/memory.rb
@@ -16,7 +16,7 @@ module Stoplight
         @recovery_probe_errors = Hash.new { |h, k| h[k] = [] }
         @recovery_probe_successes = Hash.new { |h, k| h[k] = [] }
 
-        @metadata = Hash.new { |h, k| h[k] = Metadata.new }
+        @metadata = Hash.new { |h, k| h[k] = Metadata.new(current_time: Time.now) }
         super # MonitorMixin
       end
 
@@ -29,16 +29,16 @@ module Stoplight
       # @return [Stoplight::Metadata]
       def get_metadata(config)
         light_name = config.name
-        window_end = Time.now
-        recovery_window = (window_end - config.cool_off_time)..window_end
 
         synchronize do
+          current_time = Time.now
+          recovery_window = (current_time - config.cool_off_time)..current_time
           recovered_at = @metadata[light_name].recovered_at
           window = if config.window_size
-            window_start = [recovered_at, (window_end - config.window_size)].compact.max
-            (window_start..window_end)
+            window_start = [recovered_at, (current_time - config.window_size)].compact.max
+            (window_start..current_time)
           else
-            (..window_end)
+            (..current_time)
           end
 
           errors = @errors[config.name].count do |request_time|
@@ -57,6 +57,7 @@ module Stoplight
           end
 
           @metadata[light_name].with(
+            current_time:,
             errors:,
             successes:,
             recovery_probe_errors:,

--- a/lib/stoplight/data_store/redis.rb
+++ b/lib/stoplight/data_store/redis.rb
@@ -94,8 +94,8 @@ module Stoplight
       def get_metadata(config)
         detect_clock_skew
 
-        window_end = Time.now
-        window_end_ts = window_end.to_i
+        current_time = Time.now
+        window_end_ts = current_time.to_i
         window_start_ts = window_end_ts - [config.window_size, Base::METRICS_RETENTION_TIME].compact.min.to_i
         recovery_window_start_ts = window_end_ts - config.cool_off_time.to_i
 
@@ -133,10 +133,11 @@ module Stoplight
         last_error = normalize_failure(last_error_json, config.error_notifier) if last_error_json
 
         Metadata.new(
-          successes: successes,
-          errors: errors,
-          recovery_probe_successes: recovery_probe_successes,
-          recovery_probe_errors: recovery_probe_errors,
+          current_time:,
+          successes:,
+          errors:,
+          recovery_probe_successes:,
+          recovery_probe_errors:,
           last_error:,
           **meta_hash
         )

--- a/lib/stoplight/empty_metadata.rb
+++ b/lib/stoplight/empty_metadata.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 module Stoplight
-  EmptyMetadata = Metadata.new
+  class EmptyMetadata < Metadata
+    def initialize(current_time: Time.now)
+      super
+    end
+  end
 end

--- a/lib/stoplight/empty_metadata.rb
+++ b/lib/stoplight/empty_metadata.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module Stoplight
-  class EmptyMetadata < Metadata
-    def initialize(current_time: Time.now)
-      super
-    end
-  end
-end

--- a/lib/stoplight/light.rb
+++ b/lib/stoplight/light.rb
@@ -32,10 +32,7 @@ module Stoplight
     #
     # @return [String]
     def state
-      config
-        .data_store
-        .get_metadata(config)
-        .locked_state
+      metadata.locked_state
     end
 
     # Returns current color:
@@ -49,10 +46,7 @@ module Stoplight
     #
     # @return [String] returns current light color
     def color
-      config
-        .data_store
-        .get_metadata(config)
-        .color
+      metadata.color
     end
 
     # Runs the given block of code with this circuit breaker
@@ -72,8 +66,10 @@ module Stoplight
     def run(fallback = nil, &code)
       raise ArgumentError, "nothing to run. Please, pass a block into `Light#run`" unless block_given?
 
-      strategy = state_strategy_factory(color)
-      strategy.execute(fallback, &code)
+      metadata.then do |metadata|
+        strategy = state_strategy_factory(metadata.color)
+        strategy.execute(fallback, metadata:, &code)
+      end
     end
 
     # Locks light in either +State::LOCKED_RED+ or +State::LOCKED_GREEN+
@@ -185,6 +181,11 @@ module Stoplight
     # @return [Stoplight::Light]
     def reconfigure(config)
       self.class.new(config)
+    end
+
+    # @return [Stoplight::Metadata]
+    def metadata
+      config.data_store.get_metadata(config)
     end
   end
 end

--- a/lib/stoplight/light/green_run_strategy.rb
+++ b/lib/stoplight/light/green_run_strategy.rb
@@ -12,10 +12,11 @@ module Stoplight
       # Executes the provided code block when the light is in the green state.
       #
       # @param fallback [Proc, nil] A fallback proc to execute in case of an error.
+      # @param metadata [Stoplight::Metadata] Metadata capturing the current state of the light.
       # @yield The code block to execute.
       # @return [Object] The result of the code block if successful.
       # @raise [Exception] Re-raises the error if it is not tracked or no fallback is provided.
-      def execute(fallback, &code)
+      def execute(fallback, metadata:, &code)
         # TODO: Consider implementing sampling rate to limit the memory footprint
         code.call.tap { record_success }
       rescue => error
@@ -38,7 +39,9 @@ module Stoplight
         failure = Stoplight::Failure.from_error(error)
         metadata = data_store.record_failure(config, failure)
 
-        if config.traffic_control.stop_traffic?(config, metadata) && data_store.transition_to_color(config, Color::RED)
+        stop_traffic = config.traffic_control.stop_traffic?(config, metadata)
+        transition_to_color = stop_traffic && data_store.transition_to_color(config, Color::RED)
+        if transition_to_color
           config.notifiers.each do |notifier|
             notifier.notify(config, Color::GREEN, Color::RED, error)
           end

--- a/lib/stoplight/light/green_run_strategy.rb
+++ b/lib/stoplight/light/green_run_strategy.rb
@@ -39,9 +39,7 @@ module Stoplight
         failure = Stoplight::Failure.from_error(error)
         metadata = data_store.record_failure(config, failure)
 
-        stop_traffic = config.traffic_control.stop_traffic?(config, metadata)
-        transition_to_color = stop_traffic && data_store.transition_to_color(config, Color::RED)
-        if transition_to_color
+        if config.traffic_control.stop_traffic?(config, metadata) && data_store.transition_to_color(config, Color::RED)
           config.notifiers.each do |notifier|
             notifier.notify(config, Color::GREEN, Color::RED, error)
           end

--- a/lib/stoplight/light/red_run_strategy.rb
+++ b/lib/stoplight/light/red_run_strategy.rb
@@ -12,9 +12,10 @@ module Stoplight
       # Executes the fallback proc when the light is in the red state.
       #
       # @param fallback [Proc, nil] A fallback proc to execute instead of the code block.
+      # @param metadata [Stoplight::Metadata] Metadata capturing the current state of the light.
       # @return [Object, nil] The result of the fallback proc if provided.
       # @raise [Stoplight::Error::RedLight] Raises an error if no fallback is provided.
-      def execute(fallback)
+      def execute(fallback, metadata:)
         if fallback
           fallback.call(nil)
         else

--- a/lib/stoplight/light/run_strategy.rb
+++ b/lib/stoplight/light/run_strategy.rb
@@ -22,7 +22,9 @@ module Stoplight
         @data_store = config.data_store
       end
 
-      def execute(fallback, &code)
+      # @param fallback [Proc, nil] A fallback proc to execute in case of an error.
+      # @param metadata [Stoplight::Metadata] Metadata capturing the current state of the light.
+      def execute(fallback, metadata:, &code)
         raise NotImplementedError, "Subclasses must implement the execute method"
       end
     end

--- a/lib/stoplight/light/yellow_run_strategy.rb
+++ b/lib/stoplight/light/yellow_run_strategy.rb
@@ -13,10 +13,12 @@ module Stoplight
       # Executes the provided code block when the light is in the yellow state.
       #
       # @param fallback [Proc, nil] A fallback proc to execute in case of an error.
+      # @param metadata [Stoplight::Metadata] Metadata capturing the current state of the light.
       # @yield The code block to execute.
       # @return [Object] The result of the code block if successful.
       # @raise [Exception] Re-raises the error if it is not tracked or no fallback is provided.
-      def execute(fallback, &code)
+      def execute(fallback, metadata:, &code)
+        transition_to_yellow(metadata:)
         # TODO: We need to employ a probabilistic approach here to avoid "thundering herd" problem
         code.call.tap { record_recovery_probe_success }
       rescue => error
@@ -45,6 +47,18 @@ module Stoplight
         metadata = data_store.record_recovery_probe_failure(config, failure)
 
         recover(metadata)
+      end
+
+      # @param metadata [Stoplight::Metadata]
+      # @return [void]
+      def transition_to_yellow(metadata:)
+        return unless metadata.color == Color::YELLOW
+
+        if metadata.recovery_scheduled_after && config.data_store.transition_to_color(config, Color::YELLOW)
+          config.notifiers.each do |notifier|
+            notifier.notify(config, Color::RED, Color::YELLOW, nil)
+          end
+        end
       end
 
       private def recover(metadata)

--- a/lib/stoplight/metadata.rb
+++ b/lib/stoplight/metadata.rb
@@ -16,10 +16,11 @@ module Stoplight
     :locked_state,
     :recovery_scheduled_after,
     :recovery_started_at,
-    :recovered_at
+    :recovered_at,
+    :current_time
   ) do
     def initialize(
-      successes: 0,
+      current_time:, successes: 0,
       errors: 0,
       recovery_probe_successes: 0,
       recovery_probe_errors: 0,
@@ -49,6 +50,7 @@ module Stoplight
         recovery_scheduled_after: (Time.at(Integer(recovery_scheduled_after)) if recovery_scheduled_after),
         recovery_started_at: (Time.at(Integer(recovery_started_at)) if recovery_started_at),
         recovered_at: (Time.at(Integer(recovered_at)) if recovered_at),
+        current_time:,
       )
     end
 
@@ -59,17 +61,16 @@ module Stoplight
     # @param kwargs [Hash{Symbol => Object}]
     # @return [Metadata]
     def with(**kwargs)
-      self.class.new(**to_h.merge(kwargs))
+      self.class.new(**to_h.merge(current_time: Time.now, **kwargs))
     end
 
-    # @param at [Time] (Time.now) the moment of time when the color is determined
     # @return [String] one of +Color::GREEN+, +Color::RED+, or +Color::YELLOW+
-    def color(at: Time.now)
+    def color
       if locked_state == State::LOCKED_GREEN
         Color::GREEN
       elsif locked_state == State::LOCKED_RED
         Color::RED
-      elsif (recovery_scheduled_after && recovery_scheduled_after < at) || recovery_started_at
+      elsif (recovery_scheduled_after && recovery_scheduled_after < current_time) || recovery_started_at
         Color::YELLOW
       elsif breached_at
         Color::RED

--- a/lib/stoplight/metadata.rb
+++ b/lib/stoplight/metadata.rb
@@ -20,7 +20,8 @@ module Stoplight
     :current_time
   ) do
     def initialize(
-      current_time:, successes: 0,
+      current_time: Time.now,
+      successes: 0,
       errors: 0,
       recovery_probe_successes: 0,
       recovery_probe_errors: 0,

--- a/spec/dummy/bin/rails
+++ b/spec/dummy/bin/rails
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
 
 APP_PATH = File.expand_path("../../config/application", __FILE__)
 require_relative "../config/boot"

--- a/spec/dummy/bin/rake
+++ b/spec/dummy/bin/rake
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
 
 require_relative "../config/boot"
 require "rake"

--- a/spec/properties/notifications_spec.rb
+++ b/spec/properties/notifications_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Notifications" do
         notifications_before_run = notifier.notifications(light.name).count
 
         executions_sequence.each do |(should_fail, time_gap)|
-          Timecop.travel(Time.now + time_gap)
+          Timecop.freeze(Time.now + time_gap)
           suppress(StandardError) { light.run { raise if should_fail } }
 
           color_after_run = light.color
@@ -58,10 +58,10 @@ RSpec.describe "Notifications" do
 
           if color_before_run != color_after_run
             expect(notifications.count).to eq(notifications_before_run + 1),
-              "Expected a notification when transitioning from #{color_before_run} to #{color_after_run}, but did not"
+              "Expected a notification when transitioning from `#{color_before_run}` to `#{color_after_run}`, but did not"
 
             expect(notifications.last).to eq([color_before_run, color_after_run]),
-              "Expected notification to be from #{color_before_run} to #{color_after_run}, but was #{notifications.last}"
+              "Expected notification to be from `#{color_before_run}` to `#{color_after_run}`, but was `#{notifications.last.join("` to `")}`"
           end
 
           color_before_run = color_after_run
@@ -78,7 +78,7 @@ RSpec.describe "Notifications" do
   end
 
   context "with redis data store", :redis do
-    let(:data_store) { Stoplight::DataStore::Redis.new(redis) }
+    let(:data_store) { Stoplight::DataStore::Redis.new(redis, warn_on_clock_skew: false) }
 
     it_behaves_like "notify about state changes"
   end

--- a/spec/stoplight/data_store/fail_safe_spec.rb
+++ b/spec/stoplight/data_store/fail_safe_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
         expect(error_notifier).to receive(:call).with(error)
         expect(data_store).to receive(:get_metadata).with(config) { raise error }
 
-        is_expected.to eq(Stoplight::EmptyMetadata.new(current_time: get_metadata.current_time))
+        is_expected.to eq(Stoplight::Metadata.new(current_time: get_metadata.current_time))
       end
     end
   end
@@ -78,7 +78,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
         expect(error_notifier).to receive(:call).with(error)
         expect(data_store).to receive(:record_failure).with(config, failure) { raise error }
 
-        is_expected.to be_kind_of(Stoplight::EmptyMetadata)
+        is_expected.to be_kind_of(Stoplight::Metadata)
       end
     end
   end
@@ -126,7 +126,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
         expect(error_notifier).to receive(:call).with(error)
         expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure) { raise error }
 
-        is_expected.to be_kind_of(Stoplight::EmptyMetadata)
+        is_expected.to be_kind_of(Stoplight::Metadata)
       end
     end
   end
@@ -150,7 +150,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
         expect(error_notifier).to receive(:call).with(error)
         expect(data_store).to receive(:record_recovery_probe_success).with(config) { raise error }
 
-        is_expected.to be_kind_of(Stoplight::EmptyMetadata)
+        is_expected.to be_kind_of(Stoplight::Metadata)
       end
     end
   end

--- a/spec/stoplight/data_store/fail_safe_spec.rb
+++ b/spec/stoplight/data_store/fail_safe_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe Stoplight::DataStore::FailSafe do
   end
 
   describe "#get_metadata" do
-    subject { fail_safe.get_metadata(config) }
+    subject(:get_metadata) { fail_safe.get_metadata(config) }
 
     context "when data_store returns all data" do
       let(:metadata) do
-        Stoplight::Metadata.new.with(errors: 4)
+        Stoplight::Metadata.new(current_time: Time.now).with(errors: 4)
       end
 
       it "returns all data from data_store" do
@@ -54,7 +54,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
         expect(error_notifier).to receive(:call).with(error)
         expect(data_store).to receive(:get_metadata).with(config) { raise error }
 
-        is_expected.to eq(Stoplight::Metadata.new)
+        is_expected.to eq(Stoplight::EmptyMetadata.new(current_time: get_metadata.current_time))
       end
     end
   end
@@ -78,7 +78,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
         expect(error_notifier).to receive(:call).with(error)
         expect(data_store).to receive(:record_failure).with(config, failure) { raise error }
 
-        is_expected.to eq(Stoplight::EmptyMetadata)
+        is_expected.to be_kind_of(Stoplight::EmptyMetadata)
       end
     end
   end
@@ -111,7 +111,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
     let(:failure) { Stoplight::Failure.new("class", "message", Time.new) }
 
     context "when data_store records recovery probe failure" do
-      let(:metadata) { Stoplight::Metadata.new(errors: 42) }
+      let(:metadata) { Stoplight::Metadata.new(errors: 42, current_time: Time.now) }
 
       it "returns metadata from data_store" do
         expect(error_notifier).not_to receive(:call)
@@ -126,7 +126,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
         expect(error_notifier).to receive(:call).with(error)
         expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure) { raise error }
 
-        is_expected.to eq(Stoplight::EmptyMetadata)
+        is_expected.to be_kind_of(Stoplight::EmptyMetadata)
       end
     end
   end
@@ -135,7 +135,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
     subject { fail_safe.record_recovery_probe_success(config) }
 
     context "when data_store records recovery probe success" do
-      let(:metadata) { Stoplight::Metadata.new(errors: 42) }
+      let(:metadata) { Stoplight::Metadata.new(errors: 42, current_time: Time.now) }
 
       it "returns metadata from data_store" do
         expect(error_notifier).not_to receive(:call)
@@ -150,7 +150,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
         expect(error_notifier).to receive(:call).with(error)
         expect(data_store).to receive(:record_recovery_probe_success).with(config) { raise error }
 
-        is_expected.to eq(Stoplight::EmptyMetadata)
+        is_expected.to be_kind_of(Stoplight::EmptyMetadata)
       end
     end
   end

--- a/spec/stoplight/light/green_run_strategy_spec.rb
+++ b/spec/stoplight/light/green_run_strategy_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe Stoplight::Light::GreenRunStrategy do
   end
   let(:notifier) { instance_double(Stoplight::Notifier::Base) }
   let(:traffic_control) { Stoplight::TrafficControl::ConsecutiveErrors.new }
+  let(:metadata) { instance_double(Stoplight::Metadata) }
 
   shared_examples Stoplight::Light::GreenRunStrategy do
     context "when code executes successfully" do
-      subject(:result) { strategy.execute(nil, &code) }
+      subject(:result) { strategy.execute(nil, metadata:, &code) }
 
       let(:code) { -> { "Success" } }
 
@@ -28,7 +29,7 @@ RSpec.describe Stoplight::Light::GreenRunStrategy do
     end
 
     context "when code fails" do
-      subject(:result) { strategy.execute(fallback, &code) }
+      subject(:result) { strategy.execute(fallback, metadata:, &code) }
 
       let(:error) { StandardError.new("Test error") }
       let(:code) { -> { raise error } }
@@ -156,7 +157,7 @@ RSpec.describe Stoplight::Light::GreenRunStrategy do
       let(:redis) { Redis.new(url: "redis://561922f7-6b30-49d3-8148-324922d590d2:6379/0") }
 
       context "when code fails with fallback" do
-        subject(:result) { strategy.execute(->(e) { "whoops" }, &code) }
+        subject(:result) { strategy.execute(->(e) { "whoops" }, metadata:, &code) }
 
         let(:error) { StandardError.new("Test error") }
         let(:code) { -> { raise error } }

--- a/spec/stoplight/light/red_run_strategy_spec.rb
+++ b/spec/stoplight/light/red_run_strategy_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe Stoplight::Light::RedRunStrategy do
   subject(:strategy) { described_class.new(config) }
 
   let(:config) { Stoplight.default_config.with(name: "foo", data_store:) }
+  let(:metadata) { instance_double(Stoplight::Metadata) }
 
   shared_examples Stoplight::Light::RedRunStrategy do
-    subject(:result) { strategy.execute(fallback) { 42 } }
+    subject(:result) { strategy.execute(fallback, metadata:) { 42 } }
 
     context "when fallback is provided" do
       let(:fallback) {

--- a/spec/stoplight/light/run_strategy_spec.rb
+++ b/spec/stoplight/light/run_strategy_spec.rb
@@ -8,9 +8,10 @@ RSpec.describe Stoplight::Light::RunStrategy do
 
     let(:config) { instance_double(Stoplight::Light::Config, data_store:) }
     let(:data_store) { instance_double(Stoplight::DataStore::Base) }
+    let(:metadata) { instance_double(Stoplight::Metadata) }
 
     it "raises NotImplementedError" do
-      expect { strategy.execute(nil) {} }.to raise_error(NotImplementedError)
+      expect { strategy.execute(nil, metadata:) {} }.to raise_error(NotImplementedError)
     end
   end
 end

--- a/spec/stoplight/light/yellow_run_strategy_spec.rb
+++ b/spec/stoplight/light/yellow_run_strategy_spec.rb
@@ -14,12 +14,29 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
   end
   let(:notifier) { instance_double(Stoplight::Notifier::Base) }
   let(:traffic_recovery) { Stoplight::TrafficRecovery::ConsecutiveSuccesses.new }
-  let(:metadata) { instance_double(Stoplight::Metadata) }
+  let(:in_metadata) { instance_double(Stoplight::Metadata, color: Stoplight::Color::YELLOW, recovery_scheduled_after:) }
+  let(:out_metadata) { instance_double(Stoplight::Metadata) }
+  let(:recovery_scheduled_after) { nil }
 
   shared_examples Stoplight::Light::YellowRunStrategy do
     shared_examples "recovery success" do
       before do
-        expect(traffic_recovery).to receive(:determine_color).with(config, metadata).and_return(recovery_result)
+        expect(traffic_recovery).to receive(:determine_color).with(config, out_metadata).and_return(recovery_result)
+      end
+
+      context "when it enters yellow state after cool off time expiring" do
+        let(:recovery_result) { Stoplight::TrafficRecovery::GREEN }
+        let(:recovery_scheduled_after) { Time.now - 10 }
+
+        let(:code) { -> { "Success" } }
+
+        it "transitions to yellow before the probe" do
+          expect(notifier).to receive(:notify).with(config, Stoplight::Color::RED, Stoplight::Color::YELLOW, nil)
+          expect(notifier).to receive(:notify).with(config, Stoplight::Color::YELLOW, Stoplight::Color::GREEN, nil)
+          expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(out_metadata)
+
+          expect(result).to eq("Success")
+        end
       end
 
       context "when recovery strategy returns PASS" do
@@ -28,7 +45,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
         it "does not make any recovery decisions" do
           expect(data_store).not_to receive(:transition_to_color)
           expect(notifier).not_to receive(:notify)
-          allow(data_store).to receive(:record_recovery_probe_success).with(config).and_return(metadata)
+          allow(data_store).to receive(:record_recovery_probe_success).with(config).and_return(out_metadata)
 
           suppress(StandardError) { result }
         end
@@ -44,7 +61,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
           it "records success, notify and returns result" do
             expect(notifier).to receive(:notify).with(config, Stoplight::Color::YELLOW, Stoplight::Color::GREEN, nil)
-            expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(metadata)
+            expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(out_metadata)
 
             suppress(StandardError) { result }
           end
@@ -57,7 +74,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
           it "records success and returns result without a notification" do
             expect(notifier).not_to receive(:notify)
-            expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(metadata)
+            expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(out_metadata)
 
             suppress(StandardError) { result }
           end
@@ -74,7 +91,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
           it "records success, notify and returns result" do
             expect(notifier).to receive(:notify).with(config, Stoplight::Color::YELLOW, Stoplight::Color::RED, nil)
-            expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(metadata)
+            expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(out_metadata)
 
             suppress(StandardError) { result }
           end
@@ -87,7 +104,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
           it "records success and returns result without a notification" do
             expect(notifier).not_to receive(:notify)
-            expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(metadata)
+            expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(out_metadata)
 
             suppress(StandardError) { result }
           end
@@ -104,7 +121,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
           it "records failure, notify and raises an exception" do
             expect(notifier).to receive(:notify).with(config, Stoplight::Color::RED, Stoplight::Color::YELLOW, nil)
-            expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(metadata)
+            expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(out_metadata)
 
             suppress(StandardError) { result }
           end
@@ -117,7 +134,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
           it "records failure, raises an exception without a notification" do
             expect(notifier).not_to receive(:notify)
-            expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(metadata)
+            expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(out_metadata)
 
             suppress(StandardError) { result }
           end
@@ -129,7 +146,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
         it "raises an error" do
           expect(notifier).not_to receive(:notify)
-          expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(metadata)
+          expect(data_store).to receive(:record_recovery_probe_success).with(config).and_return(out_metadata)
 
           expect { result }.to raise_error(/recovery strategy returned an expected color/)
         end
@@ -137,7 +154,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
     end
 
     context "when code executes successfully" do
-      subject(:result) { strategy.execute(nil, &code) }
+      subject(:result) { strategy.execute(nil, metadata: in_metadata, &code) }
 
       let(:code) { -> { "Success" } }
       let(:failures) { [Stoplight::Failure.from_error(StandardError.new)] }
@@ -146,7 +163,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
     end
 
     context "when code fails" do
-      subject(:result) { strategy.execute(fallback, &code) }
+      subject(:result) { strategy.execute(fallback, metadata: in_metadata, &code) }
 
       let(:error) { StandardError.new("Test error") }
       let(:code) { -> { raise error } }
@@ -158,7 +175,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
           let(:fallback) { nil }
 
           before do
-            expect(traffic_recovery).to receive(:determine_color).with(config, metadata).and_return(recovery_result)
+            expect(traffic_recovery).to receive(:determine_color).with(config, out_metadata).and_return(recovery_result)
           end
 
           context "when recovery strategy returns GREEN" do
@@ -174,7 +191,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
                 Timecop.freeze do
                   failure = Stoplight::Failure.from_error(error)
-                  expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(metadata)
+                  expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(out_metadata)
 
                   expect { result }.to raise_error(error)
                 end
@@ -191,7 +208,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
                 Timecop.freeze do
                   failure = Stoplight::Failure.from_error(error)
-                  expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(metadata)
+                  expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(out_metadata)
 
                   expect { result }.to raise_error(error)
                 end
@@ -212,7 +229,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
                 Timecop.freeze do
                   failure = Stoplight::Failure.from_error(error)
-                  expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(metadata)
+                  expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(out_metadata)
 
                   expect { result }.to raise_error(error)
                 end
@@ -229,7 +246,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
                 Timecop.freeze do
                   failure = Stoplight::Failure.from_error(error)
-                  expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(metadata)
+                  expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(out_metadata)
 
                   expect { result }.to raise_error(error)
                 end
@@ -250,7 +267,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
                 Timecop.freeze do
                   failure = Stoplight::Failure.from_error(error)
-                  expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(metadata)
+                  expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(out_metadata)
 
                   expect { result }.to raise_error(error)
                 end
@@ -267,7 +284,7 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
                 Timecop.freeze do
                   failure = Stoplight::Failure.from_error(error)
-                  expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(metadata)
+                  expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(out_metadata)
 
                   expect { result }.to raise_error(error)
                 end
@@ -286,11 +303,11 @@ RSpec.describe Stoplight::Light::YellowRunStrategy do
 
           it "records a failed recovery probe and returns fallback" do
             allow(notifier).to receive(:notify)
-            expect(traffic_recovery).to receive(:determine_color).with(config, metadata).and_return(Stoplight::TrafficRecovery::YELLOW)
+            expect(traffic_recovery).to receive(:determine_color).with(config, out_metadata).and_return(Stoplight::TrafficRecovery::YELLOW)
 
             Timecop.freeze do
               failure = Stoplight::Failure.from_error(error)
-              expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(metadata)
+              expect(data_store).to receive(:record_recovery_probe_failure).with(config, failure).and_return(out_metadata)
               expect(result).to eq("Fallback")
             end
 

--- a/spec/stoplight/light_spec.rb
+++ b/spec/stoplight/light_spec.rb
@@ -126,8 +126,9 @@ RSpec.describe Stoplight::Light do
   end
 
   context "with memory data store" do
-    let(:config) { Stoplight.default_config.with(name: random_string, data_store:) }
+    let(:config) { Stoplight.default_config.with(name: random_string, data_store:, notifiers: [notifier]) }
     let(:data_store) { Stoplight::DataStore::Memory.new }
+    let(:notifier) { instance_double(Stoplight::Notifier::Base) }
 
     it_behaves_like "Stoplight::Light#state"
     it_behaves_like "Stoplight::Light#color"
@@ -135,8 +136,9 @@ RSpec.describe Stoplight::Light do
   end
 
   context "with redis data store", :redis do
-    let(:config) { Stoplight.default_config.with(name: random_string, data_store:) }
+    let(:config) { Stoplight.default_config.with(name: random_string, data_store:, notifiers: [notifier]) }
     let(:data_store) { Stoplight::DataStore::Redis.new(redis) }
+    let(:notifier) { instance_double(Stoplight::Notifier::Base) }
 
     it_behaves_like "Stoplight::Light#state"
     it_behaves_like "Stoplight::Light#color"

--- a/spec/stoplight/metadata_spec.rb
+++ b/spec/stoplight/metadata_spec.rb
@@ -3,18 +3,20 @@
 require "spec_helper"
 
 RSpec.describe Stoplight::Metadata do
+  let(:current_time) { Time.now }
+
   describe "#color" do
-    subject(:color) { metadata.color(at: current_time) }
+    subject(:color) { metadata.color }
 
     let(:metadata) do
       Stoplight::Metadata.new(
         locked_state:,
         recovery_scheduled_after:,
         recovery_started_at:,
-        breached_at:
+        breached_at:,
+        current_time:
       )
     end
-    let(:current_time) { Time.now }
     let(:recovery_scheduled_after) { nil }
     let(:locked_state) { nil }
     let(:recovery_started_at) { nil }
@@ -55,7 +57,7 @@ RSpec.describe Stoplight::Metadata do
 
   describe "#error_rate" do
     context "when there successes or errors are nil" do
-      let(:metadata) { Stoplight::Metadata.new(successes: nil, errors: nil) }
+      let(:metadata) { Stoplight::Metadata.new(successes: nil, errors: nil, current_time:) }
 
       it "returns 0" do
         expect(metadata.error_rate).to eq(0)
@@ -63,7 +65,7 @@ RSpec.describe Stoplight::Metadata do
     end
 
     context "when there are no successes or errors" do
-      let(:metadata) { Stoplight::Metadata.new(successes: 0, errors: 0) }
+      let(:metadata) { Stoplight::Metadata.new(successes: 0, errors: 0, current_time:) }
 
       it "returns 0" do
         expect(metadata.error_rate).to eq(0)
@@ -71,7 +73,7 @@ RSpec.describe Stoplight::Metadata do
     end
 
     context "when there are successes and errors" do
-      let(:metadata) { Stoplight::Metadata.new(successes: 10, errors: 5) }
+      let(:metadata) { Stoplight::Metadata.new(successes: 10, errors: 5, current_time:) }
 
       it "returns the error rate" do
         expect(metadata.error_rate).to eq(5.fdiv(15))
@@ -82,7 +84,7 @@ RSpec.describe Stoplight::Metadata do
   describe "#with" do
     subject { metadata.with(successes: "42") }
 
-    let(:metadata) { Stoplight::Metadata.new }
+    let(:metadata) { Stoplight::Metadata.new(current_time:) }
 
     it "applies constructor logic" do
       is_expected.to have_attributes(successes: 42)

--- a/spec/stoplight/traffic_control/error_rate_spec.rb
+++ b/spec/stoplight/traffic_control/error_rate_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe Stoplight::TrafficControl::ErrorRate do
   subject(:traffic_control) { described_class.new }
 
+  let(:current_time) { Time.now }
+
   describe "#check_compatibility" do
     subject(:availability) { traffic_control.check_compatibility(config) }
 
@@ -65,7 +67,7 @@ RSpec.describe Stoplight::TrafficControl::ErrorRate do
     let(:config) { instance_double(Stoplight::Light::Config, window_size: 300, threshold: 0.6) }
 
     let(:metadata) do
-      Stoplight::Metadata.new(successes:, errors:)
+      Stoplight::Metadata.new(successes:, errors:, current_time:)
     end
 
     context "when there are no requests" do

--- a/spec/stoplight/traffic_recovery/consecutive_successes_spec.rb
+++ b/spec/stoplight/traffic_recovery/consecutive_successes_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe Stoplight::TrafficRecovery::ConsecutiveSuccesses do
         recovery_probe_successes:,
         last_error_at:,
         recovery_started_at:,
-        recovery_scheduled_after:
+        recovery_scheduled_after:,
+        current_time: Time.now
       )
     end
     let(:last_error_at) { recovery_started_at - 60 }


### PR DESCRIPTION
Fixes #438 - Missing RED→YELLOW transition notifications

The issue was that time-based RED→YELLOW transitions (when `recovery_scheduled_after` expires) weren't sending notifications, breaking the deduplication logic and causing missing notifications in complex sequences.

- RED→YELLOW notifications now happen in `YellowRunStrategy#execute`, giving strategies access to full metadata context
- All run strategies now receive metadata to enable consistent transition handling  
- Made `current_time` a required parameter in `Metadata` constructor to eliminate race conditions where color calculations used different time contexts
- Use `Timecop.freeze` to ensure deterministic timing behavior

The fix ensures all automatic transitions trigger proper notifications, maintaining the notification chain required for the deduplication mechanism to work correctly.
