### PR TITLE
Attach current config to a RedLight exception

### DIFF
--- a/lib/stoplight/error.rb
+++ b/lib/stoplight/error.rb
@@ -5,6 +5,14 @@ module Stoplight
     Base = Class.new(StandardError)
     ConfigurationError = Class.new(Base)
     IncorrectColor = Class.new(Base)
-    RedLight = Class.new(Base)
+
+    class RedLight < Base
+      attr_reader :config
+
+      def initialize(message, config: nil)
+        @config = config
+        super(message)
+      end
+    end
   end
 end

--- a/lib/stoplight/light/red_run_strategy.rb
+++ b/lib/stoplight/light/red_run_strategy.rb
@@ -19,7 +19,7 @@ module Stoplight
         if fallback
           fallback.call(nil)
         else
-          raise Error::RedLight, config.name
+          raise Error::RedLight.new(config.name, config: config)
         end
       end
     end

--- a/spec/stoplight/light/red_run_strategy_spec.rb
+++ b/spec/stoplight/light/red_run_strategy_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe Stoplight::Light::RedRunStrategy do
       it "records and raises the error" do
         expect { result }.to raise_error(Stoplight::Error::RedLight, config.name)
       end
+
+      context "with custom light config" do
+        let(:config) { Stoplight("bar", cool_off_time: 42).config }
+
+        it "attaches the config to the error" do
+          expect { result }.to raise_error { |error| expect(error.config.cool_off_time).to eq(42) }
+        end
+      end
     end
   end
 


### PR DESCRIPTION
In some cases I would like to get specific light settings from a `Stoplight::Error::RedLight` exception that can be rescued at some top level where it can be unclear which circuit breaker was triggered.

E.g. to calculate background job retry time from specific light cool off time:

```ruby
class JobWithCustomRetry
  include Sidekiq::Job

  sidekiq_retry_in do |count, exception, _jobhash|
    case exception
    when Stoplight::Error::RedLight
      exception.config.cool_off_time * (count + 1)
    end
  end

  def perform(...)
  end
end
```

See [Sidekiq Error Handling](https://github.com/sidekiq/sidekiq/wiki/Error-Handling) for details on this example.

Right now only light name is available as exception message and, as far as I understand the code, it is not possible to get an existing instance with previously defined config from just a light name.