### PR TITLE
Inline red-light behavior into YellowRunStrategy instead of delegating

### DIFF
--- a/lib/stoplight/domain/strategies/yellow_run_strategy.rb
+++ b/lib/stoplight/domain/strategies/yellow_run_strategy.rb
@@ -16,7 +16,6 @@ module Stoplight
           error_tracking_policy:,
           notifiers:,
           request_tracker:,
-          cool_off_time:,
           state_store:,
           metrics_store:,
           recovery_lock_store:,
@@ -24,7 +23,6 @@ module Stoplight
         )
           @notifiers = notifiers
           @request_tracker = request_tracker
-          @cool_off_time = cool_off_time
           @state_store = state_store
           @metrics_store = metrics_store
           @recovery_lock_store = recovery_lock_store
@@ -83,7 +81,7 @@ module Stoplight
 
             raise Error::RedLight.new(
               @name,
-              cool_off_time: @cool_off_time,
+              cool_off_time: @config.cool_off_time,
               retry_after: state_snapshot.recovery_scheduled_after
             )
           end

--- a/lib/stoplight/domain/strategies/yellow_run_strategy.rb
+++ b/lib/stoplight/domain/strategies/yellow_run_strategy.rb
@@ -16,7 +16,7 @@ module Stoplight
           error_tracking_policy:,
           notifiers:,
           request_tracker:,
-          red_run_strategy:,
+          cool_off_time:,
           state_store:,
           metrics_store:,
           recovery_lock_store:,
@@ -24,7 +24,7 @@ module Stoplight
         )
           @notifiers = notifiers
           @request_tracker = request_tracker
-          @red_run_strategy = red_run_strategy
+          @cool_off_time = cool_off_time
           @state_store = state_store
           @metrics_store = metrics_store
           @recovery_lock_store = recovery_lock_store
@@ -46,7 +46,7 @@ module Stoplight
           #   - execute user's code
           #   - record outcome
           #   - transition to green or red if needed
-          with_recovery_lock(fallback:, state_snapshot:, code:) do
+          with_recovery_lock(fallback:, state_snapshot:) do
             enter_recovery(state_snapshot)
 
             result = code.call
@@ -72,15 +72,20 @@ module Stoplight
 
         attr_reader :notifiers
         attr_reader :request_tracker
-        attr_reader :red_run_strategy
         attr_reader :state_store
         attr_reader :metrics_store
         attr_reader :recovery_lock_store
 
-        def with_recovery_lock(fallback:, state_snapshot:, code:)
+        def with_recovery_lock(fallback:, state_snapshot:)
           recovery_lock_token = recovery_lock_store.acquire_lock
           if recovery_lock_token.nil?
-            return red_run_strategy.execute(fallback, state_snapshot:, &code)
+            return fallback.call(nil) if fallback
+
+            raise Error::RedLight.new(
+              @name,
+              cool_off_time: @cool_off_time,
+              retry_after: state_snapshot.recovery_scheduled_after
+            )
           end
 
           begin

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -111,7 +111,6 @@ module Stoplight
           error_tracking_policy: @error_tracking_policy,
           notifiers:,
           request_tracker: recovery_probe_tracker,
-          cool_off_time: @cool_off_time,
           state_store:,
           metrics_store:,
           recovery_lock_store:,

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -111,7 +111,7 @@ module Stoplight
           error_tracking_policy: @error_tracking_policy,
           notifiers:,
           request_tracker: recovery_probe_tracker,
-          red_run_strategy:,
+          cool_off_time: @cool_off_time,
           state_store:,
           metrics_store:,
           recovery_lock_store:,

--- a/sig/_private/stoplight/domain/strategies/yellow_run_strategy.rbs
+++ b/sig/_private/stoplight/domain/strategies/yellow_run_strategy.rbs
@@ -9,18 +9,18 @@ module Stoplight
         attr_reader recovery_lock_store: _RecoveryLockStore
         attr_reader notifiers: Array[state_transition_notifier]
         attr_reader request_tracker: Tracker::RecoveryProbe
-        attr_reader red_run_strategy: RedRunStrategy
 
         @name: String
         @config: Domain::Config
         @error_tracking_policy: ErrorTrackingPolicy
