### PR TITLE
Optimize light configuration and caching

### DIFF
--- a/bench/system_light.rb
+++ b/bench/system_light.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "benchmark/ips"
+require_relative "../lib/stoplight"
+Stoplight(SecureRandom.uuid, threshold: 10)
+
+system = Stoplight.__stoplight__system("default")
+
+Benchmark.ips do |b|
+  b.report("before") { system.light("bar", threshold: 4) }
+  b.hold!("cache")
+  b.report("after") { system.light("bar", threshold: 4) }
+
+  b.compare!
+end

--- a/bench/system_light_prof.rb
+++ b/bench/system_light_prof.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "ruby-prof"
+require_relative "../lib/stoplight"
+require "redis"
+require "fileutils"
+
+# Create output directory
+FileUtils.mkdir_p("profile_results")
+
+PROF_TYPES = {
+  flat: RubyProf::FlatPrinter,
+  graph: RubyProf::GraphHtmlPrinter,
+  callstack: RubyProf::CallStackPrinter
+}.freeze
+
+system = Stoplight.__stoplight__system("default 2")
+system.light("bar", threshold: 4)
+
+def profile_scenario(name, &block)
+  result = RubyProf::Profile.profile do
+    block.call
+  end
+
+  PROF_TYPES.each_pair do |type, klass|
+    File.open("profile_results/#{name}_#{type}.txt", "w") do |file|
+      klass.new(result).print(file)
+    end
+  end
+end
+
+profile_scenario("success") do
+  50.times do
+    system.light("bar", threshold: 4)
+  end
+end
+
+puts "Profiling complete. Results saved in profile_results/ directory."

