### PR TITLE
Add Registry storage abstraction

### DIFF
--- a/lib/stoplight/infrastructure/fail_safe/storage/registry.rb
+++ b/lib/stoplight/infrastructure/fail_safe/storage/registry.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Infrastructure
+    module FailSafe
+      module Storage
+        class Registry
+          def initialize(primary_registry:, error_notifier:, failover_registry:, circuit_breaker:)
+            @primary_registry = primary_registry
+            @error_notifier = error_notifier
+            @failover_registry = failover_registry
+            @circuit_breaker = circuit_breaker
+          end
+
+          def names
+            fallback = ->(error) {
+              @error_notifier.call(error) if error
+              @failover_registry.names
+            }
+            @circuit_breaker.run(fallback) do
+              @primary_registry.names
+            end
+          end
+
+          def register(name, config:)
+            fallback = ->(error) {
+              @error_notifier.call(error) if error
+              @failover_registry.register(name, config:)
+            }
+            @circuit_breaker.run(fallback) do
+              @primary_registry.register(name, config:)
+            end
+          end
+
+          def unregister(name)
+            fallback = ->(error) {
+              @error_notifier.call(error) if error
+              @failover_registry.unregister(name)
+            }
+            @circuit_breaker.run(fallback) do
+              @primary_registry.unregister(name)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/infrastructure/memory/storage/registry.rb
+++ b/lib/stoplight/infrastructure/memory/storage/registry.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "concurrent/map"
+
+module Stoplight
+  module Infrastructure
+    module Memory
+      module Storage
+        class Registry
+          def names = []
+
+          def register(name, config:) = nil
+          def unregister(name) = nil
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/infrastructure/redis/storage/registry.rb
+++ b/lib/stoplight/infrastructure/redis/storage/registry.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Infrastructure
+    module Redis
+      module Storage
+        class Registry
+          REDIS_KEY = "lights"
+          private_constant :REDIS_KEY
+
+          def initialize(redis:, key_space:, clock:)
+            @redis = redis
+            @key_space = key_space
+            @clock = clock
+          end
+
+          def names
+            @redis.with do |conn|
+              conn.hkeys(@key_space.key(REDIS_KEY))
+            end
+          end
+
+          def register(name, config:)
+            @redis.with do |conn|
+              conn.hset(
+                @key_space.key(REDIS_KEY),
+                name,
+                {
+                  meta: {
+                    version: 1,
+                    registered_at: @clock.current_time.to_i
+                  }
+                }.to_json
+              )
+            end
+          end
+
+          def unregister(name)
+            @redis.with do |conn|
+              conn.hdel(@key_space.key(REDIS_KEY), name)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/infrastructure/redis/storage/system_key_space.rb
+++ b/lib/stoplight/infrastructure/redis/storage/system_key_space.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Infrastructure
+    module Redis
+      module Storage
+        SystemKeySpace = Data.define(:system_id)
+
+        class SystemKeySpace
+          class << self
+            def build(system_name:) = new(
+              system_id: hash_name(system_name)
+            )
+
+            # Generates a truncated SHA256 hash for use in Redis keys.
+            def hash_name(name) = Digest::SHA256.hexdigest(name.to_s)[0, 12] #: String
+          end
+
+          # Builds a Redis key within this namespace.
+          #
+          # @param pieces  Key segments to append
+          # @return  Full Redis key
+          def key(*pieces) = [:stoplight, :v5, system_id, *pieces].join(":")
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/wiring/system.rb
+++ b/lib/stoplight/wiring/system.rb
@@ -116,6 +116,7 @@ module Stoplight
             [
               LightFactory.new(
                 system: self,
+                failover_system: failover_system,
                 config: light_dsl.configure!(system_config)
               ).build,
               config_digest,
@@ -130,6 +131,12 @@ module Stoplight
       private
 
       attr_reader :lights
+
+      def failover_system
+        @failover_system ||= Wiring::System.new(
+          config: Wiring::FailSafeConfig.with(name: "__stoplight__:failover:#{@name}")
+        )
+      end
     end
   end
 end

--- a/lib/stoplight/wiring/system/light_factory.rb
+++ b/lib/stoplight/wiring/system/light_factory.rb
@@ -4,8 +4,9 @@ module Stoplight
   module Wiring
     class System
       class LightFactory < Wiring::LightFactory
-        def initialize(system:, config:)
+        def initialize(system:, failover_system:, config:)
           @system = system
+          @failover_system = failover_system
 
           super(config:)
         end
@@ -22,17 +23,13 @@ module Stoplight
         private
 
         attr_reader :system
+        attr_reader :failover_system
 
         def state_store = storage_set.state_store
         def recovery_lock_store = storage_set.recovery_lock_store
         def recovery_metrics_store = storage_set.recovery_metrics_store
         def metrics_store = storage_set.metrics_store
         def storage_scripting = Infrastructure::Redis::Storage::Scripting.new(redis:)
-
-        def failover_system = @failover_system ||= Stoplight.__stoplight__system(
-          "failover-#{system.name}",
-          data_store: Stoplight::DataStore::Memory.new
-        )
 
         def build_backend
           case data_store_config

--- a/sig/_private/stoplight/domain/ports/registry.rbs
+++ b/sig/_private/stoplight/domain/ports/registry.rbs
@@ -1,0 +1,11 @@
+module Stoplight
+  module Domain
+    # Holds the information about existing lights.
+    # Each system has its own registry so you can query lights belonging to it.
+    interface _Registry
+      def names: -> Array[String]
+      def register: (String name, config: Domain::Config) -> void
+      def unregister: (String name) -> void
+    end
+  end
+end

--- a/sig/_private/stoplight/infrastructure/fail_safe/storage/registry.rbs
+++ b/sig/_private/stoplight/infrastructure/fail_safe/storage/registry.rbs
@@ -1,0 +1,23 @@
+module Stoplight
+  module Infrastructure
+    module FailSafe
+      module Storage
+        class Registry
+          include Domain::_Registry
+
+          @primary_registry: Domain::_Registry
+          @error_notifier: error_notifier
+          @failover_registry: Domain::_Registry
+          @circuit_breaker: _Light
+
+          def initialize: (
+            primary_registry: Domain::_Registry,
+            error_notifier: error_notifier,
+            failover_registry: Domain::_Registry,
+            circuit_breaker: _Light
+          ) -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/_private/stoplight/infrastructure/memory/storage/registry.rbs
+++ b/sig/_private/stoplight/infrastructure/memory/storage/registry.rbs
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Infrastructure
+    module Memory
+      module Storage
+        class Registry
+          include Domain::_Registry
+        end
+      end
+    end
+  end
+end

--- a/sig/_private/stoplight/infrastructure/redis/storage/registry.rbs
+++ b/sig/_private/stoplight/infrastructure/redis/storage/registry.rbs
@@ -1,0 +1,18 @@
+module Stoplight
+  module Infrastructure
+    module Redis
+      module Storage
+        class Registry
+          include Domain::_Registry
+
+          REDIS_KEY: String
+          @redis: redis
+          @key_space: SystemKeySpace
+          @clock: Domain::_Clock
+
+          def initialize: (redis: redis, key_space: SystemKeySpace, clock: Domain::_Clock) -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/_private/stoplight/infrastructure/redis/storage/system_key_space.rbs
+++ b/sig/_private/stoplight/infrastructure/redis/storage/system_key_space.rbs
@@ -1,0 +1,18 @@
+module Stoplight
+  module Infrastructure
+    module Redis
+      module Storage
+        class SystemKeySpace
+          def system_id: -> String
+
+          def self.build: (system_name: _ToS) -> SystemKeySpace
+
+          def self.hash_name: (_ToS) -> String
+
+          def initialize: (system_id: String) -> void
+          def key: (*_ToS) -> String
+        end
+      end
+    end
+  end
+end

--- a/sig/_private/stoplight/system/light_factory.rbs
+++ b/sig/_private/stoplight/system/light_factory.rbs
@@ -8,13 +8,13 @@ module Stoplight
         @storage_set: StorageSet
         @key_space: Infrastructure::Redis::Storage::KeySpace
 
-        def initialize: (config: Domain::Config, system: System) -> void
+        def initialize: (config: Domain::Config, system: System, failover_system: _System) -> void
 
         def key_space: -> Infrastructure::Redis::Storage::KeySpace
 
         private def redis: -> redis
         private def storage_scripting: -> Infrastructure::Redis::Storage::Scripting
-        private def failover_system: -> _System
+        private attr_reader failover_system: _System
         private def storage_set: -> StorageSet
         private def build_backend: -> DataStoreBackend
       end

--- a/sig/_private/stoplight/wiring/system.rbs
+++ b/sig/_private/stoplight/wiring/system.rbs
@@ -4,11 +4,14 @@ module Stoplight
       include _System
 
       @name: String
+      @failover_system: System?
 
       attr_reader lights: Concurrent::Map[String, [_Light, Integer, String?]]
       attr_reader system_config: Domain::Config
 
       def initialize: (config: Domain::Config) -> void
+
+      private def failover_system: -> System
     end
   end
 end

--- a/spec/unit/stoplight/infrastructure/fail_safe/storage/registry_spec.rb
+++ b/spec/unit/stoplight/infrastructure/fail_safe/storage/registry_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Infrastructure::FailSafe::Storage::Registry do
+  let(:fail_safe) do
+    described_class.new(
+      primary_registry:, error_notifier:, failover_registry:,
+      circuit_breaker:
+    )
+  end
+  let(:primary_registry) { instance_double(Stoplight::Infrastructure::Redis::Storage::Registry) }
+  let(:failover_registry) { instance_double(Stoplight::Infrastructure::Memory::Storage::Registry) }
+  let(:error_notifier) { instance_double(Proc) }
+  let(:circuit_breaker) { closed_circuit_breaker_class.new }
+
+  # Simulates a healthy circuit: runs the block, rescues and delegates to fallback on error.
+  let(:closed_circuit_breaker_class) do
+    Class.new(Stoplight::Domain::Light) do
+      def initialize
+      end
+
+      def run(fallback)
+        yield
+      rescue => exception
+        fallback.call(exception)
+      end
+    end
+  end
+
+  # Simulates an open circuit: skips the block entirely and calls fallback with nil.
+  let(:open_circuit_breaker_class) do
+    Class.new(Stoplight::Domain::Light) do
+      def initialize
+      end
+
+      def run(fallback)
+        fallback.call(nil)
+      end
+    end
+  end
+
+  describe "#names" do
+    subject { fail_safe.names }
+
+    context "when primary registry does not fail" do
+      it "returns names from primary registry" do
+        expect(primary_registry).to receive(:names).and_return(["stripe"])
+
+        is_expected.to eq(["stripe"])
+      end
+    end
+
+    context "when primary registry fails" do
+      let(:error) { StandardError.new("connection refused") }
+
+      it "notifies the error and returns names from the failover registry" do
+        expect(primary_registry).to receive(:names).and_raise(error)
+        expect(error_notifier).to receive(:call).with(error)
+        expect(failover_registry).to receive(:names).and_return([])
+
+        is_expected.to eq([])
+      end
+    end
+
+    context "when the circuit is open" do
+      let(:circuit_breaker) { open_circuit_breaker_class.new }
+
+      it "does not notify and returns names from the failover registry" do
+        expect(primary_registry).not_to receive(:names)
+        expect(error_notifier).not_to receive(:call)
+        expect(failover_registry).to receive(:names).and_return([])
+
+        is_expected.to eq([])
+      end
+    end
+  end
+
+  describe "#register" do
+    subject(:register) { fail_safe.register("stripe", config: nil) }
+
+    context "when primary registry does not fail" do
+      it "delegates to primary registry" do
+        expect(primary_registry).to receive(:register).with("stripe", config: nil)
+
+        register
+      end
+    end
+
+    context "when primary registry fails" do
+      let(:error) { StandardError.new("connection refused") }
+
+      it "notifies the error and falls back to the failover registry" do
+        expect(primary_registry).to receive(:register).with("stripe", config: nil).and_raise(error)
+        expect(error_notifier).to receive(:call).with(error)
+        expect(failover_registry).to receive(:register).with("stripe", config: nil)
+
+        register
+      end
+    end
+
+    context "when the circuit is open" do
+      let(:circuit_breaker) { open_circuit_breaker_class.new }
+
+      it "does not notify and falls back to the failover registry" do
+        expect(primary_registry).not_to receive(:register)
+        expect(error_notifier).not_to receive(:call)
+        expect(failover_registry).to receive(:register).with("stripe", config: nil)
+
+        register
+      end
+    end
+  end
+
+  describe "#unregister" do
+    subject(:unregister) { fail_safe.unregister("stripe") }
+
+    context "when primary registry does not fail" do
+      it "delegates to primary registry" do
+        expect(primary_registry).to receive(:unregister).with("stripe")
+
+        unregister
+      end
+    end
+
+    context "when primary registry fails" do
+      let(:error) { StandardError.new("connection refused") }
+
+      it "notifies the error and falls back to the failover registry" do
+        expect(primary_registry).to receive(:unregister).with("stripe").and_raise(error)
+        expect(error_notifier).to receive(:call).with(error)
+        expect(failover_registry).to receive(:unregister).with("stripe")
+
+        unregister
+      end
+    end
+
+    context "when the circuit is open" do
+      let(:circuit_breaker) { open_circuit_breaker_class.new }
+
+      it "does not notify and falls back to the failover registry" do
+        expect(primary_registry).not_to receive(:unregister)
+        expect(error_notifier).not_to receive(:call)
+        expect(failover_registry).to receive(:unregister).with("stripe")
+
+        unregister
+      end
+    end
+  end
+end

--- a/spec/unit/stoplight/infrastructure/redis/storage/registry_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/registry_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Infrastructure::Redis::Storage::Registry, :redis do
+  subject(:registry) { described_class.new(redis:, key_space:, clock:) }
+
+  let(:key_space) { Stoplight::Infrastructure::Redis::Storage::SystemKeySpace.new(system_id: SecureRandom.uuid) }
+  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
+
+  describe "#names" do
+    subject { registry.names }
+
+    context "when no lights have been registered" do
+      it { is_expected.to eq([]) }
+    end
+
+    context "when a light has been registered" do
+      before { registry.register("stripe", config: nil) }
+
+      it { is_expected.to contain_exactly("stripe") }
+    end
+
+    context "when a light has been unregistered" do
+      before do
+        registry.register("stripe", config: nil)
+        registry.unregister("stripe")
+      end
+
+      it { is_expected.not_to include("stripe") }
+    end
+
+    context "when the same light is registered twice" do
+      before do
+        registry.register("stripe", config: nil)
+        registry.register("stripe", config: nil)
+      end
+
+      it { is_expected.to contain_exactly("stripe") }
+    end
+
+    context "when two different lights are registered" do
+      before do
+        registry.register("stripe", config: nil)
+        registry.register("paypal", config: nil)
+      end
+
+      it { is_expected.to contain_exactly("stripe", "paypal") }
+    end
+  end
+end

--- a/spec/unit/stoplight/wiring/system_spec.rb
+++ b/spec/unit/stoplight/wiring/system_spec.rb
@@ -105,6 +105,20 @@ RSpec.describe Stoplight::Wiring::System do
       end
     end
 
+    describe "with a Redis-backed system", :redis do
+      let(:system_config) do
+        Stoplight::Wiring::DefaultConfig.with(
+          name: "redis-test-system",
+          data_store: Stoplight::DataStore::Redis.new(redis)
+        )
+      end
+
+      it "allows creating multiple lights without raising" do
+        system.light("stripe")
+        expect { system.light("paypal") }.not_to raise_error
+      end
+    end
+
     describe "inheriting system configuration" do
       before do
         system.light("foo")
@@ -125,8 +139,8 @@ RSpec.describe Stoplight::Wiring::System do
           system.light("bar", cool_off_time: 30, threshold: 44)
         end.to raise_error(
           include(/Light `bar` already registered with different configuration/)
-            .and(include(/system_spec\.rb:121/))
-            .and(include(/system_spec\.rb:125/))
+            .and(include(/system_spec\.rb:135/))
+            .and(include(/system_spec\.rb:139/))
         )
       end
     end


### PR DESCRIPTION
## Summary

Until now, Stoplight had no concept of a registry - a place to record which named lights
belong to a system. The upcoming change that makes all lights go through a `System` needs
to enumerate lights by system (for the admin panel), but the existing `DataStore` interface 
has no such concept.

This PR introduces `Domain::_Registry` as a dedicated interface for that single
responsibility, along with three concrete implementations that mirror the pattern already
used for other storage types:

- `Infrastructure::Memory::Storage::Registry` - a no-op stub (in-memory lights do not
  persist registrations across restarts, so tracking them is unnecessary)
- `Infrastructure::Redis::Storage::Registry` - stores light names in a Redis hash,
  keyed by `SystemKeySpace`
- `Infrastructure::FailSafe::Storage::Registry` - wraps a primary registry with
  circuit-breaker fallback to the memory stub
 
No existing code is wired to these classes yet. The wiring follows in the next PR.