### PR TITLE
Implement automatic failover to in-memory data store when Redis unavailable

### DIFF
--- a/lib/stoplight/config/system_config.rb
+++ b/lib/stoplight/config/system_config.rb
@@ -2,6 +2,9 @@
 
 module Stoplight
   module Config
-    SystemConfig = LibraryDefaultConfig
+    SystemConfig = LibraryDefaultConfig.with(
+      traffic_recovery: :consecutive_successes,
+      recovery_threshold: 3
+    )
   end
 end

--- a/lib/stoplight/data_store/fail_safe.rb
+++ b/lib/stoplight/data_store/fail_safe.rb
@@ -10,10 +10,6 @@ module Stoplight
     #
     # @api private
     class FailSafe < Base
-      # @!attribute [r] data_store
-      #   @return [Stoplight::DataStore::Base] The underlying data store being wrapped.
-      protected attr_reader :data_store
-
       class << self
         # Wraps a data store with fail-safe mechanisms.
         #
@@ -30,62 +26,70 @@ module Stoplight
         end
       end
 
+      # @!attribute data_store
+      #  @return [Stoplight::DataStore::Base] The underlying primary data store being used
+      protected attr_reader :data_store
+
+      # @!attribute failover_data_store
+      #   @return [Stoplight::DataStore::Base] The fallback data store used when the primary fails.
+      private attr_reader :failover_data_store
+
+      # @!attribute circuit_breaker
+      #   @return [Stoplight::Light] The circuit breaker used to handle data store failures.
+      private attr_reader :circuit_breaker
+
       # @param data_store [Stoplight::DataStore::Base]
       def initialize(data_store)
         @data_store = data_store
-        @circuit_breaker = Stoplight(
-          "stoplight:data_store:fail_safe:#{data_store.class.name}",
-          data_store: Default::DATA_STORE,
-          traffic_control: TrafficControl::ConsecutiveErrors.new,
-          threshold: Default::THRESHOLD
-        )
+        @failover_data_store = Default::DATA_STORE
+        @circuit_breaker = Stoplight.system_light("stoplight:data_store:fail_safe:#{data_store.class.name}")
       end
 
       def names
-        with_fallback([]) do
+        with_fallback(:names) do
           data_store.names
         end
       end
 
-      def get_metadata(config)
-        with_fallback(Metadata.new, config) do
-          data_store.get_metadata(config)
+      def get_metadata(config, *args, **kwargs)
+        with_fallback(:get_metadata, config, *args, **kwargs) do
+          data_store.get_metadata(config, *args, **kwargs)
         end
       end
 
-      def record_failure(config, failure)
-        with_fallback(Metadata.new, config) do
-          data_store.record_failure(config, failure)
+      def record_failure(config, *args, **kwargs)
+        with_fallback(:record_failure, config, *args, **kwargs) do
+          data_store.record_failure(config, *args, **kwargs)
         end
       end
 
-      def record_success(config, **args)
-        with_fallback(nil, config) do
-          data_store.record_success(config, **args)
+      def record_success(config, *args, **kwargs)
+        with_fallback(:record_success, config, *args, **kwargs) do
+          data_store.record_success(config, *args, **kwargs)
         end
       end
 
-      def record_recovery_probe_success(config, **args)
-        with_fallback(Metadata.new, config) do
-          data_store.record_recovery_probe_success(config, **args)
+      def record_recovery_probe_success(config, *args, **kwargs)
+        with_fallback(:record_recovery_probe_success, config, *args, **kwargs) do
+          data_store.record_recovery_probe_success(config, *args, **kwargs)
         end
       end
 
-      def record_recovery_probe_failure(config, failure)
-        with_fallback(Metadata.new, config) do
-          data_store.record_recovery_probe_failure(config, failure)
+      def record_recovery_probe_failure(config, *args, **kwargs)
+        with_fallback(:record_recovery_probe_failure, config, *args, **kwargs) do
+          data_store.record_recovery_probe_failure(config, *args, **kwargs)
         end
       end
 
-      def set_state(config, state)
-        with_fallback(State::UNLOCKED, config) do
-          data_store.set_state(config, state)
+      def set_state(config, *args, **kwargs)
+        with_fallback(:set_state, config, *args, **kwargs) do
+          data_store.set_state(config, *args, **kwargs)
         end
       end
 
-      def transition_to_color(config, color)
-        with_fallback(false, config) do
-          data_store.transition_to_color(config, color)
+      def transition_to_color(config, *args, **kwargs)
+        with_fallback(:transition_to_color, config, *args, **kwargs) do
+          data_store.transition_to_color(config, *args, **kwargs)
         end
       end
 
@@ -93,20 +97,15 @@ module Stoplight
         other.is_a?(self.class) && other.data_store == data_store
       end
 
