### PR TITLE
Stoplight Telemetry

### DIFF
--- a/sig/_private/stoplight/domain/ports/telemetry_publisher.rbs
+++ b/sig/_private/stoplight/domain/ports/telemetry_publisher.rbs
@@ -1,0 +1,14 @@
+module Stoplight
+  module Domain
+    # Producer-facing side of the telemetry bus, injected into Telemetry::Emitter. End users never
+    # see it: they get the consumer side (_Telemetry) from +_System#telemetry+.
+    interface _TelemetryPublisher
+      # True when any subscriber (firehose, exact class, or via the StateTransitioned marker) would
+      # receive this event class. The Emitter guards on it before building anything.
+      def subscribed?: (Telemetry::event_class) -> bool
+
+      # Delivers to every interested subscriber, synchronously, in subscription order.
+      def publish: (Telemetry::Envelope[Telemetry::event]) -> void
+    end
+  end
+end

--- a/sig/_private/stoplight/domain/telemetry.rbs
+++ b/sig/_private/stoplight/domain/telemetry.rbs
@@ -1,0 +1,62 @@
+module Stoplight
+  module Domain
+    # In-process telemetry bus.
+    #
+    # Contract:
+    # - Events are process-local observations: they describe what this process observed or did, not the
+    #   globally shared circuit state.
+    # - Every color change this process observes or effects emits exactly one +state_transitioned+ event. That
+    #   stream alone reconstructs the color timeline (breaches, recovery, and locks included).
+    # - Events are traffic-driven - no traffic, no events.
+    # - Handlers run synchronously on the calling thread and are error-isolated:
+    #   a raising handler is routed to the error notifier and never affects the run.
+    # - Emission allocates nothing when nothing is subscribed to that event class - a transitions-only
+    #   subscriber keeps RunCompleted emission free.
+    # - Publish pays for interested handlers only: no filter matching happens at publish time
+    #   (interest is resolved at subscribe time), and subscriptions to other event classes add
+    #   nothing. The handlers themselves run inline, so their cost belongs to the subscriber.
+    #   Subscribing mid-publish takes effect on the next publish.
+    class Telemetry
+      # The consumer side (subscribe/unsubscribe), what +_System#telemetry+ returns.
+      include _Telemetry
+      # The producer side (publish/subscribed?), what wiring injects into Emitter.
+      include _TelemetryPublisher
+
+      # @param error_notifier receives any StandardError a subscriber's handler raises.
+      # @param max_subscriptions caps the number of live subscriptions - #subscribe raises
+      #   Stoplight::Error::TooManySubscriptions once reached.
+      def initialize: (error_notifier: error_notifier, ?max_subscriptions: Integer) -> void
+
+      # Run outcomes reflect the light's accounting, not the caller's experience: an untracked (skipped) error
+      # emits +:success+ with +failure.tracked = false+.
+      type run_outcome = :success | :failure | :blocked
+      type probe_outcome = :success | :failure
+
+      # Closed union over the state machine's edges. New traffic/recovery policies never add variants. They
+      # self-identify via the open +policy+ string inside the matching variant. Every variant includes
+      # the +StateTransitioned+ marker module - the union's runtime name.
+      type state_transitioned =
+        TrafficBreached |
+        RecoveryStarted |
+        RecoverySucceeded |
+        RecoveryFailed |
+        LockChanged
+
+      type event = RunCompleted | state_transitioned | RecoveryProbeCompleted | LightRegistered
+
+      # The +event+ union at the class level - what emit and subscribed? take.
+      type event_class = singleton(RunCompleted)
+                       | singleton(TrafficBreached)
+                       | singleton(RecoveryStarted)
+                       | singleton(RecoverySucceeded)
+                       | singleton(RecoveryFailed)
+                       | singleton(LockChanged)
+                       | singleton(RecoveryProbeCompleted)
+                       | singleton(LightRegistered)
+
+      # Value-level mirror of the +event+ union. A new event type is added here and to the union
+      # together (a spec pins them in sync).
+      EVENT_CLASSES: Array[event_class]
+    end
+  end
+end

