### PR TITLE
Fix incorrect failure count in Admin Dashboard

### DIFF
--- a/lib/stoplight/admin/lights_repository.rb
+++ b/lib/stoplight/admin/lights_repository.rb
@@ -75,7 +75,8 @@ module Stoplight
           name: name,
           color: state_snapshot.color,
           state: state_snapshot.locked_state,
-          failures: [metrics.last_error].compact
+          failures: [metrics.last_error].compact,
+          failure_count: metrics.consecutive_errors
         )
       end
 

--- a/lib/stoplight/admin/lights_repository/light.rb
+++ b/lib/stoplight/admin/lights_repository/light.rb
@@ -37,16 +37,23 @@ module Stoplight
         # @dynamic failures
         attr_reader :failures
 
+        # @!attribute failure_count
+        #   @return [Integer]
+        # @dynamic failure_count
+        attr_reader :failure_count
+
         # @param name [String]
         # @param color [String]
         # @param state [String]
         # @param failures [<Stoplight::Failure>]
-        def initialize(name:, color:, state:, failures:)
+        # @param failure_count [Integer, nil]
+        def initialize(name:, color:, state:, failures:, failure_count: nil)
           @id = SecureRandom.uuid
           @name = name
           @color = color
           @state = state
           @failures = failures
+          @failure_count = failure_count
         end
 
         def latest_failure

--- a/lib/stoplight/admin/views/_card.erb
+++ b/lib/stoplight/admin/views/_card.erb
@@ -117,7 +117,7 @@
   <!-- Stats Row -->
   <div class="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-3">
     <div>
-      <span class="font-medium">Failures:</span> <%= light.failures.count  %>
+      <span class="font-medium">Failures:</span> <%= light.failure_count %>
     </div>
 
     <% light.last_check_in_words.then do |last_check| %>

--- a/spec/unit/stoplight/admin_spec.rb
+++ b/spec/unit/stoplight/admin_spec.rb
@@ -43,6 +43,26 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
         expect(last_response.body).not_to include("Ensure that your Stoplight data store is properly configured and that your Stoplight blocks have been run.")
       end
     end
+
+    context "when light has multiple consecutive failures" do
+      let(:light) { Stoplight("failing") }
+
+      before do
+        3.times do
+          light.run { raise "whoops" }
+        rescue
+          nil
+        end
+      end
+
+      it "displays the correct failure count" do
+        get "/"
+
+        expect(last_response).to be_ok
+
+        expect(last_response.body).to include(">Failures:</span> 3")
+      end
+    end
   end
 
   describe "GET /stats" do


### PR DESCRIPTION
Fixes #599 

### Motivation

The Admin Dashboard was displaying "Failures: 1" regardless of the actual number of consecutive errors that tripped the circuit.

### Solution

Previously, the view calculated the count based on the `failures` array.
However, this array contained only the most recent error (at most 1 element).

This was incorrect because it didn't reflect the actual consecutive failure count that the circuit breaker uses for its logic. I have updated the class to fetch the actual `consecutive_errors` metric and pass it through to the view.

### Reproduction

I tested the solution using the reproduction script provided in the issue (see #599 for the full script).
This script triggers 3 failures to trip a circuit with a threshold of 3.

**Before:**
<img width="450" alt="image" src="https://github.com/user-attachments/assets/e041f0e9-f6c9-4860-b135-2e368bc55b6e" />

**After:**
(count fixed)
 <img width="450" alt="image" src="https://github.com/user-attachments/assets/6a5f3a7f-1642-492e-a2dc-3e50823cf5a3" />