-      # @param default [Object, nil]
-      # @param config [Stoplight::Light::Config]
-      private def with_fallback(default = nil, config = nil, &code)
+      # @param method_name [Symbol] protected method name
+      private def with_fallback(method_name, *args, **kwargs, &code)
         fallback = proc do |error|
+          config = args.first
           config.error_notifier.call(error) if config && error
-          default
+          @failover_data_store.public_send(method_name, *args, **kwargs)
         end
 
         circuit_breaker.run(fallback, &code)
-      end
-
-      # @return [Stoplight::Light] The circuit breaker used to handle failures.
-      private def circuit_breaker
-        @circuit_breaker ||= Stoplight.system_light("stoplight:data_store:fail_safe:#{data_store.class.name}")
       end
     end
   end

--- a/spec/stoplight/data_store/fail_safe_spec.rb
+++ b/spec/stoplight/data_store/fail_safe_spec.rb
@@ -5,8 +5,9 @@ require "spec_helper"
 RSpec.describe Stoplight::DataStore::FailSafe do
   let(:fail_safe) { described_class.new(data_store) }
   let(:data_store) { instance_double(Stoplight::DataStore::Base) }
+  let(:config) { Stoplight.default_config.with(name:, error_notifier:) }
   let(:error_notifier) { instance_double(Proc) }
-  let(:config) { instance_double(Stoplight::Light::Config, error_notifier:) }
+  let(:name) { SecureRandom.uuid }
   let(:error) { StandardError.new("Test error") }
 
   it_behaves_like "Stoplight::DataStore::Base"
@@ -28,7 +29,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
       it "returns empty list of names" do
         expect(data_store).to receive(:names) { raise error }
 
-        is_expected.to eq([])
+        is_expected.to be_kind_of(Array)
       end
     end
   end
@@ -173,7 +174,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
         expect(error_notifier).to receive(:call).with(error)
         expect(data_store).to receive(:set_state).with(config, state) { raise error }
 
-        is_expected.to eq(Stoplight::State::UNLOCKED)
+        is_expected.to eq(Stoplight::State::LOCKED_GREEN)
       end
     end
   end
@@ -199,7 +200,7 @@ RSpec.describe Stoplight::DataStore::FailSafe do
         expect(error_notifier).to receive(:call).with(error)
         expect(data_store).to receive(:transition_to_color).with(config, color).and_raise(error)
 
-        is_expected.to eq(false)
+        is_expected.to eq(true)
       end
     end
   end
@@ -229,6 +230,36 @@ RSpec.describe Stoplight::DataStore::FailSafe do
       it "returns a new FailSafe instance wrapping the data_store" do
         is_expected.to be_a(described_class)
         expect(subject.instance_variable_get(:@data_store)).to eq(data_store)
+      end
+    end
+  end
+
+  describe "faulty data store" do
+    let(:data_store) { instance_double(Stoplight::DataStore::Base) }
+
+    it "when primary store fails" do
+      # Prepare: move internal circuit breaker into the red state
+      allow(data_store).to receive(:names).and_raise(Redis::TimeoutError)
+      Stoplight::Config::SystemConfig.threshold.times do
+        expect { fail_safe.names }.not_to raise_error
+      end
+
+      # Verify: now the fallback data store is used
+      RSpec::Mocks.space.proxy_for(data_store).reset
+      allow(data_store).to receive(:names)
+      allow(data_store).to receive(:record_success)
+
+      fail_safe.record_success(config)
+      expect(fail_safe.names).to include(config.name)
+
+      expect(data_store).not_to have_received(:record_success), "expected to use fallback data store without trying primary"
+      expect(data_store).not_to have_received(:names), "expected to use fallback data store without trying primary"
+
+      # After cool_off_time, the primary data store is tried again
+      Timecop.travel(Time.now + Stoplight::Config::SystemConfig.cool_off_time) do
+        expect(data_store).to receive(:names).and_return(["recovered"])
+
+        expect(fail_safe.names).to eq(["recovered"])
       end
     end
   end


### PR DESCRIPTION
Previously, when the Redis data store became unavailable, Stoplight would return empty default values (`[]`, `{}`, `nil`) instead of maintaining circuit breaker functionality. This caused circuit breakers to appear functional but unable to track failures or transition states, leaving protected services vulnerable during Redis outages.

This PR changes this behaviour. When Redis becomes unavailable, automatically switch to in-memory data store to maintain full circuit breaker functionality.

Impact:
- Circuit breakers remain fully functional during Redis outages
- Protected services continue to be protected with proper failure tracking
- Zero-latency failover once circuit opens (no Redis timeout delays)
- Automatic recovery when Redis becomes available again

Closes #419