--- a/sig/_private/stoplight/domain/telemetry/emitter.rbs
+++ b/sig/_private/stoplight/domain/telemetry/emitter.rbs
@@ -1,0 +1,39 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # The producer side of the bus. One per light, bound to its coordinates at construction time in
+      # wiring, responsible for building envelopes. Injected into strategies, trackers, and Light the same
+      # way notifiers are today.
+      class Emitter
+        def initialize: (
+            bus: _TelemetryPublisher,
+            clock: _Clock,
+            system_name: String,
+            light_name: String
+          ) -> void
+
+        # Lazily yields the event's payload only when the bus has subscribers for this event class, then stamps
+        # +occurred_at+ from the clock and publishes.
+        #
+        # Emitting an unwatched event class allocates nothing - no payload, no envelope.
+        #
+        # The leading class argument is what lets the per-class guard run before the payload exists. Each overload
+        # pins the block's return type to it, so a mismatch is a Steep error at the emission site.
+        #
+        # @example
+        #   emitter.emit(Telemetry::RecoveryStarted) do
+        #     RecoveryStarted.new(from_color: "red", to_color: "yellow", breached_at: Time.now)
+        #   end
+        #
+        def emit: (singleton(RunCompleted)) { () -> RunCompleted } -> void
+                | (singleton(TrafficBreached)) { () -> TrafficBreached } -> void
+                | (singleton(RecoveryStarted)) { () -> RecoveryStarted } -> void
+                | (singleton(RecoverySucceeded)) { () -> RecoverySucceeded } -> void
+                | (singleton(RecoveryFailed)) { () -> RecoveryFailed } -> void
+                | (singleton(LockChanged)) { () -> LockChanged } -> void
+                | (singleton(RecoveryProbeCompleted)) { () -> RecoveryProbeCompleted } -> void
+                | (singleton(LightRegistered)) { () -> LightRegistered } -> void
+      end
+    end
+  end
+end

--- a/sig/stoplight/ports/system.rbs
+++ b/sig/stoplight/ports/system.rbs
@@ -17,5 +17,7 @@ module Stoplight
       ?traffic_control: optional[traffic_control],
       ?traffic_recovery: optional[traffic_recovery]
     ) -> _Light
+
+    def telemetry: -> _Telemetry
   end
 end

--- a/sig/stoplight/ports/telemetry.rbs
+++ b/sig/stoplight/ports/telemetry.rbs
@@ -1,0 +1,26 @@
+module Stoplight
+  # Consumer-facing side of the telemetry bus: subscription only. The producer side is internal
+  # (see Domain::_TelemetryPublisher). This is what +_System#telemetry+ returns.
+  interface _Telemetry
+    # Supports the following variants:
+    #  - Firehose (no filter): every event, including types added in future versions - filter by payload class
+    #    (+case envelope.payload+ narrows the union).
+    #  - Filtered by event class: only that event, with the envelope's payload pre-narrowed.
+    #  - Filtered by +StateTransitioned+: the closed transition union - the complete color timeline.
+    #
+    # @raise [Stoplight::Error::TooManySubscriptions] if the bus's subscription cap is reached.
+    def subscribe: () { (Telemetry::envelope[Telemetry::event]) -> void } -> Telemetry::subscription
+                 | (singleton(Telemetry::RunCompleted)) { (Telemetry::envelope[Telemetry::RunCompleted]) -> void } -> Telemetry::subscription
+                 | (singleton(Telemetry::TrafficBreached)) { (Telemetry::envelope[Telemetry::TrafficBreached]) -> void } -> Telemetry::subscription
+                 | (singleton(Telemetry::RecoveryStarted)) { (Telemetry::envelope[Telemetry::RecoveryStarted]) -> void } -> Telemetry::subscription
+                 | (singleton(Telemetry::RecoverySucceeded)) { (Telemetry::envelope[Telemetry::RecoverySucceeded]) -> void } -> Telemetry::subscription
+                 | (singleton(Telemetry::RecoveryFailed)) { (Telemetry::envelope[Telemetry::RecoveryFailed]) -> void } -> Telemetry::subscription
+                 | (singleton(Telemetry::LockChanged)) { (Telemetry::envelope[Telemetry::LockChanged]) -> void } -> Telemetry::subscription
+                 | (singleton(Telemetry::RecoveryProbeCompleted)) { (Telemetry::envelope[Telemetry::RecoveryProbeCompleted]) -> void } -> Telemetry::subscription
+                 | (singleton(Telemetry::LightRegistered)) { (Telemetry::envelope[Telemetry::LightRegistered]) -> void } -> Telemetry::subscription
+                 | (singleton(Telemetry::StateTransitioned)) { (Telemetry::envelope[Telemetry::state_transitioned]) -> void } -> Telemetry::subscription
+
+    # Idempotent: removing an already-removed or unknown token is a no-op.
+    def unsubscribe: (Telemetry::subscription) -> void
+  end
+end

