### PR TITLE
Telemetry (Part 2) - subscriber and publisher implementation

### DIFF
--- a/lib/stoplight/domain/telemetry.rb
+++ b/lib/stoplight/domain/telemetry.rb
@@ -2,7 +2,9 @@
 
 module Stoplight
   module Domain
+    # In-process telemetry bus
     class Telemetry
+      # Value-level mirror of the +event+ union.
       EVENT_CLASSES = [
         RunCompleted,
         TrafficBreached,
@@ -13,6 +15,70 @@ module Stoplight
         RecoveryProbeCompleted,
         LightRegistered
       ].freeze
+
+      MAX_SUBSCRIPTIONS = 1_000
+
+      def initialize(error_notifier:, max_subscriptions: MAX_SUBSCRIPTIONS)
+        @mutex = Mutex.new
+        @error_notifier = error_notifier
+        @max_subscriptions = max_subscriptions
+        @subscriptions = []
+        rebuild
+      end
+
+      def subscribe(filter = nil, &handler)
+        raise ArgumentError, "nothing to subscribe. Please, pass a block into `Telemetry#subscribe`" unless handler
+
+        subscription = Subscription.new
+        @mutex.synchronize do
+          if @subscriptions.size >= @max_subscriptions
+            raise Stoplight::Error::TooManySubscriptions, "exceeded #{@max_subscriptions} telemetry subscriptions"
+          end
+
+          @subscriptions << [subscription, filter, handler]
+          rebuild
+        end
+        subscription
+      end
+
+      def unsubscribe(subscription)
+        @mutex.synchronize do
+          @subscriptions.reject! { |token, _, _| token.equal?(subscription) }
+          rebuild
+        end
+        nil
+      end
+
+      def subscribed?(event_class)
+        @dispatch.key?(event_class)
+      end
+
+      def publish(envelope)
+        @dispatch[envelope.payload.class]&.each do |handler|
+          handler.call(envelope)
+        rescue => error
+          begin
+            @error_notifier.call(error)
+          rescue => notifier_error
+            warn "Stoplight telemetry error_notifier raised: #{notifier_error.message}"
+          end
+        end
+        nil
+      end
+
+      # Called under @mutex. Resolves every filter (nil = firehose, module, or exact class) against the closed set of
+      # concrete classes and swaps in a frozen table - copy-on-write, so publish never sees a table mid-mutation and
+      # needs no lock.
+      private def rebuild
+        table = {} #: Hash[Class, Array[untyped]]
+        EVENT_CLASSES.each do |event_class|
+          handlers = @subscriptions.filter_map do |_, filter, handler|
+            handler if filter.nil? || event_class <= filter
+          end
+          table[event_class] = handlers.freeze unless handlers.empty?
+        end
+        @dispatch = table.freeze
+      end
     end
   end
 end