--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -175,7 +175,7 @@ module Stoplight # rubocop:disable Style/Documentation
           raise ArgumentError, "system `#{name}` is already in use"
         else
           Wiring::System.new(
-            config: Wiring::ConfigurationDsl.new(
+            config: Wiring::SystemConfigurationDsl.new(
               name: name.to_s,
               cool_off_time:,
               threshold:,

--- a/lib/stoplight/domain/traffic_control/consecutive_errors.rb
+++ b/lib/stoplight/domain/traffic_control/consecutive_errors.rb
@@ -41,6 +41,8 @@ module Stoplight
           metrics.consecutive_errors >= config.threshold
         end
 
+        def hash = self.class.hash
+
         def ==(other)
           other.is_a?(self.class)
         end

--- a/lib/stoplight/domain/traffic_control/error_rate.rb
+++ b/lib/stoplight/domain/traffic_control/error_rate.rb
@@ -46,6 +46,8 @@ module Stoplight
           other.is_a?(self.class) && min_requests == other.min_requests
         end
 
+        def hash = [self.class, @min_requests].hash
+
         protected
 
         attr_reader :min_requests

--- a/lib/stoplight/domain/traffic_recovery/consecutive_successes.rb
+++ b/lib/stoplight/domain/traffic_recovery/consecutive_successes.rb
@@ -55,6 +55,8 @@ module Stoplight
           end
         end
 
+        def hash = self.class.hash
+
         def ==(other) = other.is_a?(self.class)
       end
     end

--- a/lib/stoplight/types.rb
+++ b/lib/stoplight/types.rb
@@ -4,7 +4,8 @@ require "singleton"
 
 module Stoplight
   module Types
-    def self.undefined = Undefined.instance
+    UNDEFINED = Undefined.instance
+    def self.undefined = UNDEFINED
 
     # Asserts a value is non-nil, returning it with a narrowed type.
     #

--- a/lib/stoplight/wiring/configuration_dsl.rb
+++ b/lib/stoplight/wiring/configuration_dsl.rb
@@ -22,10 +22,10 @@ module Stoplight
         @threshold = threshold
         @recovery_threshold = recovery_threshold
         @window_size = window_size
-        @tracked_errors = tracked_errors
-        @skipped_errors = skipped_errors
-        @traffic_control = traffic_control
-        @traffic_recovery = traffic_recovery
+        @tracked_errors = tracked_errors.is_a?(Undefined) ? tracked_errors : Array(tracked_errors)
+        @skipped_errors = skipped_errors.is_a?(Undefined) ? skipped_errors : Array(skipped_errors)
+        @traffic_control = traffic_control.is_a?(Undefined) ? traffic_control : LightFactory::TrafficControlDsl.call(traffic_control)
+        @traffic_recovery = traffic_recovery.is_a?(Undefined) ? traffic_recovery : LightFactory::TrafficRecoveryDsl.call(traffic_recovery)
         @error_notifier = error_notifier
         @data_store = data_store
         @notifiers = notifiers
@@ -60,42 +60,10 @@ module Stoplight
       attr_reader :error_notifier
       attr_reader :data_store
       attr_reader :notifiers
-
-      def tracked_errors
-        value = @tracked_errors
-        if value.is_a?(Undefined)
-          value
-        else
-          Array(value)
-        end
-      end
-
-      def skipped_errors
-        value = @skipped_errors
-        if value.is_a?(Undefined)
-          value
-        else
-          Array(value)
-        end
-      end
-
-      def traffic_control
-        value = @traffic_control
-        if value.is_a?(Undefined)
-          value
-        else
-          LightFactory::TrafficControlDsl.call(value)
-        end
-      end
-
-      def traffic_recovery
-        value = @traffic_recovery
-        if value.is_a?(Undefined)
-          value
-        else
-          LightFactory::TrafficRecoveryDsl.call(value)
-        end
-      end
+      attr_reader :tracked_errors
+      attr_reader :skipped_errors
+      attr_reader :traffic_control
+      attr_reader :traffic_recovery
     end
   end
 end

--- a/lib/stoplight/wiring/default_configuration.rb
+++ b/lib/stoplight/wiring/default_configuration.rb
@@ -76,7 +76,7 @@ module Stoplight
 
       # Builds and validates configuration
       def to_config!
-        ConfigurationDsl.new(
+        LegacyConfigurationDsl.new(
           cool_off_time: @cool_off_time,
           threshold: @threshold,
           recovery_threshold: @recovery_threshold,

--- a/lib/stoplight/wiring/legacy_configuration_dsl.rb
+++ b/lib/stoplight/wiring/legacy_configuration_dsl.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Wiring
+    class LegacyConfigurationDsl
+      def initialize(
+        name: T.undefined,
+        cool_off_time: T.undefined,
+        threshold: T.undefined,
+        recovery_threshold: T.undefined,
+        window_size: T.undefined,
+        tracked_errors: T.undefined,
+        skipped_errors: T.undefined,
+        data_store: T.undefined,
+        error_notifier: T.undefined,
+        notifiers: T.undefined,
+        traffic_control: T.undefined,
+        traffic_recovery: T.undefined
+      )
+        @name = name
+        @cool_off_time = cool_off_time
+        @threshold = threshold
+        @recovery_threshold = recovery_threshold
+        @window_size = window_size
+        @tracked_errors = tracked_errors.is_a?(Undefined) ? tracked_errors : Array(tracked_errors)
+        @skipped_errors = skipped_errors.is_a?(Undefined) ? skipped_errors : Array(skipped_errors)
+        @traffic_control = traffic_control.is_a?(Undefined) ? traffic_control : LightFactory::TrafficControlDsl.call(traffic_control)
+        @traffic_recovery = traffic_recovery.is_a?(Undefined) ? traffic_recovery : LightFactory::TrafficRecoveryDsl.call(traffic_recovery)
+        @error_notifier = error_notifier
+        @data_store = data_store
+        @notifiers = notifiers
+      end
+
+      def configure!(default_config)
+        ConfigCompatibilityValidator.call(
+          config: default_config.with(
+            name:,
+            cool_off_time:,
+            threshold:,
+            recovery_threshold:,
+            window_size:,
+            tracked_errors:,
+            skipped_errors:,
+            traffic_control:,
+            traffic_recovery:,
+            error_notifier:,
+            data_store:,
+            notifiers:
+          )
+        )
+      end
+
+      private
+
+      attr_reader :name
+      attr_reader :cool_off_time
+      attr_reader :threshold
+      attr_reader :recovery_threshold
+      attr_reader :window_size
+      attr_reader :error_notifier
+      attr_reader :data_store
+      attr_reader :notifiers
+      attr_reader :tracked_errors
+      attr_reader :skipped_errors
+      attr_reader :traffic_control
+      attr_reader :traffic_recovery
+    end
+  end
+end

--- a/lib/stoplight/wiring/light_configuration_dsl.rb
+++ b/lib/stoplight/wiring/light_configuration_dsl.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Wiring
+    class LightConfigurationDsl
+      def initialize(
+        name: T.undefined,
+        cool_off_time: T.undefined,
+        threshold: T.undefined,
+        recovery_threshold: T.undefined,
+        window_size: T.undefined,
+        tracked_errors: T.undefined,
+        skipped_errors: T.undefined,
+        traffic_control: T.undefined,
+        traffic_recovery: T.undefined
+      )
+        @name = name
+        @cool_off_time = cool_off_time
+        @threshold = threshold
+        @recovery_threshold = recovery_threshold
+        @window_size = window_size
+        @tracked_errors = tracked_errors.is_a?(Undefined) ? tracked_errors : Array(tracked_errors)
+        @skipped_errors = skipped_errors.is_a?(Undefined) ? skipped_errors : Array(skipped_errors)
+        @traffic_control = traffic_control.is_a?(Undefined) ? traffic_control : LightFactory::TrafficControlDsl.call(traffic_control)
+        @traffic_recovery = traffic_recovery.is_a?(Undefined) ? traffic_recovery : LightFactory::TrafficRecoveryDsl.call(traffic_recovery)
+      end
+
+      def configure!(default_config)
+        ConfigCompatibilityValidator.call(
+          config: default_config.with(
+            name:,
+            cool_off_time:,
+            threshold:,
+            recovery_threshold:,
+            window_size:,
+            tracked_errors:,
+            skipped_errors:,
+            traffic_control:,
+            traffic_recovery:
+          )
+        )
+      end
+
+      private
+
+      attr_reader :name
+      attr_reader :cool_off_time
+      attr_reader :threshold
+      attr_reader :recovery_threshold
+      attr_reader :window_size
+      attr_reader :tracked_errors
+      attr_reader :skipped_errors
+      attr_reader :traffic_control
+      attr_reader :traffic_recovery
+    end
+  end
+end

--- a/lib/stoplight/wiring/light_configuration_dsl.rb
+++ b/lib/stoplight/wiring/light_configuration_dsl.rb
@@ -4,7 +4,7 @@ module Stoplight
   module Wiring
     class LightConfigurationDsl
       def initialize(
-        name: T.undefined,
+        name:,
         cool_off_time: T.undefined,
         threshold: T.undefined,
         recovery_threshold: T.undefined,
@@ -39,6 +39,20 @@ module Stoplight
             traffic_recovery:
           )
         )
+      end
+
+      def digest
+        [
+          name,
+          cool_off_time,
+          threshold,
+          recovery_threshold,
+          window_size,
+          tracked_errors,
+          skipped_errors,
+          traffic_control,
+          traffic_recovery
+        ].hash
       end
 
       private

--- a/lib/stoplight/wiring/light_configuration_dsl.rb
+++ b/lib/stoplight/wiring/light_configuration_dsl.rb
@@ -14,15 +14,17 @@ module Stoplight
         traffic_control: T.undefined,
         traffic_recovery: T.undefined
       )
-        @name = name
-        @cool_off_time = cool_off_time
-        @threshold = threshold
-        @recovery_threshold = recovery_threshold
-        @window_size = window_size
-        @tracked_errors = tracked_errors.is_a?(Undefined) ? tracked_errors : Array(tracked_errors)
-        @skipped_errors = skipped_errors.is_a?(Undefined) ? skipped_errors : Array(skipped_errors)
-        @traffic_control = traffic_control.is_a?(Undefined) ? traffic_control : LightFactory::TrafficControlDsl.call(traffic_control)
-        @traffic_recovery = traffic_recovery.is_a?(Undefined) ? traffic_recovery : LightFactory::TrafficRecoveryDsl.call(traffic_recovery)
+        @digest = [
+          @name = name,
+          @cool_off_time = cool_off_time,
+          @threshold = threshold,
+          @recovery_threshold = recovery_threshold,
+          @window_size = window_size,
+          @tracked_errors = tracked_errors.is_a?(Undefined) ? tracked_errors : Array(tracked_errors),
+          @skipped_errors = skipped_errors.is_a?(Undefined) ? skipped_errors : Array(skipped_errors),
+          @traffic_control = traffic_control.is_a?(Undefined) ? traffic_control : LightFactory::TrafficControlDsl.call(traffic_control),
+          @traffic_recovery = traffic_recovery.is_a?(Undefined) ? traffic_recovery : LightFactory::TrafficRecoveryDsl.call(traffic_recovery)
+        ].hash
       end
 
       def configure!(default_config)
@@ -41,19 +43,7 @@ module Stoplight
         )
       end
 
-      def digest
-        [
-          name,
-          cool_off_time,
-          threshold,
-          recovery_threshold,
-          window_size,
-          tracked_errors,
-          skipped_errors,
-          traffic_control,
-          traffic_recovery
-        ].hash
-      end
+      attr_reader :digest
 
       private
 

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -34,7 +34,7 @@ module Stoplight
         traffic_recovery: T.undefined
       )
         self.class.new(
-          config: ConfigurationDsl.new(
+          config: LegacyConfigurationDsl.new(
             name:,
             cool_off_time:,
             threshold:,

--- a/lib/stoplight/wiring/system.rb
+++ b/lib/stoplight/wiring/system.rb
@@ -83,7 +83,7 @@ module Stoplight
         traffic_control: T.undefined,
         traffic_recovery: T.undefined
       )
-        light_config = ConfigurationDsl.new(
+        light_config = LightConfigurationDsl.new(
           name:,
           cool_off_time:,
           threshold:,

--- a/lib/stoplight/wiring/system.rb
+++ b/lib/stoplight/wiring/system.rb
@@ -83,7 +83,7 @@ module Stoplight
         traffic_control: T.undefined,
         traffic_recovery: T.undefined
       )
-        light_config = LightConfigurationDsl.new(
+        light_dsl = LightConfigurationDsl.new(
           name:,
           cool_off_time:,
           threshold:,
@@ -93,26 +93,37 @@ module Stoplight
           skipped_errors:,
           traffic_control:,
           traffic_recovery:
-        ).configure!(system_config)
-
-        light, _ = lights.compute(name) do |existing|
+        )
+        config_digest = light_dsl.digest
+        light, _, _ = lights.compute(name) do |existing|
           if existing
-            existing_light, existing_config = existing
-            if light_config == existing_config
-              [existing_light, existing_config]
-            else
-              raise Stoplight::Error::ConfigurationError, <<~MSG
-                Light name `#{name}` reused with different settings:
-                  existing settings: #{existing_config}
-                  new settings:      #{light_config}
+            _, existing_digest, existing_source_line = existing
 
-                You cannot use the same light name with different settings.
+            if config_digest != existing_digest
+              raise Stoplight::Error::ConfigurationError, <<~MSG
+                Light `#{name}` already registered with different configuration.
+
+                Original registration: #{existing_source_line}
+                Current attempt: #{caller(6, 1)&.first}
+
+                Lights must have consistent configuration across all call sites.
               MSG
             end
+
+            existing
           else
-            [LightFactory.new(system: self, config: light_config).build, light_config]
+            source_line = caller(6, 1)&.first
+            [
+              LightFactory.new(
+                system: self,
+                config: light_dsl.configure!(system_config)
+              ).build,
+              config_digest,
+              source_line
+            ]
           end
         end
+
         light
       end
 

--- a/lib/stoplight/wiring/system.rb
+++ b/lib/stoplight/wiring/system.rb
@@ -61,15 +61,10 @@ module Stoplight
       # If a light with this name already exists, returns the cached instance.
       # If settings differ from the existing light, raises +Stoplight::Error::ConfigurationError+.
       #
-      #
       # @raise [Stoplight::Error::ConfigurationError] if light exists with different settings
       #
       # @example Create a light
       #   light = system.light("stripe", threshold: 5, window_size: 60)
-      #
-      # @example Retrieve existing light - both return cached light
-      #   light = system.light("stripe", threshold: 5, window_size: 60)
-      #   light = system.light("stripe")
       #
       # @example Configuration conflict
       #   system.light("api", threshold: 5)

--- a/lib/stoplight/wiring/system/light_factory.rb
+++ b/lib/stoplight/wiring/system/light_factory.rb
@@ -28,7 +28,7 @@ module Stoplight
         )
           self.class.new(
             system:,
-            config: ConfigurationDsl.new(
+            config: LegacyConfigurationDsl.new(
               cool_off_time:,
               threshold:,
               recovery_threshold:,

--- a/lib/stoplight/wiring/system_configuration_dsl.rb
+++ b/lib/stoplight/wiring/system_configuration_dsl.rb
@@ -2,7 +2,7 @@
 
 module Stoplight
   module Wiring
-    class ConfigurationDsl
+    class SystemConfigurationDsl
       def initialize(
         name: T.undefined,
         cool_off_time: T.undefined,

--- a/lib/stoplight/wiring/system_configuration_dsl.rb
+++ b/lib/stoplight/wiring/system_configuration_dsl.rb
@@ -4,7 +4,7 @@ module Stoplight
   module Wiring
     class SystemConfigurationDsl
       def initialize(
-        name: T.undefined,
+        name:,
         cool_off_time: T.undefined,
         threshold: T.undefined,
         recovery_threshold: T.undefined,

--- a/sig/_private/stoplight/types.rbs
+++ b/sig/_private/stoplight/types.rbs
@@ -1,5 +1,7 @@
 module Stoplight
   module Types
+    UNDEFINED: Undefined
+
     def self.undefined: -> Undefined
     def self.must: [T < Object] (T? value) -> T
   end

--- a/sig/_private/stoplight/wiring/configuration_dsl.rbs
+++ b/sig/_private/stoplight/wiring/configuration_dsl.rbs
@@ -1,11 +1,6 @@
 module Stoplight
   module Wiring
     class ConfigurationDsl
-      @tracked_errors: optional[Array[_ExceptionMatcher] | _ExceptionMatcher]
-      @skipped_errors: optional[Array[_ExceptionMatcher] | _ExceptionMatcher]
-      @traffic_control: optional[traffic_control]
-      @traffic_recovery: optional[traffic_recovery]
-
       def initialize: (
         ?name: optional[String],
         ?cool_off_time: optional[duration],
@@ -33,11 +28,10 @@ module Stoplight
       attr_reader data_store: optional[data_store]
       attr_reader error_notifier: optional[error_notifier]
       attr_reader notifiers: optional[Array[state_transition_notifier]]
-
-      def tracked_errors: -> optional[Array[_ExceptionMatcher]]
-      def skipped_errors: -> optional[Array[_ExceptionMatcher]]
-      def traffic_control: -> optional[Domain::_TrafficControl]
-      def traffic_recovery: -> optional[Domain::_TrafficRecovery]
+      attr_reader tracked_errors: optional[Array[_ExceptionMatcher]]
+      attr_reader skipped_errors: optional[Array[_ExceptionMatcher]]
+      attr_reader traffic_control: optional[Domain::_TrafficControl]
+      attr_reader traffic_recovery: optional[Domain::_TrafficRecovery]
     end
   end
 end

--- a/sig/_private/stoplight/wiring/legacy_configuration_dsl.rbs
+++ b/sig/_private/stoplight/wiring/legacy_configuration_dsl.rbs
@@ -1,6 +1,6 @@
 module Stoplight
   module Wiring
-    class ConfigurationDsl
+    class LegacyConfigurationDsl
       def initialize: (
         ?name: optional[String],
         ?cool_off_time: optional[duration],

--- a/sig/_private/stoplight/wiring/light_configuration_dsl.rbs
+++ b/sig/_private/stoplight/wiring/light_configuration_dsl.rbs
@@ -15,7 +15,7 @@ module Stoplight
 
       def configure!: (Domain::Config default_config) -> Domain::Config
 
-      def digest: -> Integer
+      attr_reader digest: Integer
 
       private
 

--- a/sig/_private/stoplight/wiring/light_configuration_dsl.rbs
+++ b/sig/_private/stoplight/wiring/light_configuration_dsl.rbs
@@ -2,7 +2,7 @@ module Stoplight
   module Wiring
     class LightConfigurationDsl
       def initialize: (
-        ?name: optional[String],
+        name: String,
         ?cool_off_time: optional[duration],
         ?threshold: optional[percentage | Integer],
         ?recovery_threshold: optional[Integer],
@@ -15,9 +15,11 @@ module Stoplight
 
       def configure!: (Domain::Config default_config) -> Domain::Config
 
+      def digest: -> Integer
+
       private
 
-      attr_reader name: optional[String]
+      attr_reader name: String
       attr_reader cool_off_time: optional[duration]
       attr_reader threshold: optional[percentage | Integer]
       attr_reader recovery_threshold: optional[Integer]

--- a/sig/_private/stoplight/wiring/light_configuration_dsl.rbs
+++ b/sig/_private/stoplight/wiring/light_configuration_dsl.rbs
@@ -1,0 +1,31 @@
+module Stoplight
+  module Wiring
+    class LightConfigurationDsl
+      def initialize: (
+        ?name: optional[String],
+        ?cool_off_time: optional[duration],
+        ?threshold: optional[percentage | Integer],
+        ?recovery_threshold: optional[Integer],
+        ?window_size: optional[duration?],
+        ?tracked_errors: optional[Array[_ExceptionMatcher] | _ExceptionMatcher],
+        ?skipped_errors: optional[Array[_ExceptionMatcher] | _ExceptionMatcher],
+        ?traffic_control: optional[traffic_control],
+        ?traffic_recovery: optional[traffic_recovery],
+      ) -> void
+
+      def configure!: (Domain::Config default_config) -> Domain::Config
+
+      private
+
+      attr_reader name: optional[String]
+      attr_reader cool_off_time: optional[duration]
+      attr_reader threshold: optional[percentage | Integer]
+      attr_reader recovery_threshold: optional[Integer]
+      attr_reader window_size: optional[duration?]
+      attr_reader tracked_errors: optional[Array[_ExceptionMatcher]]
+      attr_reader skipped_errors: optional[Array[_ExceptionMatcher]]
+      attr_reader traffic_control: optional[Domain::_TrafficControl]
+      attr_reader traffic_recovery: optional[Domain::_TrafficRecovery]
+    end
+  end
+end

--- a/sig/_private/stoplight/wiring/system.rbs
+++ b/sig/_private/stoplight/wiring/system.rbs
@@ -6,7 +6,7 @@ module Stoplight
       @name: String
 
       attr_reader light_factory: Domain::_LightFactory
-      attr_reader lights: Concurrent::Map[String, [_Light, Domain::Config]]
+      attr_reader lights: Concurrent::Map[String, [_Light, Integer, String?]]
       attr_reader system_config: Domain::Config
 
       def initialize: (config: Domain::Config) -> void

--- a/sig/_private/stoplight/wiring/system_configuration_dsl.rbs
+++ b/sig/_private/stoplight/wiring/system_configuration_dsl.rbs
@@ -2,7 +2,7 @@ module Stoplight
   module Wiring
     class SystemConfigurationDsl
       def initialize: (
-        ?name: optional[String],
+        name: String,
         ?cool_off_time: optional[duration],
         ?threshold: optional[percentage | Integer],
         ?recovery_threshold: optional[Integer],
@@ -20,7 +20,7 @@ module Stoplight
 
       private
 
-      attr_reader name: optional[String]
+      attr_reader name: String
       attr_reader cool_off_time: optional[duration]
       attr_reader threshold: optional[percentage | Integer]
       attr_reader recovery_threshold: optional[Integer]

--- a/sig/_private/stoplight/wiring/system_configuration_dsl.rbs
+++ b/sig/_private/stoplight/wiring/system_configuration_dsl.rbs
@@ -1,0 +1,37 @@
+module Stoplight
+  module Wiring
+    class SystemConfigurationDsl
+      def initialize: (
+        ?name: optional[String],
+        ?cool_off_time: optional[duration],
+        ?threshold: optional[percentage | Integer],
+        ?recovery_threshold: optional[Integer],
+        ?window_size: optional[duration?],
+        ?tracked_errors: optional[Array[_ExceptionMatcher] | _ExceptionMatcher],
+        ?skipped_errors: optional[Array[_ExceptionMatcher] | _ExceptionMatcher],
+        ?data_store: optional[data_store],
+        ?error_notifier: optional[error_notifier],
+        ?notifiers: optional[Array[state_transition_notifier]],
+        ?traffic_control: optional[traffic_control],
+        ?traffic_recovery: optional[traffic_recovery],
+      ) -> void
+
+      def configure!: (Domain::Config default_config) -> Domain::Config
+
+      private
+
+      attr_reader name: optional[String]
+      attr_reader cool_off_time: optional[duration]
+      attr_reader threshold: optional[percentage | Integer]
+      attr_reader recovery_threshold: optional[Integer]
+      attr_reader window_size: optional[duration?]
+      attr_reader data_store: optional[data_store]
+      attr_reader error_notifier: optional[error_notifier]
+      attr_reader notifiers: optional[Array[state_transition_notifier]]
+      attr_reader tracked_errors: optional[Array[_ExceptionMatcher]]
+      attr_reader skipped_errors: optional[Array[_ExceptionMatcher]]
+      attr_reader traffic_control: optional[Domain::_TrafficControl]
+      attr_reader traffic_recovery: optional[Domain::_TrafficRecovery]
+    end
+  end
+end

--- a/spec/integration/stoplight/wiring/system_spec.rb
+++ b/spec/integration/stoplight/wiring/system_spec.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.describe Stoplight::Wiring::System do
-end

--- a/spec/properties/light_configuration_dsl_spec.rb
+++ b/spec/properties/light_configuration_dsl_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rantly/rspec_extensions"
+
+RSpec.describe Stoplight::Wiring::LightConfigurationDsl do
+  describe "#digest" do
+    # Main property test: same params = same digest
+    specify "produces same digest for identical parameters across all variations" do
+      property_of {
+        {
+          name: string,
+          cool_off_time: choose(integer.abs, float.abs, Stoplight::Types.undefined),
+          threshold: choose(integer.abs, float.abs, Stoplight::Types.undefined),
+          recovery_threshold: choose(integer.abs, float.abs, Stoplight::Types.undefined),
+          window_size: choose(integer.abs, float.abs, Stoplight::Types.undefined),
+          tracked_errors: choose(
+            StandardError,
+            [StandardError],
+            [RuntimeError, ArgumentError],
+            [],
+            Stoplight::Types.undefined
+          ),
+          skipped_errors: choose(
+            ArgumentError,
+            [ArgumentError],
+            [IOError, SystemCallError],
+            [],
+            Stoplight::Types.undefined
+          ),
+          traffic_control: choose(
+            :consecutive_errors,
+            :error_rate,
+            {error_rate: {min_requests: integer.abs}},
+            Stoplight::Types.undefined
+          ),
+          traffic_recovery: choose(
+            :consecutive_successes,
+            Stoplight::Types.undefined
+          )
+        }
+      }.check do |params|
+        dsl1 = described_class.new(**params)
+        dsl2 = described_class.new(**params)
+
+        expect(dsl1.digest).to eq(dsl2.digest),
+          "Expected same digest for identical params: #{params.inspect}"
+      end
+    end
+
+    # Property: digest is stable
+    specify "digest remains stable across multiple calls" do
+      property_of {
+        {
+          name: string,
+          cool_off_time: choose(integer.abs, float.abs, Stoplight::Types.undefined),
+          threshold: choose(integer.abs, float.abs, Stoplight::Types.undefined),
+          recovery_threshold: choose(integer.abs, float.abs, Stoplight::Types.undefined),
+          window_size: choose(integer.abs, float.abs, Stoplight::Types.undefined),
+          tracked_errors: choose(
+            StandardError,
+            [StandardError],
+            [RuntimeError, ArgumentError],
+            [],
+            Stoplight::Types.undefined
+          ),
+          skipped_errors: choose(
+            ArgumentError,
+            [ArgumentError],
+            [IOError, SystemCallError],
+            [],
+            Stoplight::Types.undefined
+          ),
+          traffic_control: choose(
+            :consecutive_errors,
+            :error_rate,
+            Stoplight::Types.undefined
+          ),
+          traffic_recovery: choose(
+            :consecutive_successes,
+            Stoplight::Types.undefined
+          )
+        }
+      }.check do |params|
+        dsl = described_class.new(**params)
+
+        digest1 = dsl.digest
+        digest2 = dsl.digest
+        digest3 = dsl.digest
+
+        expect(digest1).to eq(digest2)
+        expect(digest2).to eq(digest3)
+      end
+    end
+
+    # Property: normalization produces same digest
+    specify "produces same digest for normalized values" do
+      property_of {
+        name = string
+        error_class = choose(StandardError, RuntimeError, ArgumentError)
+
+        [
+          {name: name, tracked_errors: error_class},
+          {name: name, tracked_errors: [error_class]}
+        ]
+      }.check do |params1, params2|
+        dsl1 = described_class.new(**params1)
+        dsl2 = described_class.new(**params2)
+
+        expect(dsl1.digest).to eq(dsl2.digest)
+      end
+    end
+
+    # Property: parameter order doesn't matter
+    specify "produces same digest regardless of parameter order" do
+      property_of {
+        name = string
+        cool_off_time = choose(integer.abs, float.abs, Stoplight::Types.undefined)
+        threshold = choose(integer.abs, float.abs, Stoplight::Types.undefined)
+        recovery_threshold = choose(integer.abs, float.abs, Stoplight::Types.undefined)
+        window_size = choose(integer.abs, float.abs, Stoplight::Types.undefined)
+
+        [
+          {name:, cool_off_time:, threshold:, recovery_threshold:, window_size:},
+          {recovery_threshold:, window_size:, threshold:, name:, cool_off_time:}
+        ]
+      }.check do |params1, params2|
+        dsl1 = described_class.new(**params1)
+        dsl2 = described_class.new(**params2)
+
+        expect(dsl1.digest).to eq(dsl2.digest)
+      end
+    end
+
+    # Property: different params = different digest (collision resistance)
+    specify "produces different digests for different parameters" do
+      property_of {
+        name = string
+        cool_off_time = integer
+        threshold1 = choose(integer.abs, float.abs, Stoplight::Types.undefined)
+        threshold2 = choose(integer.abs, float.abs, Stoplight::Types.undefined)
+
+        [
+          {name: name, cool_off_time: cool_off_time, threshold: threshold1},
+          {name: name, cool_off_time: cool_off_time, threshold: threshold2}
+        ]
+      }.check do |params1, params2|
+        # Skip if randomly identical
+        next if params1[:threshold] == params2[:threshold]
+
+        dsl1 = described_class.new(**params1)
+        dsl2 = described_class.new(**params2)
+
+        # Should be different (collisions are theoretically possible but rare)
+        expect(dsl1.digest).not_to eq(dsl2.digest)
+      end
+    end
+  end
+end

--- a/spec/unit/stoplight/wiring/system_spec.rb
+++ b/spec/unit/stoplight/wiring/system_spec.rb
@@ -106,10 +106,14 @@ RSpec.describe Stoplight::Wiring::System do
     end
 
     describe "inheriting system configuration" do
-      it "inherits threshold from system" do
-        expect(system.light("foo")).to equal(
+      before do
+        system.light("foo")
+      end
+
+      it "raises error as user-provided settings does not match exactly" do
+        expect do
           system.light("foo", threshold: system_config.threshold)
-        )
+        end.to raise_error(Stoplight::Error::ConfigurationError)
       end
     end
 
@@ -120,8 +124,9 @@ RSpec.describe Stoplight::Wiring::System do
         expect do
           system.light("bar", cool_off_time: 30, threshold: 44)
         end.to raise_error(
-          include(/reused with different settings/)
-            .and(include("existing settings")).and(include("new settings"))
+          include(/Light `bar` already registered with different configuration/)
+            .and(include(/system_spec\.rb:121/))
+            .and(include(/system_spec\.rb:125/))
         )
       end
     end

--- a/spec/unit/stoplight/wiring/system_spec.rb
+++ b/spec/unit/stoplight/wiring/system_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Wiring::System do
+  subject!(:system) { described_class.new(config: system_config) }
+
+  describe "#light" do
+    let(:system_config) { Stoplight::Wiring::DefaultConfig }
+
+    describe "caching behavior with same name and no settings" do
+      let(:light) { system.light(name) }
+      let(:name) { "foo" }
+
+      it "returns cached instance on repeated calls" do
+        expect(light).to equal(system.light(name))
+      end
+    end
+
+    describe "isolation with different light names" do
+      let(:light) { system.light(name) }
+      let(:name) { "foo" }
+
+      it "returns different instances for different names" do
+        expect(light).not_to equal(system.light("bar"))
+      end
+    end
+
+    describe "caching with identical settings" do
+      let(:light) { system.light(name, cool_off_time: 30, threshold: 4) }
+      let(:name) { "foo" }
+
+      it "returns cached instance when settings match exactly" do
+        expect(light).to equal(system.light(name, cool_off_time: 30, threshold: 4))
+      end
+    end
+
+    describe "caching with settings in different order" do
+      let(:light) { system.light(name, cool_off_time: 30, threshold: 4) }
+      let(:name) { "foo" }
+
+      it "returns cached instance regardless of parameter order" do
+        expect(light).to equal(system.light(name, threshold: 4, cool_off_time: 30))
+      end
+    end
+
+    describe "configuration conflict detection" do
+      before do
+        system.light("name", cool_off_time: 30, threshold: 4)
+      end
+
+      it "raises error when same name used with different settings" do
+        expect do
+          system.light("name", cool_off_time: 30, threshold: 5)
+        end.to raise_error(Stoplight::Error::ConfigurationError)
+      end
+    end
+
+    describe "different names with different settings" do
+      let(:light) { system.light("bar", cool_off_time: 30, threshold: 4) }
+
+      it "allows different configurations for different light names" do
+        expect(light).not_to equal(system.light("foo", cool_off_time: 30, threshold: 5))
+      end
+    end
+
+    describe "with normalized equivalent settings" do
+      let!(:light) { system.light("bar", tracked_errors: RuntimeError) }
+
+      it "returns same light when tracked_errors is normalized" do
+        expect(light).to equal(system.light("bar", tracked_errors: [RuntimeError]))
+      end
+    end
+
+    describe "with different traffic control strategies" do
+      before { system.light("bar", traffic_control: :consecutive_errors) }
+
+      it "raises error when same name uses different strategies" do
+        expect do
+          system.light("bar", traffic_control: :error_rate, threshold: 0.3)
+        end.to raise_error(Stoplight::Error::ConfigurationError)
+      end
+    end
+
+    describe "concurrent access" do
+      let(:expected) { system.light("bar", cool_off_time: 30) }
+
+      let(:lights) do
+        100.times
+          .map { Thread.new { system.light("bar", cool_off_time: 30) } }
+          .each(&:join)
+          .map(&:value)
+      end
+
+      it "creates only one light instance when called concurrently" do
+        lights.each { |light| expect(light).to equal(expected) }
+      end
+    end
+
+    describe "with partially overlapping settings" do
+      before { system.light("bar", cool_off_time: 30) }
+
+      it "raises error when adding different setting to same name" do
+        expect do
+          system.light("bar", cool_off_time: 30, threshold: 44)
+        end.to raise_error(Stoplight::Error::ConfigurationError)
+      end
+    end
+
+    describe "inheriting system configuration" do
+      it "inherits threshold from system" do
+        expect(system.light("foo")).to equal(
+          system.light("foo", threshold: system_config.threshold)
+        )
+      end
+    end
+
+    describe "error messages" do
+      before { system.light("bar", cool_off_time: 30) }
+
+      it "includes both configs in error message" do
+        expect do
+          system.light("bar", cool_off_time: 30, threshold: 44)
+        end.to raise_error(
+          include(/reused with different settings/)
+            .and(include("existing settings")).and(include("new settings"))
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
 Improved `System#light` caching performance using pre-computed configuration digests and added better error messages with source locations.

-  Pre-compute digest during  `LightConfigurationDsl` initialization
-  Implement `#hash` for traffic/recovery control strategies -- allows comparing configurations effectively
- Cache UNDEFINED constant (saves `Undefined.instance` lookup overhead) - there is more room for improvement here, but it does not play well with RBS.
- Improve configuration conflict errors. Previously error message included both configurations, not it includes both call sites.
- Split DSL classes by use case
   - `LightConfigurationDsl`: Optimized for light caching with pre-computed digest
   - `SystemConfigurationDsl`: For system-level configuration
   - `LegacyConfigurationDsl`: For backward compatibility, used outside of system, will be removed eventually.

### Performance impact

More effective lights cashing enabled a massive performance gain on light lookup.

```
ruby 3.2.4 (2024-04-23 revision af471c0e01) [arm64-darwin23]
Warming up --------------------------------------
               after    70.405k i/100ms
Calculating -------------------------------------
               after    690.021k (± 3.8%) i/s    (1.45 μs/i) -      3.450M in   5.007544s

Comparison:
               after:   690021.2 i/s
              before:   251477.5 i/s - 2.74x  slower
```

When we switch to "system lights", a hottest path will have a very little overhead for light instantiation:


```ruby
Stoplight(name).run {. ... } # <- Faster lookup
```