--- a/sig/stoplight/telemetry.rbs
+++ b/sig/stoplight/telemetry.rbs
@@ -1,0 +1,22 @@
+module Stoplight
+  # Public face of the telemetry bus. The bus and its events live in the domain layer
+  # (Domain::Telemetry); this namespace re-exports them so callers never reference the
+  # Domain:: boundary - mirroring Stoplight::Notifier and Stoplight::DataStore.
+  module Telemetry
+    class RunCompleted = Domain::Telemetry::RunCompleted
+    class TrafficBreached = Domain::Telemetry::TrafficBreached
+    class RecoveryStarted = Domain::Telemetry::RecoveryStarted
+    class RecoverySucceeded = Domain::Telemetry::RecoverySucceeded
+    class RecoveryFailed = Domain::Telemetry::RecoveryFailed
+    class LockChanged = Domain::Telemetry::LockChanged
+    class RecoveryProbeCompleted = Domain::Telemetry::RecoveryProbeCompleted
+    class LightRegistered = Domain::Telemetry::LightRegistered
+
+    module StateTransitioned = Domain::Telemetry::StateTransitioned
+
+    type event = Domain::Telemetry::event
+    type state_transitioned = Domain::Telemetry::state_transitioned
+    type envelope[T < Domain::Telemetry::event] = Domain::Telemetry::Envelope[T]
+    type subscription = Domain::Telemetry::Subscription
+  end
+end

--- a/sig/stoplight/telemetry/envelope.rbs
+++ b/sig/stoplight/telemetry/envelope.rbs
@@ -1,0 +1,30 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # Wraps every published event. Carries only what the emission site knows.
+      #
+      # Identity, sequencing, and transport-level enrichment (ids, host, app version, deploy), etc. belong to the
+      # exporter, which can attach them at delivery time.
+      class Envelope[out P < event] < Data
+        attr_reader system_name: String
+        attr_reader light_name: String
+        attr_reader occurred_at: Time
+        attr_reader payload: P
+
+        def self.new: [Q < event] (
+            system_name: String,
+            light_name: String,
+            occurred_at: Time,
+            payload: Q
+          ) -> Envelope[Q]
+
+        def initialize: (
+            system_name: String,
+            light_name: String,
+            occurred_at: Time,
+            payload: P
+          ) -> void
+      end
+    end
+  end
+end

--- a/sig/stoplight/telemetry/failure.rbs
+++ b/sig/stoplight/telemetry/failure.rbs
@@ -1,0 +1,23 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # Carries the live exception.
+      class Failure < Data
+        attr_reader exception: StandardError
+        # false when the exception matched skipped_errors: the light counted the run a success, but the caller still
+        # saw the exception.
+        attr_reader tracked: bool
+
+        def self.new: (
+            exception: StandardError,
+            tracked: bool
+          ) -> instance
+
+        def initialize: (
+            exception: StandardError,
+            tracked: bool
+          ) -> void
+      end
+    end
+  end
+end

--- a/sig/stoplight/telemetry/light_registered.rbs
+++ b/sig/stoplight/telemetry/light_registered.rbs
@@ -1,0 +1,23 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # Emitted once per (process instance, system, light): the cache-miss branch of System#light.
+      #
+      # Consumers deduplicate by (system_name, light_name) + settings content.
+      #
+      # Emitted by wiring through the light's own emitter, after the light is fully constructed and before it is
+      # returned to the caller - so on the bus it precedes every other event of that light.
+      class LightRegistered < Data
+        attr_reader settings: Settings
+
+        def self.new: (
+            settings: Settings
+          ) -> instance
+
+        def initialize: (
+            settings: Settings
+          ) -> void
+      end
+    end
+  end
+end

--- a/sig/stoplight/telemetry/lock_changed.rbs
+++ b/sig/stoplight/telemetry/lock_changed.rbs
@@ -1,0 +1,35 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # state_transitioned variant: manual lock override changed.
+      #
+      # Emitted even when the effective color is unchanged (from_color == to_color), so the lock timeline is complete.
+      class LockChanged < Data
+        include StateTransitioned
+
+        attr_reader from_color: color
+        attr_reader to_color: color
+        attr_reader from_state: state
+        attr_reader to_state: state
+        # Open set: "api", "admin", custom.
+        attr_reader source: String
+
+        def self.new: (
+            from_color: color,
+            to_color: color,
+            from_state: state,
+            to_state: state,
+            source: String
+          ) -> instance
+
+        def initialize: (
+            from_color: color,
+            to_color: color,
+            from_state: state,
+            to_state: state,
+            source: String
+          ) -> void
+      end
+    end
+  end
+end

