### PR TITLE
Telemetry (Part 3) - Wire telemetry emitter into light and system factories

### DIFF
--- a/lib/stoplight/infrastructure/system_clock.rb
+++ b/lib/stoplight/infrastructure/system_clock.rb
@@ -10,6 +10,8 @@ module Stoplight
     class SystemClock
       def current_time = Time.now.utc
 
+      def monotonic_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
       def at(timestamp) = Time.at(timestamp).utc
     end
   end

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -7,7 +7,7 @@ module Stoplight
     #
     # @api private
     class LightFactory
-      def initialize(system_name:, config:, failover_system:)
+      def initialize(system_name:, config:, failover_system:, telemetry:)
         @system_name = system_name
         @failover_system = failover_system
         @config = config
@@ -27,6 +27,12 @@ module Stoplight
           skipped: config.skipped_errors
         )
 
+        @emitter = Domain::Telemetry::Emitter.new(
+          bus: telemetry,
+          system_name: system_name,
+          light_name: config.name,
+          clock: @clock
+        )
         @wrapped_notifiers = nil
       end
 

--- a/lib/stoplight/wiring/system.rb
+++ b/lib/stoplight/wiring/system.rb
@@ -62,6 +62,7 @@ module Stoplight
         @lights = Concurrent::Map.new
         @failover_system = failover_system
         @registry = registry
+        @telemetry = Domain::Telemetry.new(error_notifier: config.error_notifier)
       end
 
       # Creates or retrieves a light.
@@ -122,7 +123,12 @@ module Stoplight
           else
             source_line = caller(6, 1)&.first
             config = light_dsl.configure!(system_config)
-            light = LightFactory.new(system_name: @name, config:, failover_system: @failover_system).build
+            light = LightFactory.new(
+              system_name: @name,
+              config:,
+              failover_system: @failover_system,
+              telemetry: @telemetry
+            ).build
             @registry.register(name, config:)
             [light, config_digest, source_line]
           end
@@ -133,7 +139,11 @@ module Stoplight
 
       # @api private
       def __stoplight__storage
-        Storage.new(system_name: @name, failover_system: T.must(@failover_system)) # works only with redis ds
+        Storage.new(
+          system_name: @name,
+          failover_system: T.must(@failover_system), # works only with redis ds
+          telemetry: @telemetry
+        )
       end
 
       # @api private

--- a/lib/stoplight/wiring/system/storage.rb
+++ b/lib/stoplight/wiring/system/storage.rb
@@ -5,10 +5,11 @@ module Stoplight
     class System
       # Only for admin panel use.
       class Storage
-        def initialize(system_name:, failover_system:)
+        def initialize(system_name:, failover_system:, telemetry:)
           @system_name = system_name
           @failover_system = failover_system
           @factories = {}
+          @telemetry = telemetry
         end
 
         def state_snapshot(config)
@@ -33,7 +34,12 @@ module Stoplight
         end
 
         private def light_factory(config)
-          @factories[config] ||= LightFactory.new(system_name: @system_name, config:, failover_system: @failover_system)
+          @factories[config] ||= LightFactory.new(
+            system_name: @system_name,
+            config:,
+            failover_system: @failover_system,
+            telemetry: @telemetry
+          )
         end
       end
     end

--- a/sig/_private/stoplight/domain/ports/clock.rbs
+++ b/sig/_private/stoplight/domain/ports/clock.rbs
@@ -11,6 +11,9 @@ module Stoplight
       # Returns the current time.
       def current_time: () -> Time
 
+      # Returns monotonic time in ms
+      def monotonic_time: () -> Float
+
       # Converts a Unix timestamp to a Time object.
       def at: (timestamp) -> Time
     end

--- a/sig/_private/stoplight/wiring/light_factory.rbs
+++ b/sig/_private/stoplight/wiring/light_factory.rbs
@@ -30,11 +30,17 @@ module Stoplight
       @cool_off_time: duration
       @error_tracking_policy: Domain::ErrorTrackingPolicy
       @wrapped_notifiers: Array[state_transition_notifier]?
+      @emitter: Domain::Telemetry::Emitter
       @failover_system: _System?
       @storage_set: StorageSet
       @key_space: Infrastructure::Redis::Storage::KeySpace
 
-      def initialize: (config: Domain::Config, system_name: String, failover_system: _System?) -> void
+      def initialize: (
+          config: Domain::Config,
+          system_name: String,
+          failover_system: _System?,
+          telemetry: Domain::_TelemetryPublisher
+        ) -> void
 
       def storage_set: -> StorageSet
       def key_space: -> Infrastructure::Redis::Storage::KeySpace

--- a/sig/_private/stoplight/wiring/system.rbs
+++ b/sig/_private/stoplight/wiring/system.rbs
@@ -6,6 +6,7 @@ module Stoplight
       @name: String
       @failover_system: _System?
       @registry: Domain::_Registry
+      @telemetry: Domain::_TelemetryPublisher
 
       attr_reader lights: Concurrent::Map[String, [_Light, Integer, String?]]
       attr_reader system_config: Domain::Config

--- a/sig/_private/stoplight/wiring/system/storage.rbs
+++ b/sig/_private/stoplight/wiring/system/storage.rbs
@@ -5,8 +5,9 @@ module Stoplight
         @system_name: String
         @failover_system: _System
         @factories: Hash[Domain::Config, LightFactory]
+        @telemetry: Domain::_TelemetryPublisher
 
-        def initialize: (system_name: String, failover_system: _System) -> void
+        def initialize: (system_name: String, failover_system: _System, telemetry: Domain::_TelemetryPublisher) -> void
 
         def state_snapshot: (Domain::Config) -> Domain::StateSnapshot
         def metrics_snapshot: (Domain::Config) -> Domain::MetricsSnapshot

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require_relative "support/adapters/null_recovery_lock_token"
 require_relative "support/adapters/null_state_store"
 require_relative "support/adapters/null_traffic_control"
 require_relative "support/adapters/null_traffic_recovery"
