### PR TITLE
Optimization: Stoplight.ensure_configured

### DIFF
--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -173,6 +173,8 @@ module Stoplight # rubocop:disable Style/Documentation
 
     # @api private
     private def ensure_configured
+      return if configured?
+
       CONFIG_MUTEX.synchronize do
         configure unless configured?
       end


### PR DESCRIPTION
`Stoplight.ensure_configured` now checks `configured?` before taking mutex. Once the library is configured
  (the overwhelming majority of calls, since every `Stoplight()`/`Stoplight.light` invocation goes through state ->  `ensure_configured`), the mutex is never touched.

  Benchmark on isolated `ensure_configured` itself:

```
  after:  8.59M i/s  (116 ns/i)
  before: 5.57M i/s  (180 ns/i)
  after is 1.54x faster
```