+        @cool_off_time: duration
 
         def initialize: (
           name: String,
           error_tracking_policy: ErrorTrackingPolicy,
           notifiers: Array[state_transition_notifier],
           request_tracker: Tracker::RecoveryProbe,
-          red_run_strategy: RedRunStrategy,
+          cool_off_time: duration,
           state_store: Domain::_StateStore,
           metrics_store: _MetricsStore,
           recovery_lock_store: _RecoveryLockStore,
@@ -30,7 +30,6 @@ module Stoplight
         def with_recovery_lock: [T] (
             fallback: (^(StandardError?) -> T)?,
             state_snapshot: StateSnapshot,
-            code: ^() -> T,
           ) { () -> T } -> T
 
         def record_recovery_probe_success: () -> void

--- a/sig/_private/stoplight/domain/strategies/yellow_run_strategy.rbs
+++ b/sig/_private/stoplight/domain/strategies/yellow_run_strategy.rbs
@@ -13,14 +13,12 @@ module Stoplight
         @name: String
         @config: Domain::Config
         @error_tracking_policy: ErrorTrackingPolicy
-        @cool_off_time: duration
 
         def initialize: (
           name: String,
           error_tracking_policy: ErrorTrackingPolicy,
           notifiers: Array[state_transition_notifier],
           request_tracker: Tracker::RecoveryProbe,
-          cool_off_time: duration,
           state_store: Domain::_StateStore,
           metrics_store: _MetricsStore,
           recovery_lock_store: _RecoveryLockStore,

--- a/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
       error_tracking_policy:,
       notifiers: notifiers,
       request_tracker:,
-      red_run_strategy:,
+      cool_off_time:,
       state_store:,
       metrics_store:,
       recovery_lock_store:,
@@ -23,7 +23,6 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
   let(:state_store) { instance_double(NullStateStore) }
   let(:metrics_store) { instance_double(NullMetricsStore) }
   let(:request_tracker) { instance_double(Stoplight::Domain::Tracker::RecoveryProbe) }
-  let(:red_run_strategy) { Stoplight::Domain::Strategies::RedRunStrategy.new(name:, cool_off_time:) }
   let(:cool_off_time) { 60 }
   let(:config) { instance_double(Stoplight::Domain::Config, name:) }
 

--- a/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
   let(:state_store) { instance_double(NullStateStore) }
   let(:metrics_store) { instance_double(NullMetricsStore) }
   let(:request_tracker) { instance_double(Stoplight::Domain::Tracker::RecoveryProbe) }
-  let(:red_run_strategy) { instance_double(Stoplight::Domain::Strategies::RedRunStrategy) }
+  let(:red_run_strategy) { Stoplight::Domain::Strategies::RedRunStrategy.new(name:, cool_off_time:) }
+  let(:cool_off_time) { 60 }
   let(:config) { instance_double(Stoplight::Domain::Config, name:) }
 
   describe "#exceute" do
@@ -108,18 +109,41 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
     end
 
     context "when recovery lock is not acquired" do
-      let(:value) { instance_double(Object) }
-      let(:fallback) { instance_double(Proc) }
-      let(:state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot) }
+      let(:state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot, recovery_scheduled_after: Time.now) }
 
-      it "delegates to red_run_strategy" do
-        expect(recovery_lock_store).to receive(:acquire_lock).and_return(nil)
-        expect(red_run_strategy).to receive(:execute).with(fallback, state_snapshot:).and_return(value)
+      before do
+        allow(recovery_lock_store).to receive(:acquire_lock).and_return(nil)
+      end
 
-        expect do |code|
-          result = strategy.execute(fallback, state_snapshot:, &code)
-          expect(result).to eq(value)
-        end.not_to yield_control
+      context "when fallback is provided" do
+        let(:fallback) do
+          ->(error) {
+            @error = error
+            "Fallback"
+          }
+        end
+
+        it "returns the fallback result without yielding" do
+          expect do |code|
+            result = strategy.execute(fallback, state_snapshot:, &code)
+            expect(result).to eq("Fallback")
+          end.not_to yield_control
+
+          expect(@error).to eq(nil)
+        end
+      end
+
+      context "when fallback is not provided" do
+        let(:fallback) { nil }
+
+        it "raises RedLight without yielding" do
+          expect do |code|
+            expect { strategy.execute(fallback, state_snapshot:, &code) }.to raise_error(Stoplight::Error::RedLight, name) { |error|
+              expect(error.cool_off_time).to eq(cool_off_time)
+              expect(error.retry_after).to eq(state_snapshot.recovery_scheduled_after)
+            }
+          end.not_to yield_control
+        end
       end
     end
   end

--- a/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
       error_tracking_policy:,
       notifiers: notifiers,
       request_tracker:,
-      cool_off_time:,
       state_store:,
       metrics_store:,
       recovery_lock_store:,
@@ -24,7 +23,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
   let(:metrics_store) { instance_double(NullMetricsStore) }
   let(:request_tracker) { instance_double(Stoplight::Domain::Tracker::RecoveryProbe) }
   let(:cool_off_time) { 60 }
-  let(:config) { instance_double(Stoplight::Domain::Config, name:) }
+  let(:config) { instance_double(Stoplight::Domain::Config, name:, cool_off_time:) }
 
   describe "#exceute" do
     before do


### PR DESCRIPTION
YellowRunStrategy delegated to RedRunStrategy when it lost the recovery-lock race, treating lock contention as a red-light call. That was a false abstraction: yellow and red only happen to raise the same error - they're not the same situation, and RedRunStrategy has no way to know it's being borrowed.

- Inline the fallback-or-raise-RedLight behavior directly into YellowRunStrategy instead of delegating; RedRunStrategy is untouched and still owns the true red-light path.
- This duplicates a few lines of RedLight construction between the two strategies - accepted, since the alternative (delegation) was the wrong coupling.