--- a/sig/stoplight/telemetry/metrics.rbs
+++ b/sig/stoplight/telemetry/metrics.rbs
@@ -1,0 +1,27 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # The serializable subset of MetricsSnapshot. successes/errors are nil for non-windowed metrics.
+      class Metrics < Data
+        attr_reader successes: Integer?
+        attr_reader errors: Integer?
+        attr_reader consecutive_errors: Integer
+        attr_reader consecutive_successes: Integer
+
+        def self.new: (
+            successes: Integer?,
+            errors: Integer?,
+            consecutive_errors: Integer,
+            consecutive_successes: Integer
+          ) -> instance
+
+        def initialize: (
+            successes: Integer?,
+            errors: Integer?,
+            consecutive_errors: Integer,
+            consecutive_successes: Integer
+          ) -> void
+      end
+    end
+  end
+end

--- a/sig/stoplight/telemetry/recovery_failed.rbs
+++ b/sig/stoplight/telemetry/recovery_failed.rbs
@@ -1,0 +1,36 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # state_transitioned variant: recovery policy sent the light back to red.
+      class RecoveryFailed < Data
+        include StateTransitioned
+
+        attr_reader from_color: yellow
+        attr_reader to_color: red
+        # Open set - the traffic-recovery policy self-identifies.
+        attr_reader policy: String
+        # Semantic nil: today's ConsecutiveSuccesses always has a triggering exception, but a future policy may fail
+        # a recovery without one (e.g. a deadline-based strategy).
+        attr_reader failure: Failure?
+        # Recovery metrics at the decision point.
+        attr_reader metrics: Metrics
+
+        def self.new: (
+            from_color: yellow,
+            to_color: red,
+            policy: String,
+            failure: Failure?,
+            metrics: Metrics
+          ) -> instance
+
+        def initialize: (
+            from_color: yellow,
+            to_color: red,
+            policy: String,
+            failure: Failure?,
+            metrics: Metrics
+          ) -> void
+      end
+    end
+  end
+end

--- a/sig/stoplight/telemetry/recovery_probe_completed.rbs
+++ b/sig/stoplight/telemetry/recovery_probe_completed.rbs
@@ -1,0 +1,29 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # Emitted for every recovery probe.
+      class RecoveryProbeCompleted < Data
+        attr_reader outcome: probe_outcome
+        # Latency of the recovering dependency.
+        attr_reader duration_ms: Float
+        attr_reader failure: Failure?
+        # Recovery metrics after this probe.
+        attr_reader progress: Metrics
+
+        def self.new: (
+            outcome: probe_outcome,
+            duration_ms: Float,
+            failure: Failure?,
+            progress: Metrics
+          ) -> instance
+
+        def initialize: (
+            outcome: probe_outcome,
+            duration_ms: Float,
+            failure: Failure?,
+            progress: Metrics
+          ) -> void
+      end
+    end
+  end
+end

--- a/sig/stoplight/telemetry/recovery_started.rbs
+++ b/sig/stoplight/telemetry/recovery_started.rbs
@@ -1,0 +1,26 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # state_transitioned variant: cool-off elapsed and the first probe explicitly entered recovery.
+      class RecoveryStarted < Data
+        include StateTransitioned
+
+        attr_reader from_color: red
+        attr_reader to_color: yellow
+        attr_reader breached_at: Time
+
+        def self.new: (
+            from_color: red,
+            to_color: yellow,
+            breached_at: Time
+          ) -> instance
+
+        def initialize: (
+            from_color: red,
+            to_color: yellow,
+            breached_at: Time
+          ) -> void
+      end
+    end
+  end
+end

