### PR TITLE
refactor: Slightly adjust Admin panel design

### DIFF
--- a/lib/stoplight/admin/views/_card.erb
+++ b/lib/stoplight/admin/views/_card.erb
@@ -1,4 +1,4 @@
-<div class="max-w-xl mr-5 p-6 border border-gray-200 rounded-lg shadow-sm dark:bg-gray-800 dark:border-gray-700">
+<div class="flex flex-col max-w-xl mr-5 p-6 border border-gray-200 rounded-lg shadow-sm dark:bg-gray-800 dark:border-gray-700">
   <div class="flex items-center">
     <% light_name = CGI.escape(light.name) %>
 
@@ -107,7 +107,7 @@
         <p><%= light.description_comment %></p>
       </div>
       <% if light.latest_failure %>
-        <div class="whitespace-nowrap text-center">
+        <div class="whitespace-nowrap text-center" style="margin-bottom: auto;">
           <%= light.latest_failure.time.strftime("%F %T") %>
           <span class="text-gray-400 dark:text-gray-500 uppercase tracking-wide">
             UTC
@@ -118,7 +118,7 @@
   </div>
 
   <!-- Stats Row -->
-  <div class="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-3">
+  <div class="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-3" style="margin-top: auto;">
     <div>
       <span class="font-medium">Failures:</span> <%= light.failure_count %>
     </div>

--- a/lib/stoplight/admin/views/index.erb
+++ b/lib/stoplight/admin/views/index.erb
@@ -28,7 +28,13 @@
     </div>
   </section>
 <% else %>
-  <section class="grid gap-4" style="grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));">
+  <style nonce="<%= nonce %>">
+    .lights-grid { grid-template-columns: 1fr; }
+    @media (min-width: 800px) {
+      .lights-grid { grid-template-columns: repeat(auto-fill, 500px); }
+    }
+  </style>
+  <section class="grid gap-4 lights-grid">
     <% lights.each do |light| %>
       <%= erb :_card, locals: { light:, color: light.color } %>
     <% end %>

--- a/lib/stoplight/admin/views/layout.erb
+++ b/lib/stoplight/admin/views/layout.erb
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flowbite@3.1.2/dist/flowbite.min.css" />
   </head>
   <body>
-    <div class="antialiased bg-gray-50 dark:bg-gray-900 h-screen flex flex-col justify-between">
+    <div class="antialiased bg-gray-50 dark:bg-gray-900 min-h-screen flex flex-col justify-between">
       <div>
         <nav class="bg-white border-gray-200 dark:bg-gray-900">
           <div class="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">

--- a/lib/stoplight/admin/views/layout.erb
+++ b/lib/stoplight/admin/views/layout.erb
@@ -14,7 +14,7 @@
     </script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flowbite@3.1.2/dist/flowbite.min.css" />
   </head>
-  <body>
+  <body class="bg-gray-50 dark:bg-gray-900">
     <div class="antialiased bg-gray-50 dark:bg-gray-900 min-h-screen flex flex-col justify-between">
       <div>
         <nav class="bg-white border-gray-200 dark:bg-gray-900">

--- a/lib/stoplight/admin/views/layout.erb
+++ b/lib/stoplight/admin/views/layout.erb
@@ -15,8 +15,8 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flowbite@3.1.2/dist/flowbite.min.css" />
   </head>
   <body class="bg-gray-50 dark:bg-gray-900">
-    <div class="antialiased bg-gray-50 dark:bg-gray-900 min-h-screen flex flex-col justify-between">
-      <div>
+    <div class="antialiased bg-gray-50 dark:bg-gray-900 flex flex-col" style="min-height: 100vh;">
+      <div class="grow">
         <nav class="bg-white border-gray-200 dark:bg-gray-900">
           <div class="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
             <a href="<%= url('/') %>" class="flex items-center space-x-3 rtl:space-x-reverse">

--- a/lib/stoplight/admin/views/layout.erb
+++ b/lib/stoplight/admin/views/layout.erb
@@ -18,7 +18,7 @@
     <div class="antialiased bg-gray-50 dark:bg-gray-900 flex flex-col" style="min-height: 100vh;">
       <div class="grow">
         <nav class="bg-white border-gray-200 dark:bg-gray-900">
-          <div class="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
+          <div class="flex flex-wrap items-center justify-between p-4">
             <a href="<%= url('/') %>" class="flex items-center space-x-3 rtl:space-x-reverse">
               🚦
               <span class="self-center text-2xl font-semibold whitespace-nowrap dark:text-white">Stoplight Admin</span>


### PR DESCRIPTION
This PR attempts to slightly improve Admin panel design:

1. Cards alignment on the grid. Currently cards behave a little bit weird if we have only two of them. I think that if we stick them to the left side it would look better.

| Before | After |
| ------ | ----- |
| <img width="1728" height="885" alt="Screenshot 2026-05-01 at 17 27 14" src="https://github.com/user-attachments/assets/652d74a0-dd07-44ed-9e60-f522dfbdad54" /> | <img width="1728" height="885" alt="Screenshot 2026-05-01 at 17 28 06" src="https://github.com/user-attachments/assets/eda8069a-7c8b-469c-985c-a8203a1ac737" /> |

2. Our background cuts after one screen. So if user have a lot of lights and scrolls down background changes to plain white background.