### PR TITLE
Add Stoplight.register / Stoplight.light for reusable, faster-looked-up lights

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        light-creation: [ 'Stoplight()', 'System#light' ]
+        light-creation: [ 'Stoplight()', 'System#register' ]
         data-store: [ 'Redis' ]
         data-store-image:
           - 'redis:7.4'
@@ -60,7 +60,7 @@ jobs:
             light-creation: 'Stoplight()'
           - data-store: 'Memory'
             data-store-image: 'redis:7.4'
-            light-creation: 'System#light'
+            light-creation: 'System#register'
     services:
       data-store:
         image: ${{ matrix.data-store-image }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,9 @@ fails lint:
   signatures only** (`sig/_private/stoplight/domain/ports/`), never Ruby base classes.
 - **Infrastructure implements** those interfaces by **duck typing** (no inheritance).
 - Domain must never reference the composition root (`Stoplight.light` /
-  `.configure` / `Stoplight()`) or the root aliases `Stoplight::DataStore` /
-  `Stoplight::Notifier`. Use `Domain::Light` and domain interfaces directly.
+  `Stoplight.register` / `.configure` / `.light` / `Stoplight()`) or the root aliases
+  `Stoplight::DataStore` / `Stoplight::Notifier`. Use `Domain::Light` and
+  domain interfaces directly.
 - The same boundary rule applies to specs under `spec/unit/<layer>/`.
 
 Full detail: `docs/architecture.md`.
@@ -47,7 +48,8 @@ Full detail: `docs/architecture.md`.
 - `# frozen_string_literal: true` at the top of every Ruby file.
 - Let zeitwerk autoload - no manual `require` inside `lib/`. File path = constant path.
 - Internal-but-public plumbing uses the `__stoplight__` prefix.
-- Public surface is only: `Stoplight()`, `Stoplight.light`, `Stoplight.configure`.
+- Public surface is only: `Stoplight()`, `Stoplight.register`, `Stoplight.light`,
+  `Stoplight.configure`, `Light#run`
 - Public API methods require a doc comment with at least one usage example -
   see `lib/stoplight.rb` for the pattern. Document behavior, not types - types
   belong in RBS (`docs/types_and_rbs.md`).

--- a/README.md
+++ b/README.md
@@ -236,6 +236,29 @@ light = Stoplight("Payment Service",
 )
 ```
 
+### Registering Lights
+
+Calling `Stoplight("name", ...)` at every call site works well for a handful of lights. As an app
+grows, repeating the same settings everywhere makes them easy to drift out of sync, and there's no
+single place listing what lights exist.
+
+Register a light once and look it up by name wherever you need it, instead of repeating the same
+settings at every call site.
+
+```ruby
+# config/initializers/stoplight.rb
+Stoplight.register("Payment Service", threshold: 5, cool_off_time: 60)
+```
+
+```ruby
+# anywhere else in your app
+Stoplight.light("Payment Service").run { payment_gateway.process(order) }
+```
+
+`Stoplight("name", ...)` still works as shown above -- registration is an addition, not a replacement.
+`Stoplight.light` is also approximately 10 times faster, since it's a plain lookup rather than re-validating 
+the configuration on every call.
+
 ## Error Handling
 
 By default, Stoplight tracks all `StandardError` exceptions.

--- a/README.md
+++ b/README.md
@@ -236,29 +236,6 @@ light = Stoplight("Payment Service",
 )
 ```
 
-### Registering Lights
-
-Calling `Stoplight("name", ...)` at every call site works well for a handful of lights. As an app
-grows, repeating the same settings everywhere makes them easy to drift out of sync, and there's no
-single place listing what lights exist.
-
-Register a light once and look it up by name wherever you need it, instead of repeating the same
-settings at every call site.
-
-```ruby
-# config/initializers/stoplight.rb
-Stoplight.register("Payment Service", threshold: 5, cool_off_time: 60)
-```
-
-```ruby
-# anywhere else in your app
-Stoplight.light("Payment Service").run { payment_gateway.process(order) }
-```
-
-`Stoplight("name", ...)` still works as shown above -- registration is an addition, not a replacement.
-`Stoplight.light` is also approximately 10 times faster, since it's a plain lookup rather than re-validating 
-the configuration on every call.
-
 ## Error Handling
 
 By default, Stoplight tracks all `StandardError` exceptions.