--- a/sig/stoplight/telemetry/recovery_succeeded.rbs
+++ b/sig/stoplight/telemetry/recovery_succeeded.rbs
@@ -1,0 +1,31 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # state_transitioned variant: recovery policy resumed traffic.
+      class RecoverySucceeded < Data
+        include StateTransitioned
+
+        attr_reader from_color: yellow
+        attr_reader to_color: green
+        # Open set - the traffic-recovery policy self-identifies ("consecutive_successes", custom).
+        attr_reader policy: String
+        # Recovery metrics at the decision point.
+        attr_reader metrics: Metrics
+
+        def self.new: (
+            from_color: yellow,
+            to_color: green,
+            policy: String,
+            metrics: Metrics
+          ) -> instance
+
+        def initialize: (
+            from_color: yellow,
+            to_color: green,
+            policy: String,
+            metrics: Metrics
+          ) -> void
+      end
+    end
+  end
+end

--- a/sig/stoplight/telemetry/run_completed.rbs
+++ b/sig/stoplight/telemetry/run_completed.rbs
@@ -1,0 +1,36 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # Emitted for every Light#run.
+      class RunCompleted < Data
+        attr_reader outcome: run_outcome
+        attr_reader color: color
+        # nil only when blocked (no user code ran).
+        attr_reader duration_ms: Float?
+        # Present on failures and on successes caused by untracked (skipped) errors (see Failure#tracked).
+        attr_reader failure: Failure?
+        attr_reader fallback_used: bool
+        # Set only when blocked, nil under locked-red (no recovery scheduled).
+        attr_reader retry_after: Time?
+
+        def self.new: (
+            outcome: run_outcome,
+            color: color,
+            duration_ms: Float?,
+            failure: Failure?,
+            fallback_used: bool,
+            retry_after: Time?
+          ) -> instance
+
+        def initialize: (
+            outcome: run_outcome,
+            color: color,
+            duration_ms: Float?,
+            failure: Failure?,
+            fallback_used: bool,
+            retry_after: Time?
+          ) -> void
+      end
+    end
+  end
+end

--- a/sig/stoplight/telemetry/settings.rbs
+++ b/sig/stoplight/telemetry/settings.rbs
@@ -1,0 +1,48 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # The serializable subset of a light's configuration. No live objects (notifiers, data stores, procs) cross the
+      # telemetry boundary.
+      class Settings < Data
+        attr_reader cool_off_time: duration
+        attr_reader threshold: Float | Integer
+        attr_reader recovery_threshold: Integer
+        attr_reader window_size: duration?
+        # Constant names of the error matchers (matchers are named constants responding to #===).
+        attr_reader tracked_errors: Array[String]
+        attr_reader skipped_errors: Array[String]
+        # Policy tags plus their parameters (e.g. error_rate min_requests).
+        attr_reader traffic_control: String
+        attr_reader traffic_control_params: Hash[String, untyped]
+        attr_reader traffic_recovery: String
+        attr_reader traffic_recovery_params: Hash[String, untyped]
+
+        def self.new: (
+            cool_off_time: duration,
+            threshold: Float | Integer,
+            recovery_threshold: Integer,
+            window_size: duration?,
+            tracked_errors: Array[String],
+            skipped_errors: Array[String],
+            traffic_control: String,
+            traffic_control_params: Hash[String, untyped],
+            traffic_recovery: String,
+            traffic_recovery_params: Hash[String, untyped]
+          ) -> instance
+
+        def initialize: (
+            cool_off_time: duration,
+            threshold: Float | Integer,
+            recovery_threshold: Integer,
+            window_size: duration?,
+            tracked_errors: Array[String],
+            skipped_errors: Array[String],
+            traffic_control: String,
+            traffic_control_params: Hash[String, untyped],
+            traffic_recovery: String,
+            traffic_recovery_params: Hash[String, untyped]
+          ) -> void
+      end
+    end
+  end
+end

--- a/sig/stoplight/telemetry/state_transitioned.rbs
+++ b/sig/stoplight/telemetry/state_transitioned.rbs
@@ -1,0 +1,11 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # Runtime name for the +state_transitioned+ union: a marker module included by every transition variant.
+      # Carries no behavior - it exists so subscription filters can dispatch on the union with
+      # Module#=== (RBS unions have no runtime constant). The type alias keeps typing the payload, this module names it at runtime.
+      module StateTransitioned
+      end
+    end
+  end
+end

--- a/sig/stoplight/telemetry/subscription.rbs
+++ b/sig/stoplight/telemetry/subscription.rbs
@@ -1,0 +1,9 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # Opaque, single-use token returned by +Telemetry#subscribe+ and accepted by +Telemetry#unsubscribe+. No public behavior.
+      class Subscription
+      end
+    end
+  end
+end

