### PR TITLE
docs: Fix repository badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ Fowler’s [CircuitBreaker][] article.
 [version]: https://rubygems.org/gems/stoplight
 [Build badge]: https://github.com/bolshakov/stoplight/workflows/Specs/badge.svg
 [build]: https://github.com/bolshakov/stoplight/actions?query=branch%3Amaster
-[Coverage badge]: https://img.shields.io/coveralls/bolshakov/stoplight/master.svg?label=coverage
+[Coverage badge]: https://img.shields.io/coveralls/bolshakov/stoplight/main.svg?label=coverage
 [coverage]: https://coveralls.io/r/bolshakov/stoplight
 [stoplight-admin]: https://github.com/bolshakov/stoplight-admin
 [Semantic Versioning]: http://semver.org/spec/v2.0.0.html

--- a/README.md
+++ b/README.md
@@ -639,8 +639,8 @@ Fowler’s [CircuitBreaker][] article.
 [Stoplight]: https://github.com/bolshakov/stoplight
 [Version badge]: https://img.shields.io/gem/v/stoplight.svg?label=version
 [version]: https://rubygems.org/gems/stoplight
-[Build badge]: https://github.com/bolshakov/stoplight/workflows/Specs/badge.svg
-[build]: https://github.com/bolshakov/stoplight/actions?query=branch%3Amaster
+[Build badge]: https://github.com/bolshakov/stoplight/actions/workflows/ci.yml/badge.svg?branch=main
+[build]: https://github.com/bolshakov/stoplight/actions?query=branch%3Amain
 [Coverage badge]: https://img.shields.io/coveralls/bolshakov/stoplight/main.svg?label=coverage
 [coverage]: https://coveralls.io/r/bolshakov/stoplight
 [stoplight-admin]: https://github.com/bolshakov/stoplight-admin


### PR DESCRIPTION
This PR aims to fix small issues with repository bafges.

Currently our `coverage` badge points to the wrong branch (`master` instead of `main`) and our Build badge does not show anything.

<img width="340" height="107" alt="Screenshot 2026-05-25 at 19 53 51" src="https://github.com/user-attachments/assets/21c28ff2-583f-4af1-b8dd-4503696258c5" />

I'll fix links in this PR.

~~Also, looks like our default branch is `master` (I think? We should double-check the repo settings), but it should be `main` since it contains the latest stable release.~~
Actually, no, our default branch is `develop` and we should keep it as is. Sorry for confusion 🙏 