### PR TITLE
Return monotonic time in milliseconds from SystemClock

### DIFF
--- a/lib/stoplight/infrastructure/system_clock.rb
+++ b/lib/stoplight/infrastructure/system_clock.rb
@@ -10,7 +10,7 @@ module Stoplight
     class SystemClock
       def current_time = Time.now.utc
 
-      def monotonic_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      def monotonic_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
 
       def at(timestamp) = Time.at(timestamp).utc
     end

--- a/spec/unit/stoplight/infrastructure/system_clock_spec.rb
+++ b/spec/unit/stoplight/infrastructure/system_clock_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Stoplight::Infrastructure::SystemClock do
       Timecop.freeze { example.run }
     end
 
-    it "returns monotonic time" do
-      expect(monotonic_time).to be_within(0.1).of(Process.clock_gettime(Process::CLOCK_MONOTONIC))
+    it "returns monotonic time in milliseconds" do
+      expect(monotonic_time).to be_within(10).of(Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond))
     end
   end
 


### PR DESCRIPTION
`SystemClock#monotonic_time` was added to the clock port with the documented contract "Returns monotonic time in ms" (`sig/_private/stoplight/domain/ports/clock.rbs`), and the sibling telemetry event field is named `duration_ms`. But the implementation used `Process.clock_gettime(Process::CLOCK_MONOTONIC)`, whose default unit is `:float_second` — it returned **seconds**, not milliseconds. A duration computed from two readings and stored as `duration_ms` would have been off by 1000×.

This passes `:float_millisecond` so the value matches the documented contract, keeping sub-millisecond precision (unlike the integer `:millisecond`).

The unit test now asserts the value is in milliseconds by comparing against a fresh `:float_millisecond` reading.