--- a/sig/stoplight/telemetry/traffic_breached.rbs
+++ b/sig/stoplight/telemetry/traffic_breached.rbs
@@ -1,0 +1,36 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # state_transitioned variant: traffic control tripped the light.
+      class TrafficBreached < Data
+        include StateTransitioned
+
+        attr_reader from_color: green
+        attr_reader to_color: red
+        # Open set - the traffic-control policy self-identifies ("consecutive_errors", "error_rate", custom).
+        attr_reader policy: String
+        # Today's policies are consulted only when recording a failure, so a triggering exception is
+        # always present - but a future policy may breach without one (e.g. slow-call rate).
+        attr_reader failure: Failure?
+        # Request metrics at the decision point.
+        attr_reader metrics: Metrics
+
+        def self.new: (
+            from_color: green,
+            to_color: red,
+            policy: String,
+            failure: Failure?,
+            metrics: Metrics
+          ) -> instance
+
+        def initialize: (
+            from_color: green,
+            to_color: red,
+            policy: String,
+            failure: Failure?,
+            metrics: Metrics
+          ) -> void
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add a small, typed, in-process event bus to Stoplight that emits value-object events at the key moments of a light's lifecycle: every run, every state transition, every recovery probe, every lock change, and light registration. 

The core only emits. Aggregation, buffering, and export are subscriber concerns out of the scope of this implementation.

## Motivation

Today Stoplight records failures and notifies **only on color change**. Everything else is invisible:

- Successful runs and their latency are discarded. Degradation detection is impossible because no duration is captured anywhere.
- The only extension point, `Notifier`, sees just `(from_color, to_color, error)` - too narrow for observability dashboards, alerting, or metrics pipelines.

Stoplight already wraps every external dependency call. A typed event stream turns it into a **dependency-reliability sensor** without asking users to instrument anything.

## What this opens up?

None of these ship in this proposal. The point is that the event stream adds an extension point that is sufficient for all of them, built by us or by anyone else as a subscriber gem:

- **Metrics pipelines.** Traffic rate, error rate, and latency percentiles are all  reconstructible from the `RunCompleted` stream alone (count, error count, blocked count,  duration histogram). An OpenTelemetry or StatsD exporter is a subscriber, nothing more.
- **Incident timelines.** The `StateTransitioned` stream is, by contract, the complete color timeline: breaches, recovery attempts, and manual locks, including the lock someone set during an incident and forgot.
- **Fleet inventory.** `LightRegistered` reports every light each process knows about, together with its full serializable configuration — which lights exist, with which  policies, in which processes, before anything fails.
- **Recovery observability.** `RecoveryProbeCompleted` shows a dependency coming back (probe latency, progress toward the recovery threshold) instead of a silent red -> green jump.
- **The notifier system becomes a subscriber.** The existing notifiers keep working,  reimplemented as a bridge that subscribes to `StateTransitioned` - one delivery mechanism instead of two parallel ones.

## Design principles

1. **Core emits, subscribers decide.** No buffering, aggregation, or I/O in the domain layer. Delivery is synchronous on the calling thread. Anyone who wants async builds it into their subscriber (queue-and-return), not into the bus.
2. **Zero cost when nobody listens — per event class.** Emission of an event class with no subscribers allocates nothing: no payload, no envelope, no block object. .
4. **Make impossible states unrepresentable.** Every field permutation an event can express  is a state the domain can reach. This is why transitions are five classes instead of one class with a `reason` enum and a handful of nilable fields.
5. **Events are process-local observations.** They describe what *this process* observed or did, not the globally shared circuit state. 
6. **Typed end to end.** Subscription overloads narrow the payload to the subscribed class,  emission overloads pin the payload type to the emitted class. 

## The model

### Envelope

Every delivered event is wrapped in an `Envelope` carrying the coordinates the emission site
knows:

```rbs
class Envelope[out P < event] < Data
  attr_reader system_name: String   # lights live in named systems; "default" for most users
  attr_reader light_name: String
  attr_reader occurred_at: Time
  attr_reader payload: P
end
```

The envelope is generic over its payload, so a filtered subscription receives `Envelope[RunCompleted]`, not `Envelope[Event]`.

### Events

Eight event classes. All are frozen `Data` value objects under `Stoplight::Domain::Telemetry`.

