### PR TITLE
Telemetry (Part 1) - define events

### DIFF
--- a/lib/stoplight/domain/telemetry.rb
+++ b/lib/stoplight/domain/telemetry.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      EVENT_CLASSES = [
+        RunCompleted,
+        TrafficBreached,
+        RecoveryStarted,
+        RecoverySucceeded,
+        RecoveryFailed,
+        LockChanged,
+        RecoveryProbeCompleted,
+        LightRegistered
+      ].freeze
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/envelope.rb
+++ b/lib/stoplight/domain/telemetry/envelope.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # Wraps every published event.
+      Envelope = Data.define(
+        :system_name,
+        :light_name,
+        :occurred_at,
+        :payload
+      )
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/failure.rb
+++ b/lib/stoplight/domain/telemetry/failure.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # Carries the live exception.
+      Failure = Data.define(
+        :exception,
+        :tracked
+      )
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/light_registered.rb
+++ b/lib/stoplight/domain/telemetry/light_registered.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # Emitted once per (process instance, system, light) when the light's configuration first materializes.
+      LightRegistered = Data.define(
+        :settings
+      )
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/lock_changed.rb
+++ b/lib/stoplight/domain/telemetry/lock_changed.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # state_transitioned variant: manual lock override changed.
+      LockChanged = Data.define(
+        :from_color,
+        :to_color,
+        :from_state,
+        :to_state,
+        :source
+      )
+
+      class LockChanged
+        include StateTransitioned
+      end
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/metrics.rb
+++ b/lib/stoplight/domain/telemetry/metrics.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # The serializable subset of MetricsSnapshot.
+      Metrics = Data.define(
+        :successes,
+        :errors,
+        :consecutive_errors,
+        :consecutive_successes
+      )
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/recovery_failed.rb
+++ b/lib/stoplight/domain/telemetry/recovery_failed.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # state_transitioned variant: recovery policy sent the light back to red.
+      RecoveryFailed = Data.define(
+        :from_color,
+        :to_color,
+        :policy,
+        :failure,
+        :metrics
+      )
+
+      class RecoveryFailed
+        include StateTransitioned
+      end
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/recovery_probe_completed.rb
+++ b/lib/stoplight/domain/telemetry/recovery_probe_completed.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # Emitted for every recovery probe (a run executed while yellow, under the recovery lock).
+      RecoveryProbeCompleted = Data.define(
+        :outcome,
+        :duration_ms,
+        :failure,
+        :progress
+      )
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/recovery_started.rb
+++ b/lib/stoplight/domain/telemetry/recovery_started.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # state_transitioned variant: cool-off elapsed and the first probe explicitly entered recovery.
+      RecoveryStarted = Data.define(
+        :from_color,
+        :to_color,
+        :breached_at
+      )
+
+      class RecoveryStarted
+        include StateTransitioned
+      end
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/recovery_succeeded.rb
+++ b/lib/stoplight/domain/telemetry/recovery_succeeded.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # state_transitioned variant: recovery policy resumed traffic.
+      RecoverySucceeded = Data.define(
+        :from_color,
+        :to_color,
+        :policy,
+        :metrics
+      )
+
+      class RecoverySucceeded
+        include StateTransitioned
+      end
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/run_completed.rb
+++ b/lib/stoplight/domain/telemetry/run_completed.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # Emitted for every Light#run.
+      RunCompleted = Data.define(
+        :outcome,
+        :color,
+        :duration_ms,
+        :failure,
+        :fallback_used,
+        :retry_after
+      )
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/settings.rb
+++ b/lib/stoplight/domain/telemetry/settings.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # The serializable subset of a light's configuration.
+      Settings = Data.define(
+        :cool_off_time,
+        :threshold,
+        :recovery_threshold,
+        :window_size,
+        :tracked_errors,
+        :skipped_errors,
+        :traffic_control,
+        :traffic_control_params,
+        :traffic_recovery,
+        :traffic_recovery_params
+      )
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/state_transitioned.rb
+++ b/lib/stoplight/domain/telemetry/state_transitioned.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # Runtime name for the +state_transitioned+ union: a marker module included by every transition variant.
+      module StateTransitioned
+      end
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/subscription.rb
+++ b/lib/stoplight/domain/telemetry/subscription.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # Opaque, single-use token returned by Telemetry#subscribe and accepted by Telemetry#unsubscribe.
+      class Subscription
+      end
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/traffic_breached.rb
+++ b/lib/stoplight/domain/telemetry/traffic_breached.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # state_transitioned variant: traffic control tripped the light.
+      TrafficBreached = Data.define(
+        :from_color,
+        :to_color,
+        :policy,
+        :failure,
+        :metrics
+      )
+
+      class TrafficBreached
+        include StateTransitioned
+      end
+    end
+  end
+end

--- a/lib/stoplight/error.rb
+++ b/lib/stoplight/error.rb
@@ -11,6 +11,9 @@ module Stoplight
     class IncorrectColor < Base
     end
 
