### PR TITLE
Validate traffic recovery compatibility when calling Light#with

### DIFF
--- a/lib/stoplight/light/config.rb
+++ b/lib/stoplight/light/config.rb
@@ -82,6 +82,7 @@ module Stoplight
       # @return [Stoplight::Light::Config] The validated configuration object.
       def validate_config!
         validate_traffic_control_compatibility!
+        validate_traffic_recovery_compatibility!
         self
       end
 

--- a/spec/stoplight/light/config_spec.rb
+++ b/spec/stoplight/light/config_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe Stoplight::Light::Config do
 
       let(:recovery_threshold) { 50 }
 
-      context "when an instance of TrafficRecovery::Base" do
+      context "when TrafficRecovery::ConsecutiveSuccesses" do
         let(:traffic_recovery) { Stoplight::TrafficRecovery::ConsecutiveSuccesses.new }
 
         it "returns the same traffic recovery object" do
@@ -244,6 +244,19 @@ RSpec.describe Stoplight::Light::Config do
           ERROR
         end
       end
+
+      context "when traffic recovery is not compatible with the config" do
+        let(:traffic_recovery) { :consecutive_successes }
+        let(:recovery_threshold) { 0 } # must be >0
+
+        it "raises a configuration errors" do
+          expect { traffic_recovery_out }.to raise_error(
+            Stoplight::Error::ConfigurationError,
+            "Stoplight::TrafficControl::ConsecutiveErrors strategy is incompatible with the Stoplight configuration: " \
+              "`recovery_threshold` should be bigger than 0"
+          )
+        end
+      end
     end
 
     describe "traffic_control" do
@@ -258,7 +271,7 @@ RSpec.describe Stoplight::Light::Config do
 
       let(:threshold) { 50 }
 
-      context "when an instance of TrafficControl::Base" do
+      context "when TrafficControl::ConsecutiveErrors" do
         let(:traffic_control) { Stoplight::TrafficControl::ConsecutiveErrors.new }
 
         it "returns the same traffic control object" do


### PR DESCRIPTION
We didn't run traffic recovery validation when instantiating a new or extending existing light which coul've caused an incompatible configuration and runtime failure.

Before the fix:

```ruby
> Stoplight("foo", traffic_recovery: :consecutive_successes, recovery_threshold: 0.25)
=> #<Stoplight::Light:0x0000000106740160
```

After the fix:

```ruby
Stoplight("foo", traffic_recovery: :consecutive_successes, recovery_threshold: 0.25)
stoplight/lib/stoplight/light/config.rb:104:in `block in validate_traffic_recovery_compatibility!': Stoplight::TrafficControl::ConsecutiveErrors strategy is incompatible with the Stoplight configuration: `recovery_threshold` should be an integer (Stoplight::Error::ConfigurationError)
	from <internal:kernel>:124:in `then'
```