@@ -291,6 +268,29 @@ Any list omitted from `run` keeps its configured value. The provided list is rep
 `skipped_errors` still takes precedence over `tracked_errors`.
 
 ## Advanced Configuration
+
+### Registering Lights
+
+Calling `Stoplight("name", ...)` at every call site works well for a handful of lights. As an app
+grows, repeating the same settings everywhere makes them easy to drift out of sync, and there's no
+single place listing what lights exist.
+
+Register a light once and look it up by name wherever you need it, instead of repeating the same
+settings at every call site.
+
+```ruby
+# config/initializers/stoplight.rb
+Stoplight.register("Payment Service", threshold: 5, cool_off_time: 60)
+```
+
+```ruby
+# anywhere else in your app
+Stoplight.light("Payment Service").run { payment_gateway.process(order) }
+```
+
+`Stoplight("name", ...)` still works as shown above -- registration is an addition, not a replacement.
+`Stoplight.light` is also approximately 10 times faster, since it's a plain lookup rather than re-validating 
+the configuration on every call.
 
 ### Traffic Control Strategies
 

--- a/bench/system_light.rb
+++ b/bench/system_light.rb
@@ -7,9 +7,9 @@ Stoplight(SecureRandom.uuid, threshold: 10)
 system = Stoplight.__stoplight__system("default")
 
 Benchmark.ips do |b|
-  b.report("before") { system.light("bar", threshold: 4) }
+  b.report("before") { system.register("bar", threshold: 4) }
   b.hold!("cache")
-  b.report("after") { system.light("bar", threshold: 4) }
+  b.report("after") { system.register("bar", threshold: 4) }
 
   b.compare!
 end

--- a/bench/system_light_prof.rb
+++ b/bench/system_light_prof.rb
@@ -15,7 +15,7 @@ PROF_TYPES = {
 }.freeze
 
 system = Stoplight.__stoplight__system("default 2")
-system.light("bar", threshold: 4)
+system.register("bar", threshold: 4)
 
 def profile_scenario(name, &block)
   result = RubyProf::Profile.profile do
@@ -31,7 +31,7 @@ end
 
 profile_scenario("success") do
   50.times do
-    system.light("bar", threshold: 4)
+    system.register("bar", threshold: 4)
   end
 end
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,8 +41,8 @@ end
 ## Hard rules for domain code
 
 - No `require`/reference to Redis, IO, Sinatra, or any infrastructure constant.
-- Never call the composition root: `Stoplight.light`, `Stoplight.configure`, 
-  or `Stoplight(...)`.
+- Never call the composition root: `Stoplight.light`, `Stoplight.register`,
+  `Stoplight.configure`, or `Stoplight(...)`.
 - Never reference the root aliases `Stoplight::DataStore` / `Stoplight::Notifier`.
   Reference `Stoplight::Domain::…` directly instead.
 - These same prohibitions apply to `spec/unit/stoplight/domain/**` - build collaborator

--- a/features/stoplight/support/configure_light_world.rb
+++ b/features/stoplight/support/configure_light_world.rb
@@ -8,8 +8,8 @@ module ConfigureLightWorld
     case factory_method
     when "Stoplight()"
       Stoplight(name, **collect_settings(table))
-    when "System#light"
-      system.light(name, **collect_settings(table))
+    when "System#register"
+      system.register(name, **collect_settings(table))
     else
       raise ArgumentError, "unexpected light creation method: `#{factory_method}`"
     end

--- a/features/stoplight/support/env.rb
+++ b/features/stoplight/support/env.rb
@@ -12,7 +12,7 @@ Before do
 end
 
 Before("@global_configuration") do
-  pending("Skipping global configuration tests for systems") if ENV["STOPLIGHT_LIGHT_CREATION"] == "System#light"
+  pending("Skipping global configuration tests for systems") if ENV["STOPLIGHT_LIGHT_CREATION"] == "System#register"
 end
 
 Around do |_scenario, block|