| Event | Volume | Fields |
|---|---|---|
| `RunCompleted` | every `Light#run` | `outcome` (`:success/:failure/:blocked`), `color`, `duration_ms` (nil only when blocked), `failure?`, `fallback_used`, `retry_after?` |
| `TrafficBreached` | rare | `from_color: green`, `to_color: red`, `policy`, `failure`, `metrics` |
| `RecoveryStarted` | rare | `from_color: red`, `to_color: yellow`, `breached_at` |
| `RecoverySucceeded` | rare | `from_color: yellow`, `to_color: green`, `policy`, `metrics` |
| `RecoveryFailed` | rare | `from_color: yellow`, `to_color: red`, `policy`, `failure?`, `metrics` |
| `LockChanged` | rare | `from_color`, `to_color`, `from_state`, `to_state`, `source` |
| `RecoveryProbeCompleted` | low | `outcome`, `duration_ms`, `failure?`, `progress` (recovery metrics after this probe) |
| `LightRegistered` | once per (process, system, light) | `settings` (full serializable config) |


### Transitions

The five transition events form a closed union over the state machine's edges:

```rbs
type state_transitioned = TrafficBreached | RecoveryStarted | RecoverySucceeded | RecoveryFailed | LockChanged
```

Closed on purpose: new traffic/recovery *policies* never add union variants -- they self-identify through the open `policy` string inside the matching variant (`"error_rate"`, `"consecutive_errors"`, a user's custom policy). 

RBS unions have no runtime constant, so the union gets a runtime name via a marker module: `StateTransitioned` is included by every variant and carries no behavior. It exists so a subscription filter can dispatch on the whole union.

## Usage

The bus is a `System` component, wired like storage and notifiers are today: each system has its own bus, so tests and multi-system setups are isolated by construction. 

```ruby
# 1. Firehose: every event, including types added in future versions.
telemetry.subscribe do |envelope|
  case (payload = envelope.payload)
  when Telemetry::RunCompleted
    # payload narrowed to RunCompleted here (Steep understands the case)
  when Telemetry::StateTransitioned
    # any of the five transition variants
  end
end

# 2. One event class: the payload arrives pre-narrowed.
telemetry.subscribe(Telemetry::RunCompleted) do |envelope|
  run = envelope.payload # : Envelope[RunCompleted], no casting
  STATS.increment("stoplight.runs", tags: ["light:#{envelope.light_name}", "outcome:#{run.outcome}"])
  STATS.timing("stoplight.duration_ms", run.duration_ms) if run.duration_ms
end

# 3. The transition union via its marker module: the complete color timeline.
subscription = telemetry.subscribe(Telemetry::StateTransitioned) do |envelope|
  Rails.logger.warn("[stoplight] #{envelope.light_name}: " \
    "#{envelope.payload.from_color} -> #{envelope.payload.to_color}")
end

telemetry.unsubscribe(subscription)
```

## Emitting: the producer side

Producers (run strategies, trackers, `Light`) don't see the bus directly. They get an `Emitter` - one per light, bound to its coordinates at construction time in wiring, injected the same way notifiers are today:

```ruby
emitter.emit(Telemetry::RunCompleted) do
  Telemetry::RunCompleted.new(
    outcome: :success, color: :green, duration_ms: elapsed_ms,
    failure: nil, fallback_used: false, retry_after: nil
  )
end
```

The shape is intentional : the class argument runs the guard that enables us to yield the block only if someone is interested in this type of event. If nothing is subscribed to that class, the payload is never constructed. Per-class overloads pin the block's return type to the class argument  so  `emit(RunCompleted) { TrafficBreached.new(...) }` is a Steep error.

## Current notifiers become a bridge

The existing notifier API is reimplemented as the first subscriber: a bridge that listens to `StateTransitioned` and translates to today's `notify(config, from_color, to_color, error)` calls. User-visible notifier behavior doesn't change; the gem does not have two parallel delivery mechanisms. The bridge is also the reference subscriber.

## Other considerations 

- The public accessor for the bus (`Stoplight.telemetry` delegating to the default system not expressed in the PR but implied..
- `Settings#tracked_errors`/`skipped_errors` matchers by constant name, which requires matchers to be named constants.  Not it allows broader interface (e.g. a `Proc`) this will be deprecated, only constants accepted.


## Follow-up PRs

The whole thing is implemented in three PRs that could be reviewed sequentially:

1. https://github.com/bolshakov/stoplight/pull/723
2. https://github.com/bolshakov/stoplight/pull/724
3. https://github.com/bolshakov/stoplight/pull/726