--- a/lib/stoplight/domain/telemetry/emitter.rb
+++ b/lib/stoplight/domain/telemetry/emitter.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      class Emitter
+        def initialize(bus:, clock:, system_name:, light_name:)
+          @bus = bus
+          @clock = clock
+          @system_name = system_name
+          @light_name = light_name
+        end
+
+        # Emits telemetry event.
+        def emit(event_class)
+          return unless @bus.subscribed?(event_class)
+
+          @bus.publish(
+            Envelope.new(
+              light_name: @light_name,
+              system_name: @system_name,
+              occurred_at: @clock.current_time,
+              payload: yield
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/sig/_private/stoplight/domain/telemetry.rbs
+++ b/sig/_private/stoplight/domain/telemetry.rbs
@@ -22,6 +22,12 @@ module Stoplight
       # The producer side (publish/subscribed?), what wiring injects into Emitter.
       include _TelemetryPublisher
 
+      @error_notifier: ^(StandardError) -> void
+      @mutex: Mutex
+      @max_subscriptions: Integer
+      @subscriptions: Array[[Subscription, subscription_filter, subscription_handler]]
+      @dispatch: Hash[Class, Array[subscription_handler]]
+
       # Default cap on live subscriptions.
       MAX_SUBSCRIPTIONS: Integer
 
@@ -29,6 +35,11 @@ module Stoplight
       # @param max_subscriptions caps the number of live subscriptions - #subscribe raises
       #   Stoplight::Error::TooManySubscriptions once reached.
       def initialize: (error_notifier: error_notifier, ?max_subscriptions: Integer) -> void
+
+      type subscription_handler = ^(Envelope[event]) -> void
+      type subscription_filter =  nil | singleton(RunCompleted) | singleton(TrafficBreached) | singleton(RecoveryStarted)
+        | singleton(RecoverySucceeded) | singleton(RecoveryFailed) | singleton(LockChanged)
+        | singleton(RecoveryProbeCompleted) | singleton(LightRegistered) | singleton(StateTransitioned)
 
       # Run outcomes reflect the light's accounting, not the caller's experience: an untracked (skipped) error
       # emits +:success+ with +failure.tracked = false+.
@@ -38,12 +49,7 @@ module Stoplight
       # Closed union over the state machine's edges. New traffic/recovery policies never add variants. They
       # self-identify via the open +policy+ string inside the matching variant. Every variant includes
       # the +StateTransitioned+ marker module - the union's runtime name.
-      type state_transitioned =
-        TrafficBreached |
-        RecoveryStarted |
-        RecoverySucceeded |
-        RecoveryFailed |
-        LockChanged
+      type state_transitioned = TrafficBreached | RecoveryStarted | RecoverySucceeded | RecoveryFailed | LockChanged
 
       type event = RunCompleted | state_transitioned | RecoveryProbeCompleted | LightRegistered
 
@@ -60,6 +66,8 @@ module Stoplight
       # Value-level mirror of the +event+ union. A new event type is added here and to the union
       # together (a spec pins them in sync).
       EVENT_CLASSES: Array[event_class]
+
+      private def rebuild: -> void
     end
   end
 end

--- a/sig/_private/stoplight/domain/telemetry/emitter.rbs
+++ b/sig/_private/stoplight/domain/telemetry/emitter.rbs
@@ -5,6 +5,11 @@ module Stoplight
       # wiring, responsible for building envelopes. Injected into strategies, trackers, and Light the same
       # way notifiers are today.
       class Emitter
+        @bus: _TelemetryPublisher
+        @clock: _Clock
+        @system_name: String
+        @light_name: String
+
         def initialize: (
             bus: _TelemetryPublisher,
             clock: _Clock,

--- a/spec/unit/stoplight/domain/telemetry/emitter_spec.rb
+++ b/spec/unit/stoplight/domain/telemetry/emitter_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Domain::Telemetry::Emitter do
+  subject(:emitter) { described_class.new(bus:, clock:, system_name:, light_name:) }
+
+  let(:bus) { instance_double(Stoplight::Domain::Telemetry) }
+  let(:clock) { instance_double(NullClock) }
+  let(:system_name) { SecureRandom.uuid }
+  let(:light_name) { SecureRandom.uuid }
+
+  describe "#emit" do
+    context "when subscribed to event" do
+      let(:event_type) { Stoplight::Domain::Telemetry::RecoveryFailed }
+      let(:event) { instance_double(event_type) }
+      let(:occurred_at) { Time.at(0) }
+
+      before do
+        allow(bus).to receive(:subscribed?).with(event_type).and_return(true)
+      end
+
+      it "emits an event " do
+        envelope = Stoplight::Domain::Telemetry::Envelope.new(
+          system_name:, light_name:, occurred_at:, payload: event
+        )
+
+        expect(bus).to receive(:publish).with(envelope)
+        expect(clock).to receive(:current_time).and_return(occurred_at)
+
+        emitter.emit(event_type) { event }
+      end
+    end
+
+    context "when not subscribed to event" do
+      let(:event_type) { Stoplight::Domain::Telemetry::RecoveryFailed }
+
+      before do
+        allow(bus).to receive(:subscribed?).with(event_type).and_return(false)
+      end
+
+      it "does not emit an event nor instantiate it " do
+        expect(bus).not_to receive(:publish)
+
+        expect do |event_factory|
+          emitter.emit(event_type, &event_factory)
+        end.not_to yield_control
+      end
+    end
+  end
+end

--- a/spec/unit/stoplight/domain/telemetry_spec.rb
+++ b/spec/unit/stoplight/domain/telemetry_spec.rb
@@ -1,0 +1,268 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Domain::Telemetry do
+  subject(:bus) { described_class.new(error_notifier:) }
+
+  let(:error_notifier) { instance_spy(Proc) }
+
+  def envelope(payload)
+    described_class::Envelope.new(
+      system_name: "sys",
+      light_name: "light",
+      occurred_at: Time.at(0),
+      payload:
+    )
+  end
+
+  let(:run_completed) do
+    described_class::RunCompleted.new(
+      outcome: :success,
+      color: "green",
+      duration_ms: 1.0,
+      failure: nil,
+      fallback_used: false,
+      retry_after: nil
+    )
+  end
+
+  let(:traffic_breached) do
+    described_class::TrafficBreached.new(
+      from_color: "green",
+      to_color: "red",
+      policy: "error_rate",
+      failure: nil,
+      metrics: nil
+    )
+  end
+
+  describe "#subscribe and #publish" do
+    subject(:received) { [] }
+
+    context "when subscribed to event class" do
+      let(:published_event) { envelope(run_completed) }
+
+      it "delivers an event to a handler" do
+        expect do |handler|
+          bus.subscribe(described_class::RunCompleted, &handler)
+          bus.publish(published_event)
+        end.to yield_with_args(published_event)
+      end
+    end
+
+    context "when subscribed to a different class" do
+      let(:published_event) { envelope(run_completed) }
+
+      it "does not deliver an event to a handler" do
+        expect do |handler|
+          bus.subscribe(described_class::TrafficBreached, &handler)
+          bus.publish(published_event)
+        end.not_to yield_control
+      end
+    end
+
+    context "when subscribed without a filter" do
+      let(:published_event_1) { envelope(run_completed) }
+      let(:published_event_2) { envelope(traffic_breached) }
+
+      it "delivers every event to a firehose handler in order" do
+        expect do |handler|
+          bus.subscribe(&handler)
+          bus.publish(published_event_1)
+          bus.publish(published_event_2)
+        end.to yield_successive_args(published_event_1, published_event_2)
+      end
+    end
+
+    context "with multiple subscribers to the same event type" do
+      let(:published_event) { envelope(run_completed) }
+      let(:received) { [] }
+
+      it "delivers to multiple handlers in subscription order" do
+        bus.subscribe(described_class::RunCompleted) { received << :first }
+        bus.subscribe(described_class::RunCompleted) { received << :second }
+
+        bus.publish(published_event)
+
+        expect(received).to eq([:first, :second])
+      end
+    end
+
+    context "with StateTransitioned handler" do
+      let(:not_state_transition_event) { envelope(run_completed) }
+      let(:state_transition_event) { envelope(traffic_breached) }
+
+      it "delivers only state-transition events to a handler" do
+        expect do |handler|
+          bus.subscribe(described_class::StateTransitioned, &handler)
+
+          bus.publish(state_transition_event)
+          bus.publish(not_state_transition_event)
+        end.to yield_with_args(state_transition_event)
+      end
+    end
+
+    context "without a handler block" do
+      it "raises ArgumentError" do
+        expect { bus.subscribe(described_class::RunCompleted) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when the subscription cap is reached" do
+      subject(:bus) { described_class.new(error_notifier:, max_subscriptions: 1) }
+
+      it "raises Stoplight::Error::TooManySubscriptions" do
+        bus.subscribe(described_class::RunCompleted) {}
+
+        expect { bus.subscribe(described_class::RunCompleted) {} }
+          .to raise_error(Stoplight::Error::TooManySubscriptions)
+      end
+    end
+
+    context "when subscribing during a publish" do
+      let(:received) { [] }
+
+      it "takes effect only on the next publish, not the one in progress" do
+        bus.subscribe(described_class::RunCompleted) do
+          bus.subscribe(described_class::RunCompleted) { received << :late }
+        end
+
+        bus.publish(envelope(run_completed))
+        expect(received).to be_empty
+
+        bus.publish(envelope(run_completed))
+        expect(received).to eq([:late])
+      end
+    end
+  end
+
+  describe "handler error isolation" do
+    let(:boom) { StandardError.new("boom") }
+    let(:event) { envelope(run_completed) }
+
+    it "routes a raising handler's error to the error notifier" do
+      bus.subscribe(described_class::RunCompleted) { raise boom }
+
+      bus.publish(event)
+
+      expect(error_notifier).to have_received(:call).with(boom)
+    end
+
+    it "still delivers to the remaining handlers" do
+      bus.subscribe(described_class::RunCompleted) { raise boom }
+
+      expect do |handler|
+        bus.subscribe(described_class::RunCompleted, &handler)
+        bus.publish(event)
+      end.to yield_with_args(event)
+    end
+
+    it "does not raise out of publish when the error notifier itself raises" do
+      allow(error_notifier).to receive(:call).and_raise(StandardError.new("notifier boom"))
+      bus.subscribe(described_class::RunCompleted) { raise boom }
+
+      expect { bus.publish(event) }.not_to raise_error
+    end
+
+    it "still delivers to the remaining handlers when the error notifier itself raises" do
+      allow(error_notifier).to receive(:call).and_raise(StandardError.new("notifier boom"))
+      bus.subscribe(described_class::RunCompleted) { raise boom }
+
+      expect do |handler|
+        bus.subscribe(described_class::RunCompleted, &handler)
+        bus.publish(event)
+      end.to yield_with_args(event)
+    end
+
+    it "does not raise out of publish" do
+      bus.subscribe(described_class::RunCompleted) { raise boom }
+
+      expect { bus.publish(event) }.not_to raise_error
+    end
+  end
+
+  describe "#unsubscribe" do
+    let(:event) { envelope(run_completed) }
+
+    it "stops delivery to the removed handler" do
+      expect do |handler|
+        subscription = bus.subscribe(described_class::RunCompleted, &handler)
+        bus.unsubscribe(subscription)
+        bus.publish(event)
+      end.not_to yield_control
+    end
+
+    it "removes a firehose handler from every event class" do
+      subscription = bus.subscribe {}
+
+      bus.unsubscribe(subscription)
+
+      expect(described_class::EVENT_CLASSES).to all(satisfy { |klass| !bus.subscribed?(klass) })
+    end
+
+    it "leaves other subscriptions to the same class intact" do
+      expect do |handler_1|
+        removed = bus.subscribe(described_class::RunCompleted, &handler_1)
+
+        expect do |handler_2|
+          bus.subscribe(described_class::RunCompleted, &handler_2)
+          bus.unsubscribe(removed)
+          bus.publish(event)
+        end.to yield_with_args(event)
+      end.not_to yield_control
+    end
+
+    it "is a no-op when the token was already removed" do
+      subscription = bus.subscribe(described_class::RunCompleted) {}
+      bus.unsubscribe(subscription)
+
+      expect { bus.unsubscribe(subscription) }.not_to raise_error
+    end
+
+    it "is a no-op for an unknown token" do
+      expect { bus.unsubscribe(described_class::Subscription.new) }.not_to raise_error
+    end
+  end
+
+  describe "#subscribed?" do
+    it "is false when no handler covers the event class" do
+      bus.subscribe(described_class::TrafficBreached) {}
+
+      expect(bus).not_to be_subscribed(described_class::RunCompleted)
+    end
+
+    it "is true when a handler subscribes to that exact class" do
+      bus.subscribe(described_class::RunCompleted) {}
+
+      expect(bus).to be_subscribed(described_class::RunCompleted)
+    end
+
+    it "is true for any event class when a firehose handler is subscribed" do
+      bus.subscribe {}
+
+      expect(bus).to be_subscribed(described_class::RunCompleted)
+      expect(bus).to be_subscribed(described_class::LightRegistered)
+    end
+
+    it "is true for transition classes when a StateTransitioned handler is subscribed" do
+      bus.subscribe(described_class::StateTransitioned) {}
+
+      expect(bus).to be_subscribed(described_class::TrafficBreached)
+      expect(bus).not_to be_subscribed(described_class::RunCompleted)
+    end
+  end
+
+  describe "EVENT_CLASSES" do
+    it "mirrors the event type union" do
+      expect(described_class::EVENT_CLASSES).to contain_exactly(
+        Stoplight::Domain::Telemetry::RunCompleted,
+        Stoplight::Domain::Telemetry::TrafficBreached,
+        Stoplight::Domain::Telemetry::RecoveryStarted,
+        Stoplight::Domain::Telemetry::RecoverySucceeded,
+        Stoplight::Domain::Telemetry::RecoveryFailed,
+        Stoplight::Domain::Telemetry::LockChanged,
+        Stoplight::Domain::Telemetry::RecoveryProbeCompleted,
+        Stoplight::Domain::Telemetry::LightRegistered
+      )
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/bolshakov/stoplight/pull/723 should be merged first

Implement telemetry subscriber and publisher

`Stoplight::Domain::Telemetry` implements two interfaces:
1.  `Stoplight::_Telemetry` - public interface that end users uses (`telemetry.subscribe { |event| }`
2. `Stoplight::Domain::Telemetry::_TelemetryPublisher` - internal interface used to produce an event (`telemetry.publish(envelope)`)

Telemetry implemented the way, that every time you subscribe to events, it recalculates the dispatch table. This allows us to perform constant time lookup on the publisher side. 

Lights does not use `Telemetry#publish`, they use a think wrapper `Telemetry::Emitter#emit` that does three things:
- Provides envelope for events.
- Check if there are any subscribers before emitting an event. No subscribers - no need to emit anything. 
- Allow callers lazily instantiate events. So if event does not have subscribers, it has zero allocations. 