--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -61,11 +61,15 @@ module Stoplight # rubocop:disable Style/Documentation
       end
     end
 
-    # Create a Light with the user default configuration.
+    # Registers a Light with the given configuration.
     #
-    # @return [Stoplight::Light]
-    # @api private
-    def light(
+    # If a light with this name is already registered, returns it. If the given settings
+    # differ from the existing registration, raises +Stoplight::Error::ConfigurationError+.
+    # #
+    # @example
+    #   Stoplight.register("stripe", threshold: 5, cool_off_time: 60)
+    #
+    def register(
       name,
       cool_off_time: T.undefined,
       threshold: T.undefined,
@@ -76,7 +80,7 @@ module Stoplight # rubocop:disable Style/Documentation
       traffic_control: T.undefined,
       traffic_recovery: T.undefined
     )
-      state.default_system.light(
+      state.default_system.register(
         name,
         cool_off_time:,
         threshold:,
@@ -88,6 +92,16 @@ module Stoplight # rubocop:disable Style/Documentation
         traffic_recovery:
       )
     end
+
+    # Returns a Light previously registered.
+    #
+    # @raise [Stoplight::Error::UnregisteredLightError] if no light was registered under +name+
+    #
+    # @example
+    #   Stoplight.register("stripe", threshold: 5)
+    #   Stoplight.light("stripe")
+    #
+    def light(name) = state.default_system.light(name)
 
     # Creates a new named system with the given configuration.
     #
@@ -103,6 +117,7 @@ module Stoplight # rubocop:disable Style/Documentation
     #
     # @example Creating a system for payment services
     #   Payments = Stoplight.__stoplight__system(:payments, threshold: 3, cool_off_time: 30)
+    #   Payments.register("stripe")
     #   Payments.light("stripe").run { process_payment }
     #
     # @example Isolated system with dedicated data store
@@ -246,7 +261,7 @@ def Stoplight(
   traffic_control: Stoplight::T.undefined,
   traffic_recovery: Stoplight::T.undefined
 ) # rubocop:disable Naming/MethodName
-  Stoplight.light(
+  Stoplight.register(
     name,
     cool_off_time:,
     threshold:,

--- a/lib/stoplight/error.rb
+++ b/lib/stoplight/error.rb
@@ -5,6 +5,9 @@ module Stoplight
     class Base < StandardError
     end
 
+    class UnregisteredLightError < Base
+    end
+
     class ConfigurationError < Base
     end
 

--- a/lib/stoplight/wiring/global_state.rb
+++ b/lib/stoplight/wiring/global_state.rb
@@ -50,7 +50,7 @@ module Stoplight
             ),
             error_notifier: config.error_notifier,
             failover_registry: Infrastructure::Memory::Storage::Registry.new,
-            circuit_breaker: failover_system.light("registry")
+            circuit_breaker: failover_system.register("registry")
           )
         when DataStore::Memory
           Infrastructure::Memory::Storage::Registry.new

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -158,7 +158,7 @@ module Stoplight
       end
 
       def create_circuit_breaker(name)
-        failover_system.light(name)
+        failover_system.register(name)
       end
     end
   end

--- a/lib/stoplight/wiring/system.rb
+++ b/lib/stoplight/wiring/system.rb
@@ -4,7 +4,6 @@ require "concurrent/map"
 
 module Stoplight
   module Wiring
-    # 🚧UNDER CONSTRUCTION 🚧
     # System provides namespace isolation and shared configuration for related circuits.
     #
     # Systems enforce configuration consistency within their scope - creating the same
@@ -13,37 +12,35 @@ module Stoplight
     # This prevents subtle bugs where circuits silently interfere with each other.
     #
     # @example Basic usage
-    #   billing = Stoplight.system(:billing,
+    #   billing = Stoplight.__stoplight__system(:billing,
     #     data_store: billing_redis,
     #     threshold: 5,
     #     window_size: 300
     #   )
     #
-    #   billing.light("stripe")
-    #   billing.light("paypal")
+    #   billing.register("stripe")
+    #   billing.register("paypal")
+    #
+    #   billing.light("stripe").run { ... }
+    #   billing.light("paypal").run { ... }
     #
     # @example Multi-tenancy
-    #   tenant_a = Stoplight.system(:tenant_a, data_store: tenant_a_redis)
-    #   tenant_b = Stoplight.system(:tenant_b, data_store: tenant_b_redis)
+    #   tenant_a = Stoplight.__stoplight__system(:tenant_a, data_store: tenant_a_redis)
+    #   tenant_b = Stoplight.__stoplight__system(:tenant_b, data_store: tenant_b_redis)
     #
     #   # Same circuit name, completely isolated
-    #   tenant_a.light("api")
-    #   tenant_b.light("api")
+    #   tenant_a.register("api")
+    #   tenant_b.register("api")
     #
     # @example Configuration inheritance
-    #   system = Stoplight.system(:payments, threshold: 3, cool_off_time: 600)
+    #   system = Stoplight.__stoplight__system(:payments, threshold: 3, cool_off_time: 600)
     #
-    #   system.light("stripe")                # Inherits threshold: 3
-    #   system.light("paypal", threshold: 5)  # Overrides threshold
+    #   system.register("stripe")                # Inherits threshold: 3
+    #   system.register("paypal", threshold: 5)  # Overrides threshold
     #
-    # @note System configuration objects (data_store, notifiers) should be defined
-    #   as constants and reused, not created inline. This ensures configuration
-    #   matching works correctly across multiple system references.
-    #
-    # @note Light instances are cached within the system. Calling {#light} with
-    #   the same name returns the cached instance.
-    #
-    # @api private
+    # @note Light instances are cached within the system once {#register}ed. {#light}
+    #   returns that cached instance and raises +Stoplight::Error::UnregisteredLightError+
+    #   if the name was never registered.
     class System
       attr_reader :name
       # @!attribute system_config
@@ -65,23 +62,24 @@ module Stoplight
         @telemetry = Domain::Telemetry.new(error_notifier: config.error_notifier)
       end
 
-      # Creates or retrieves a light.
+      # Registers and returns a light.
       #
-      # If a light with this name already exists, returns the cached instance.
+      # If a light with this name already exists, returns it.
       # If settings differ from the existing light, raises +Stoplight::Error::ConfigurationError+.
       #
       # @raise [Stoplight::Error::ConfigurationError] if light exists with different settings
       #
-      # @example Create a light
-      #   light = system.light("stripe", threshold: 5, window_size: 60)
+      # @example Register a light
+      #   system.register("stripe", threshold: 5, window_size: 60)
+      #   system.light("stripe") #=> returns named light
       #
       # @example Configuration conflict
-      #   system.light("api", threshold: 5)
-      #   system.light("api", threshold: 10)  # Raises ConfigurationError
+      #   system.register("api", threshold: 5)
+      #   system.register("api", threshold: 10)  # Raises ConfigurationError
       #
       # @note Thread-safe: multiple threads can safely call this method concurrently
       #
-      def light(
+      def register(
         name,
         cool_off_time: T.undefined,
         threshold: T.undefined,
@@ -105,7 +103,7 @@ module Stoplight
         )
         config_digest = light_dsl.digest
 
-        light, existing_digest, existing_source_line = lights.compute_if_absent(name) do
+        light, existing_digest, existing_source_line = @lights.compute_if_absent(name) do
           source_line = caller(6, 1)&.first # Very expensive call
           config = light_dsl.configure!(system_config)
           built = LightFactory.new(
@@ -132,6 +130,14 @@ module Stoplight
         light
       end
 
+      # @raise [Stoplight::Error::UnregisteredLightError] if no light was registered under +name+
+      def light(name)
+        @lights[name]&.first || raise(Stoplight::Error::UnregisteredLightError, <<~MSG)
+          Light `#{name}` was never registered on system `#{@name}`.
+          Call `.register(#{name.inspect}, ...)` at boot before using it.
+        MSG
+      end
+
       # @api private
       def __stoplight__storage
         Storage.new(
@@ -145,10 +151,6 @@ module Stoplight
       def __stoplight__registry
         @registry
       end
-
-      private
-
-      attr_reader :lights
     end
   end
 end

--- a/rubocop/stoplight/architecture_boundaries.rb
+++ b/rubocop/stoplight/architecture_boundaries.rb
@@ -92,11 +92,11 @@ module RuboCop
           return unless @current_layer == :domain
           return unless node.receiver
 
-          # Check for Stoplight.light() or Stoplight.configure()
+          # Check for Stoplight.light(), Stoplight.register(), or Stoplight.configure()
           if node.receiver.const_type?
             receiver_name = extract_constant_path(node.receiver)
             if receiver_name == "Stoplight" &&
-                [:light, :system_light, :configure].include?(node.method_name)
+                [:light, :register, :system_light, :configure].include?(node.method_name)
               add_offense(
                 node,
                 message: format(

--- a/sig/_private/stoplight/wiring/system.rbs
+++ b/sig/_private/stoplight/wiring/system.rbs
@@ -4,11 +4,11 @@ module Stoplight
       include _System
 
       @name: String
+      @lights: Concurrent::Map[String, [_Light, Integer, String?]]
       @failover_system: _System?
       @registry: Domain::_Registry
       @telemetry: Domain::_TelemetryPublisher
 
-      attr_reader lights: Concurrent::Map[String, [_Light, Integer, String?]]
       attr_reader system_config: Domain::Config
 
       def initialize: (config: Domain::Config, failover_system: _System?, registry: Domain::_Registry) -> void

--- a/sig/stoplight.rbs
+++ b/sig/stoplight.rbs
@@ -30,7 +30,7 @@ module Stoplight
 
   def self.configure: (?trust_me_im_an_engineer: bool) ?{ (_Configuration) -> void } -> void
 
-  def self.light: (
+  def self.register: (
       String name,
       ?cool_off_time: optional[duration],
       ?threshold: optional[percentage | Integer],
@@ -41,6 +41,8 @@ module Stoplight
       ?traffic_control: optional[traffic_control],
       ?traffic_recovery: optional[traffic_recovery],
     ) -> _Light
+
+  def self.light: (String name) -> _Light
 end
 
 module Kernel

--- a/sig/stoplight/error.rbs
+++ b/sig/stoplight/error.rbs
@@ -3,6 +3,9 @@ module Stoplight
     class Base < StandardError
     end
 
+    class UnregisteredLightError < Base
+    end
+
     class ConfigurationError < Base
     end
 

--- a/sig/stoplight/ports/system.rbs
+++ b/sig/stoplight/ports/system.rbs
@@ -2,11 +2,11 @@
 
 module Stoplight
   # A System is a composition root that groups related circuit breakers
-  # with shared configuration.
+  # with shared infrastructure configuration and defaults.
   interface _System
     def name: -> String
 
-    def light: (
+    def register: (
       String name,
       ?cool_off_time: optional[duration],
       ?threshold: optional[percentage | Integer],
@@ -17,6 +17,8 @@ module Stoplight
       ?traffic_control: optional[traffic_control],
       ?traffic_recovery: optional[traffic_recovery]
     ) -> _Light
+
+    def light: (String name) -> _Light
 
     def telemetry: -> _Telemetry
   end

--- a/spec/unit/rubocop/architecture_boundaries_spec.rb
+++ b/spec/unit/rubocop/architecture_boundaries_spec.rb
@@ -260,6 +260,19 @@ RSpec.describe RuboCop::Cop::Stoplight::ArchitectureBoundaries, :config do
       RUBY
     end
 
+    it "detects Stoplight.register() call" do
+      expect_offense(<<~RUBY, filename)
+        module Stoplight::Domain
+          class CircuitManager
+            def create
+              Stoplight.register("test")
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^ Stoplight/ArchitectureBoundaries: domain cannot reference Stoplight composition root (use Domain::Light directly)
+            end
+          end
+        end
+      RUBY
+    end
+
     it "detects Stoplight.configure() call" do
       expect_offense(<<~RUBY, filename)
         module Stoplight::Domain

--- a/spec/unit/stoplight/admin/lights_repository_spec.rb
+++ b/spec/unit/stoplight/admin/lights_repository_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Stoplight::Admin::LightsRepository, :redis do
   let(:registry) { instance_double(Stoplight::Infrastructure::Redis::Storage::Registry) }
   let(:data_store_config) { Stoplight::DataStore::Redis.new(redis) }
   let(:name) { "lights-repository" }
-  let(:light) { system.light(name) }
+  let(:light) { system.register(name) }
 
   before do
     Stoplight.configure(trust_me_im_an_engineer: true) do |config|
@@ -56,8 +56,8 @@ RSpec.describe Stoplight::Admin::LightsRepository, :redis do
   describe "#with_color" do
     before do
       allow(registry).to receive(:names).and_return(["red-light", "green-light"])
-      system.light("red-light").lock("red")
-      system.light("green-light").lock("green")
+      system.register("red-light").lock("red")
+      system.register("green-light").lock("green")
     end
 
     it "returns light with requested color" do
@@ -84,6 +84,20 @@ RSpec.describe Stoplight::Admin::LightsRepository, :redis do
         expect { lock }
           .to change { light.state }
           .to("locked_green")
+      end
+    end
+
+    context "when the light was never registered on this system" do
+      subject(:lock) { repository.lock("never-registered") }
+
+      before { allow(registry).to receive(:names).and_return(["never-registered"]) }
+
+      it "locks the light anyway" do
+        lock
+
+        expect(repository.all).to contain_exactly(
+          have_attributes(name: "never-registered", state: "locked_green")
+        )
       end
     end
 

--- a/spec/unit/stoplight/wiring/system_spec.rb
+++ b/spec/unit/stoplight/wiring/system_spec.rb
@@ -148,8 +148,8 @@ RSpec.describe Stoplight::Wiring::System do
           system.register("bar", cool_off_time: 30, threshold: 44)
         end.to raise_error(
           include(/Light `bar` already registered with different configuration/)
-            .and(include(/system_spec\.rb:143/))
-            .and(include(/system_spec\.rb:147/))
+            .and(include(/system_spec\.rb:144/))
+            .and(include(/system_spec\.rb:148/))
         )
       end
     end

--- a/spec/unit/stoplight/wiring/system_spec.rb
+++ b/spec/unit/stoplight/wiring/system_spec.rb
@@ -12,89 +12,89 @@ RSpec.describe Stoplight::Wiring::System do
   end
   let(:registry) { instance_double(Stoplight::Infrastructure::Memory::Storage::Registry, register: nil) }
 
-  describe "#light" do
+  describe "#register" do
     let(:system_config) { Stoplight::Wiring::DefaultConfig.with(name: SecureRandom.uuid) }
 
     describe "caching behavior with same name and no settings" do
-      let(:light) { system.light(name) }
+      let(:light) { system.register(name) }
       let(:name) { "foo" }
 
       it "returns cached instance on repeated calls" do
-        expect(light).to equal(system.light(name))
+        expect(light).to equal(system.register(name))
       end
     end
 
     describe "isolation with different light names" do
-      let(:light) { system.light(name) }
+      let(:light) { system.register(name) }
       let(:name) { "foo" }
 
       it "returns different instances for different names" do
-        expect(light).not_to equal(system.light("bar"))
+        expect(light).not_to equal(system.register("bar"))
       end
     end
 
     describe "caching with identical settings" do
-      let(:light) { system.light(name, cool_off_time: 30, threshold: 4) }
+      let(:light) { system.register(name, cool_off_time: 30, threshold: 4) }
       let(:name) { "foo" }
 
       it "returns cached instance when settings match exactly" do
-        expect(light).to equal(system.light(name, cool_off_time: 30, threshold: 4))
+        expect(light).to equal(system.register(name, cool_off_time: 30, threshold: 4))
       end
     end
 
     describe "caching with settings in different order" do
-      let(:light) { system.light(name, cool_off_time: 30, threshold: 4) }
+      let(:light) { system.register(name, cool_off_time: 30, threshold: 4) }
       let(:name) { "foo" }
 
       it "returns cached instance regardless of parameter order" do
-        expect(light).to equal(system.light(name, threshold: 4, cool_off_time: 30))
+        expect(light).to equal(system.register(name, threshold: 4, cool_off_time: 30))
       end
     end
 
     describe "configuration conflict detection" do
       before do
-        system.light("name", cool_off_time: 30, threshold: 4)
+        system.register("name", cool_off_time: 30, threshold: 4)
       end
 
       it "raises error when same name used with different settings" do
         expect do
-          system.light("name", cool_off_time: 30, threshold: 5)
+          system.register("name", cool_off_time: 30, threshold: 5)
         end.to raise_error(Stoplight::Error::ConfigurationError)
       end
     end
 
     describe "different names with different settings" do
-      let(:light) { system.light("bar", cool_off_time: 30, threshold: 4) }
+      let(:light) { system.register("bar", cool_off_time: 30, threshold: 4) }
 
       it "allows different configurations for different light names" do
-        expect(light).not_to equal(system.light("foo", cool_off_time: 30, threshold: 5))
+        expect(light).not_to equal(system.register("foo", cool_off_time: 30, threshold: 5))
       end
     end
 
     describe "with normalized equivalent settings" do
-      let!(:light) { system.light("bar", tracked_errors: RuntimeError) }
+      let!(:light) { system.register("bar", tracked_errors: RuntimeError) }
 
       it "returns same light when tracked_errors is normalized" do
-        expect(light).to equal(system.light("bar", tracked_errors: [RuntimeError]))
+        expect(light).to equal(system.register("bar", tracked_errors: [RuntimeError]))
       end
     end
 
     describe "with different traffic control strategies" do
-      before { system.light("bar", traffic_control: :consecutive_errors) }
+      before { system.register("bar", traffic_control: :consecutive_errors) }
 
       it "raises error when same name uses different strategies" do
         expect do
-          system.light("bar", traffic_control: :error_rate, threshold: 0.3)
+          system.register("bar", traffic_control: :error_rate, threshold: 0.3)
         end.to raise_error(Stoplight::Error::ConfigurationError)
       end
     end
 
     describe "concurrent access" do
-      let(:expected) { system.light("bar", cool_off_time: 30) }
+      let(:expected) { system.register("bar", cool_off_time: 30) }
 
       let(:lights) do
         100.times
-          .map { Thread.new { system.light("bar", cool_off_time: 30) } }
+          .map { Thread.new { system.register("bar", cool_off_time: 30) } }
           .each(&:join)
           .map(&:value)
       end
@@ -105,11 +105,11 @@ RSpec.describe Stoplight::Wiring::System do
     end
 
     describe "with partially overlapping settings" do
-      before { system.light("bar", cool_off_time: 30) }
+      before { system.register("bar", cool_off_time: 30) }
 
       it "raises error when adding different setting to same name" do
         expect do
-          system.light("bar", cool_off_time: 30, threshold: 44)
+          system.register("bar", cool_off_time: 30, threshold: 44)
         end.to raise_error(Stoplight::Error::ConfigurationError)
       end
     end
@@ -123,33 +123,33 @@ RSpec.describe Stoplight::Wiring::System do
       end
 
       it "allows creating multiple lights without raising" do
-        system.light("stripe")
-        expect { system.light("paypal") }.not_to raise_error
+        system.register("stripe")
+        expect { system.register("paypal") }.not_to raise_error
       end
     end
 
     describe "inheriting system configuration" do
       before do
-        system.light("foo")
+        system.register("foo")
       end
 
       it "raises error as user-provided settings does not match exactly" do
         expect do
-          system.light("foo", threshold: system_config.threshold)
+          system.register("foo", threshold: system_config.threshold)
         end.to raise_error(Stoplight::Error::ConfigurationError)
       end
     end
 
     describe "error messages" do
-      before { system.light("bar", cool_off_time: 30) }
+      before { system.register("bar", cool_off_time: 30) }
 
       it "includes both configs in error message" do
         expect do
-          system.light("bar", cool_off_time: 30, threshold: 44)
+          system.register("bar", cool_off_time: 30, threshold: 44)
         end.to raise_error(
           include(/Light `bar` already registered with different configuration/)
-            .and(include(/system_spec\.rb:144/))
-            .and(include(/system_spec\.rb:148/))
+            .and(include(/system_spec\.rb:143/))
+            .and(include(/system_spec\.rb:147/))
         )
       end
     end
@@ -161,16 +161,40 @@ RSpec.describe Stoplight::Wiring::System do
       subject!(:system) { described_class.new(config: system_config, failover_system:, registry:) }
 
       it "registers the light name when a new light is created" do
-        system.light("stripe")
+        system.register("stripe")
 
         expect(registry).to have_received(:register).with("stripe", config: anything)
       end
 
       it "does not register again on repeated calls with the same name" do
-        system.light("stripe")
-        system.light("stripe")
+        system.register("stripe")
+        system.register("stripe")
 
         expect(registry).to have_received(:register).once
+      end
+    end
+  end
+
+  describe "#light" do
+    let(:system_config) { Stoplight::Wiring::DefaultConfig.with(name: SecureRandom.uuid) }
+    let(:light) { system.light("stripe") }
+
+    context "when light is registered" do
+      let!(:registered_light) { system.register("stripe") }
+
+      it "returns the light instance" do
+        expect(light).to be(registered_light)
+      end
+    end
+
+    context "when light is not registered" do
+      it "raises an error" do
+        expect do
+          light
+        end.to raise_error(
+          Stoplight::Error::UnregisteredLightError,
+          /Light `stripe` was never registered on system `.+`/
+        )
       end
     end
   end

--- a/spec/unit/stoplight_spec.rb
+++ b/spec/unit/stoplight_spec.rb
@@ -81,6 +81,32 @@ RSpec.describe "Stoplight" do
     end
   end
 
+  describe ".register" do
+    it "returns the registered light" do
+      expect(Stoplight.register(name)).to be_kind_of(Stoplight::Domain::Light)
+    end
+
+    it "returns the same instance on repeated calls with matching settings" do
+      expect(Stoplight.register(name)).to equal(Stoplight.register(name))
+    end
+  end
+
+  describe ".light" do
+    context "when the name was registered" do
+      it "returns the registered light" do
+        registered = Stoplight.register(name)
+
+        expect(Stoplight.light(name)).to be(registered)
+      end
+    end
+
+    context "when the name was never registered" do
+      it "raises an error" do
+        expect { Stoplight.light(name) }.to raise_error(Stoplight::Error::UnregisteredLightError, /#{name}/)
+      end
+    end
+  end
+
   describe ".__stoplight__system" do
     context "name is not in use yet" do
       subject(:system) { Stoplight.__stoplight__system(SecureRandom.uuid) }
@@ -134,7 +160,7 @@ RSpec.describe "Stoplight" do
           notifiers: [BrokenNotifier.new, BrokenNotifier.new, BrokenNotifier.new, spy_notifier]
         )
 
-        system.light("payments").run(->(_) {}) { raise "dependency failure" }
+        system.register("payments").run(->(_) {}) { raise "dependency failure" }
 
         expect(spy_notifier.notifications).not_to be_empty
       end


### PR DESCRIPTION
Calling `Stoplight("name", ...)` at every call site works well for a handful of lights. As
an app grows, repeating the same settings everywhere makes them easy to drift out of sync,
and there's no single place listing what lights exist.

- Adds `Stoplight.register(name, ...)` to define a light's configuration once (e.g. in an
  initializer) and `Stoplight.light(name)` to look it up by name anywhere else, without
  repeating settings. `Stoplight.light` raises the new
  `Stoplight::Error::UnregisteredLightError` if the name was never registered.
- `Stoplight(name, ...)` still works exactly as before and now registers under the hood, so
  existing call sites are unaffected - registration is additive, not a replacement.
- `Stoplight.light` is also faster: `Stoplight.register`/`Stoplight(name, ...)` re-validates
  the configuration digest on every call, while `Stoplight.light` is a plain lookup. It's 
  ~9-10x more iterations/sec compared to `Stoplight()` calls..