+require_relative "support/adapters/test_telemetry_emitter"
 
 require_relative "support/data_store"
 require_relative "support/light/color"
@@ -24,6 +25,7 @@ require_relative "support/light/state"
 require_relative "support/database_cleaner"
 require_relative "support/exception_helpers"
 require_relative "support/route_helpers"
+require_relative "support/matchers/emit"
 
 Timecop.safe_mode = true
 

--- a/spec/support/adapters/null_clock.rb
+++ b/spec/support/adapters/null_clock.rb
@@ -1,4 +1,5 @@
 class NullClock
   def current_time = raise NotImplementedError
+  def monotonic_time = raise NotImplementedError
   def at(ts) = raise NotImplementedError
 end

--- a/spec/support/adapters/test_telemetry_emitter.rb
+++ b/spec/support/adapters/test_telemetry_emitter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class TestTelemetryEmitter
+  include RSpec::Matchers
+
+  def initialize
+    @emitted = []
+  end
+
+  def emit(event_class)
+    event = yield
+    expect(event).to be_kind_of(event_class)
+    @emitted << event
+  end
+
+  def emitted = @emitted.dup
+end

--- a/spec/support/matchers/emit.rb
+++ b/spec/support/matchers/emit.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Asserts that a block emits an event through the example's `emitter`
+# (a TestTelemetryEmitter). Usage:
+#
+#   expect { light.run { "ok" } }.to emit(Stoplight::Domain::Telemetry::RunCompleted)
+#     .with(outcome: "success")
+RSpec::Matchers.define :emit do |event_class|
+  supports_block_expectations
+
+  match do |block|
+    events_before = emitter.emitted.size
+    block.call
+    @new_events = emitter.emitted.drop(events_before)
+    @matching_event = @new_events.find { |event| event.instance_of?(event_class) && attributes_match?(event) }
+
+    !@matching_event.nil?
+  end
+
+  chain :with do |attributes|
+    @attributes = attributes
+  end
+
+  define_method(:attributes_match?) do |event|
+    @actual = (@attributes || {}).keys.to_h do |name|
+      [name, event.public_send(name)]
+    end
+
+    @attributes.nil? || values_match?(@attributes, @actual)
+  end
+
+  description do
+    @attributes ? "emit #{event_class} with #{@attributes.inspect}" : "emit #{event_class}"
+  end
+
+  failure_message do
+    "expected to #{description}, but emitted: #{@new_events.inspect}"
+  end
+
+  failure_message_when_negated do
+    "expected not to #{description}, but emitted: #{@matching_event.inspect}"
+  end
+
+  diffable
+end

--- a/spec/support/matchers/emit_spec.rb
+++ b/spec/support/matchers/emit_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe "emit matcher" do
+  let(:emitter) { TestTelemetryEmitter.new }
+  let(:event_class) { Data.define(:outcome, :duration_ms) }
+  let(:other_event_class) { Data.define(:reason) }
+
+  it "matches when the block emits an instance of the given class" do
+    expect { emitter.emit(event_class) { event_class.new(outcome: "success", duration_ms: 12) } }
+      .to emit(event_class)
+  end
+
+  it "does not match when the block emits nothing" do
+    expect {}.not_to emit(event_class)
+  end
+
+  it "does not match when the block emits a different event class" do
+    expect { emitter.emit(other_event_class) { other_event_class.new(reason: "boom") } }
+      .not_to emit(event_class)
+  end
+
+  it "ignores events emitted before the block runs" do
+    emitter.emit(event_class) { event_class.new(outcome: "success", duration_ms: 12) }
+
+    expect {}.not_to emit(event_class)
+  end
+
+  it "matches when the attributes given to `with` are equal" do
+    expect { emitter.emit(event_class) { event_class.new(outcome: "success", duration_ms: 12) } }
+      .to emit(event_class).with(outcome: "success")
+  end
+
+  it "does not match when the attributes given to `with` differ" do
+    expect { emitter.emit(event_class) { event_class.new(outcome: "success", duration_ms: 12) } }
+      .not_to emit(event_class).with(outcome: "failure")
+  end
+
+  it "supports composable matchers as `with` values" do
+    expect { emitter.emit(event_class) { event_class.new(outcome: "success", duration_ms: 12) } }
+      .to emit(event_class).with(duration_ms: be > 10)
+  end
+
+  it "explains what was emitted instead on failure" do
+    expect {
+      expect { emitter.emit(other_event_class) { other_event_class.new(reason: "boom") } }
+        .to emit(event_class)
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /#{Regexp.escape(event_class.to_s)}/)
+  end
+end

--- a/spec/unit/stoplight/infrastructure/system_clock_spec.rb
+++ b/spec/unit/stoplight/infrastructure/system_clock_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe Stoplight::Infrastructure::SystemClock do
     end
   end
 
+  describe "#monotonic_time" do
+    subject(:monotonic_time) { clock.monotonic_time }
+
+    around do |example|
+      Timecop.freeze { example.run }
+    end
+
+    it "returns monotonic time" do
+      expect(monotonic_time).to be_within(0.1).of(Process.clock_gettime(Process::CLOCK_MONOTONIC))
+    end
+  end
+
   describe "#at" do
     subject(:at) { clock.at(timestamp) }
 


### PR DESCRIPTION
System now builds a `Domain::Telemetry` publisher and threads it through  `LightFactory` (which constructs a per-light `Emitter`) and `System::Storage`.

Clock gains `monotonic_time`, needed for measuring event durations. Nothing consumes the emitter yet.