### PR TITLE
Fix race condition in UnboundedWindow when accessing last_error_at

### DIFF
--- a/lib/stoplight/infrastructure/memory/storage/unbounded_metrics.rb
+++ b/lib/stoplight/infrastructure/memory/storage/unbounded_metrics.rb
@@ -58,9 +58,10 @@ module Stoplight
           def record_failure(exception)
             current_time = clock.current_time
             failure = Domain::Failure.from_error(exception, time: current_time)
-            last_error_at = self.last_error_at
 
             mutex.synchronize do
+              last_error_at = self.last_error_at
+
               if last_error_at.nil? || failure.occurred_at > last_error_at
                 self.last_error = failure
               end


### PR DESCRIPTION
I didn't figure out how to write a reproducible test 🤷‍♂️ 