+    class TooManySubscriptions < Base
+    end
+
     class RedLight < Base
       # @!attribute light_name
       #   @return [String] The light's name

--- a/lib/stoplight/telemetry.rb
+++ b/lib/stoplight/telemetry.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Stoplight
+  # Public face of the telemetry bus. The bus and its events live in the domain layer
+  # (+Domain::Telemetry+); this namespace re-exports them so callers never reference the
+  # +Domain::+ boundary - mirroring +Stoplight::Notifier+ and +Stoplight::DataStore+.
+  module Telemetry
+    RunCompleted = Domain::Telemetry::RunCompleted
+    TrafficBreached = Domain::Telemetry::TrafficBreached
+    RecoveryStarted = Domain::Telemetry::RecoveryStarted
+    RecoverySucceeded = Domain::Telemetry::RecoverySucceeded
+    RecoveryFailed = Domain::Telemetry::RecoveryFailed
+    LockChanged = Domain::Telemetry::LockChanged
+    RecoveryProbeCompleted = Domain::Telemetry::RecoveryProbeCompleted
+    LightRegistered = Domain::Telemetry::LightRegistered
+
+    StateTransitioned = Domain::Telemetry::StateTransitioned
+  end
+end

--- a/sig/_private/stoplight/domain/telemetry.rbs
+++ b/sig/_private/stoplight/domain/telemetry.rbs
@@ -22,6 +22,9 @@ module Stoplight
       # The producer side (publish/subscribed?), what wiring injects into Emitter.
       include _TelemetryPublisher
 
+      # Default cap on live subscriptions.
+      MAX_SUBSCRIPTIONS: Integer
+
       # @param error_notifier receives any StandardError a subscriber's handler raises.
       # @param max_subscriptions caps the number of live subscriptions - #subscribe raises
       #   Stoplight::Error::TooManySubscriptions once reached.

--- a/sig/stoplight/error.rbs
+++ b/sig/stoplight/error.rbs
@@ -9,6 +9,9 @@ module Stoplight
     class IncorrectColor < Base
     end
 
+    class TooManySubscriptions < Base
+    end
+
     class RedLight < Base
       attr_reader light_name: String
       attr_reader cool_off_time: Numeric

--- a/spec/unit/stoplight/domain/telemetry/state_transitioned_spec.rb
+++ b/spec/unit/stoplight/domain/telemetry/state_transitioned_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Domain::Telemetry::StateTransitioned do
+  let(:transition_events) do
+    [
+      Stoplight::Domain::Telemetry::TrafficBreached,
+      Stoplight::Domain::Telemetry::RecoveryStarted,
+      Stoplight::Domain::Telemetry::RecoverySucceeded,
+      Stoplight::Domain::Telemetry::RecoveryFailed,
+      Stoplight::Domain::Telemetry::LockChanged
+    ]
+  end
+
+  it "is included by every state transition event" do
+    expect(transition_events).to all(be < described_class)
+  end
+
+  it "is not included by any other event" do
+    other_events = Stoplight::Domain::Telemetry::EVENT_CLASSES - transition_events
+
+    expect(other_events).to all(satisfy { |event_class| !(event_class < described_class) })
+  end
+end

--- a/spec/unit/stoplight/telemetry_spec.rb
+++ b/spec/unit/stoplight/telemetry_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Telemetry do
+  # The public namespace re-exports the constants callers name explicitly - the event classes they
+  # pass to +subscribe+ and the +StateTransitioned+ marker - so they never reference the Domain::
+  # boundary. Each alias must be the very same object as its internal counterpart. Types callers only
+  # receive (Envelope, Failure, ...) are not aliased here: nobody writes their names.
+  aliased = %i[
+    RunCompleted
+    TrafficBreached
+    RecoveryStarted
+    RecoverySucceeded
+    RecoveryFailed
+    LockChanged
+    RecoveryProbeCompleted
+    LightRegistered
+    StateTransitioned
+  ]
+
+  aliased.each do |name|
+    it "exposes #{name} as an alias of Domain::Telemetry::#{name}" do
+      expect(described_class.const_get(name)).to equal(Stoplight::Domain::Telemetry.const_get(name))
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/bolshakov/stoplight/pull/721 should be merged first

This PR implements Telemetry events in code:

- `RunCompleted`
- `TrafficBreached`
- `RecoveryStarted`
- `RecoverySucceeded`
- `RecoveryFailed`
- `LockChanged`
- `RecoveryProbeCompleted`
- `LightRegistered`

All events just pure `Data` classes without any behavior. Additionally this PR defines aliases for user convenience  - users don't reference events with `Domain` prefix:

```ruby
telemetry.subscribe(Stoplight::Telemetry::RunCompleted) do |event|
end
```

instead of:

```ruby
telemetry.subscribe(Stoplight::Domain::Telemetry::RunCompleted) do |event|
end
```