### PR TITLE
Telemetry (Part 4b) - Wire RunRecorder into Green/Yellow/Red run strategies

### DIFF
--- a/lib/stoplight/domain/strategies/green_run_strategy.rb
+++ b/lib/stoplight/domain/strategies/green_run_strategy.rb
@@ -10,9 +10,11 @@ module Stoplight
       #
       # @api private
       class GreenRunStrategy
-        def initialize(error_tracking_policy:, request_tracker:)
+        def initialize(error_tracking_policy:, request_tracker:, run_recorder:, clock:)
           @error_tracking_policy = error_tracking_policy
           @request_tracker = request_tracker
+          @run_recorder = run_recorder
+          @clock = clock
         end
 
         # Executes the provided code block when the light is in the green state.
@@ -23,23 +25,27 @@ module Stoplight
         # @return The result of the code block if successful.
         # @raise re-raises the error if it is not tracked or no fallback is provided.
         def execute(fallback, state_snapshot:, &code)
-          # TODO: Consider implementing sampling rate to limit the memory footprint
-          result = code.call
-          record_success
-          result
-        rescue => error
-          if @error_tracking_policy.track?(error)
-            record_error(error)
+          started_at = capture_started_at
 
-            if fallback
-              fallback.call(error)
+          begin
+            result = code.call
+            record_success(duration_ms: duration_since(started_at))
+
+            result
+          rescue => error
+            if @error_tracking_policy.track?(error)
+              record_error(error, duration_ms: duration_since(started_at), fallback_used: !fallback.nil?)
+
+              if fallback
+                fallback.call(error)
+              else
+                raise
+              end
             else
+              # User chose to not track the error, so we record it as a success
+              record_success(duration_ms: duration_since(started_at), error: error)
               raise
             end
-          else
-            # User chose to not track the error, so we record it as a success
-            record_success
-            raise
           end
         end
 
@@ -48,11 +54,21 @@ module Stoplight
         attr_reader :config
         attr_reader :request_tracker
 
-        def record_error(error)
+        def capture_started_at
+          @clock.monotonic_time if @run_recorder.subscribed?
+        end
+
+        def duration_since(started_at)
+          @clock.monotonic_time - started_at if started_at
+        end
+
+        def record_error(error, duration_ms:, fallback_used:)
+          @run_recorder.record_failure(error, duration_ms:, fallback_used:)
           request_tracker.record_failure(error)
         end
 
-        def record_success
+        def record_success(duration_ms:, error: nil)
+          @run_recorder.record_success(duration_ms:, error:)
           request_tracker.record_success
         end
       end

--- a/lib/stoplight/domain/strategies/red_run_strategy.rb
+++ b/lib/stoplight/domain/strategies/red_run_strategy.rb
@@ -10,9 +10,10 @@ module Stoplight
       #
       # @api private
       class RedRunStrategy
-        def initialize(name:, cool_off_time:)
+        def initialize(name:, cool_off_time:, run_recorder:)
           @name = name
           @cool_off_time = cool_off_time
+          @run_recorder = run_recorder
         end
 
         # Executes the fallback proc when the light is in the red state.
@@ -22,6 +23,11 @@ module Stoplight
         # @return The result of the fallback proc if provided.
         # @raise [Stoplight::Error::RedLight] Raises an error if no fallback is provided.
         def execute(fallback, state_snapshot:)
+          @run_recorder.record_blocked(
+            fallback_used: !fallback.nil?,
+            retry_after: state_snapshot.recovery_scheduled_after
+          )
+
           if fallback
             fallback.call(nil)
           else

--- a/lib/stoplight/domain/strategies/yellow_run_strategy.rb
+++ b/lib/stoplight/domain/strategies/yellow_run_strategy.rb
@@ -19,7 +19,9 @@ module Stoplight
           state_store:,
           metrics_store:,
           recovery_lock_store:,
-          config: # FIXME: needed for backward compatibility, remove when notifier accepts light config
+          config:, # FIXME: needed for backward compatibility, remove when notifier accepts light config
+          clock:,
+          run_recorder:
         )
           @notifiers = notifiers
           @request_tracker = request_tracker
@@ -29,6 +31,8 @@ module Stoplight
           @name = name
           @error_tracking_policy = error_tracking_policy
           @config = config
+          @clock = clock
+          @run_recorder = run_recorder
         end
 
         # Executes the provided code block when the light is in the yellow state.
@@ -44,15 +48,15 @@ module Stoplight
           #   - execute user's code
           #   - record outcome
           #   - transition to green or red if needed
-          with_recovery_lock(fallback:, state_snapshot:) do
+          with_recovery_lock(fallback:, state_snapshot:) do |started_at|
             enter_recovery(state_snapshot)
 
             result = code.call
-            record_recovery_probe_success
+            record_recovery_probe_success(duration_ms: duration_since(started_at))
             result
           rescue => error
             if @error_tracking_policy.track?(error)
-              record_recovery_probe_failure(error)
+              record_recovery_probe_failure(error, duration_ms: duration_since(started_at), fallback_used: !fallback.nil?)
 
               if fallback
                 fallback.call(error)
@@ -60,7 +64,7 @@ module Stoplight
                 raise
               end
             else
-              record_recovery_probe_success
+              record_recovery_probe_success(duration_ms: duration_since(started_at), error:)
               raise
             end
           end
@@ -77,6 +81,11 @@ module Stoplight
         def with_recovery_lock(fallback:, state_snapshot:)
           recovery_lock_token = recovery_lock_store.acquire_lock
           if recovery_lock_token.nil?
+            @run_recorder.record_blocked(
+              fallback_used: !fallback.nil?,
+              retry_after: state_snapshot.recovery_scheduled_after
+            )
+
             return fallback.call(nil) if fallback
 
             raise Error::RedLight.new(
@@ -87,17 +96,27 @@ module Stoplight
           end
 
           begin
-            yield
+            yield capture_started_at
           ensure
             recovery_lock_store.release_lock(recovery_lock_token)
           end
         end
 
-        def record_recovery_probe_success
+        def capture_started_at
+          @clock.monotonic_time if @run_recorder.subscribed?
+        end
+
+        def duration_since(started_at)
+          @clock.monotonic_time - started_at if started_at
+        end
+
+        def record_recovery_probe_success(duration_ms:, error: nil)
+          @run_recorder.record_success(duration_ms:, error:)
           request_tracker.record_success
         end
 
-        def record_recovery_probe_failure(error)
+        def record_recovery_probe_failure(error, duration_ms:, fallback_used:)
+          @run_recorder.record_failure(error, duration_ms:, fallback_used:)
           request_tracker.record_failure(error)
         end
 
@@ -106,7 +125,7 @@ module Stoplight
 
           state_store.transition_to_color(Color::YELLOW)
           metrics_store.clear
-          # FIXME: use light config instead of @_config
+          # FIXME: use light config instead of @config
           # light_info = LightInfo.new(name: @name)
           notifiers.each do |notifier|
             notifier.notify(@config, Color::RED, Color::YELLOW, nil)

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -102,7 +102,9 @@ module Stoplight
       def green_run_strategy
         Domain::Strategies::GreenRunStrategy.new(
           error_tracking_policy: @error_tracking_policy,
-          request_tracker:
+          request_tracker:,
+          clock:,
+          run_recorder: run_recorder(Color::GREEN)
         )
       end
 
@@ -115,12 +117,22 @@ module Stoplight
           state_store:,
           metrics_store:,
           recovery_lock_store:,
-          config: @config
+          config: @config,
+          clock:,
+          run_recorder: run_recorder(Color::YELLOW)
         )
       end
 
       def red_run_strategy
-        Domain::Strategies::RedRunStrategy.new(name: @name, cool_off_time: @cool_off_time)
+        Domain::Strategies::RedRunStrategy.new(
+          name: @name,
+          cool_off_time: @cool_off_time,
+          run_recorder: run_recorder(Color::RED)
+        )
+      end
+
+      def run_recorder(color)
+        Domain::Telemetry::RunRecorder.new(emitter: @emitter, color:)
       end
 
       def redis

--- a/sig/_private/stoplight/domain/strategies/green_run_strategy.rbs
+++ b/sig/_private/stoplight/domain/strategies/green_run_strategy.rbs
@@ -6,11 +6,17 @@ module Stoplight
 
         attr_reader request_tracker: Tracker::Request
         @error_tracking_policy: ErrorTrackingPolicy
+        @run_recorder: Telemetry::RunRecorder
+        @clock: _Clock
 
-        def initialize: (error_tracking_policy: ErrorTrackingPolicy, request_tracker: Tracker::Request) -> void
+        def initialize: (error_tracking_policy: ErrorTrackingPolicy, request_tracker: Tracker::Request,
+            run_recorder: Telemetry::RunRecorder, clock: _Clock) -> void
 
-        def record_error: (StandardError) -> void
-        def record_success: -> void
+        def capture_started_at: () -> Float?
+        def duration_since: (Float?) -> Float?
+
+        def record_error: (StandardError, duration_ms: Float?, fallback_used: bool) -> void
+        def record_success: (duration_ms: Float?, ?error: StandardError?)-> void
       end
     end
   end

--- a/sig/_private/stoplight/domain/strategies/red_run_strategy.rbs
+++ b/sig/_private/stoplight/domain/strategies/red_run_strategy.rbs
@@ -6,11 +6,13 @@ module Stoplight
 
         @name: String
         @cool_off_time: duration
+        @run_recorder: Telemetry::RunRecorder
 
-        def initialize: (name: String, cool_off_time: duration) -> void
-
-        private def record_error: (StandardError) -> void
-        private def record_success: -> void
+        def initialize: (
+            name: String,
+            cool_off_time: duration,
+            run_recorder: Telemetry::RunRecorder,
+          ) -> void
       end
     end
   end

--- a/sig/_private/stoplight/domain/strategies/yellow_run_strategy.rbs
+++ b/sig/_private/stoplight/domain/strategies/yellow_run_strategy.rbs
@@ -13,25 +13,41 @@ module Stoplight
         @name: String
         @config: Domain::Config
         @error_tracking_policy: ErrorTrackingPolicy
+        @clock: _Clock
+        @run_recorder: Telemetry::RunRecorder
 
         def initialize: (
           name: String,
           error_tracking_policy: ErrorTrackingPolicy,
           notifiers: Array[state_transition_notifier],
           request_tracker: Tracker::RecoveryProbe,
-          state_store: Domain::_StateStore,
+          state_store: _StateStore,
           metrics_store: _MetricsStore,
           recovery_lock_store: _RecoveryLockStore,
-          config: Domain::Config,
+          config: Config,
+          clock: _Clock,
+          run_recorder: Telemetry::RunRecorder
         ) -> void
 
         def with_recovery_lock: [T] (
             fallback: (^(StandardError?) -> T)?,
             state_snapshot: StateSnapshot,
-          ) { () -> T } -> T
+          ) { (Float?) -> T } -> T
 
-        def record_recovery_probe_success: () -> void
-        def record_recovery_probe_failure: (StandardError) -> void
+        def capture_started_at: () -> Float?
+        def duration_since: (Float?) -> Float?
+
+        def record_recovery_probe_success: (
+            duration_ms: Float?,
+            ?error: StandardError?
+          ) -> void
+
+        def record_recovery_probe_failure: (
+            StandardError,
+            duration_ms: Float?,
+            fallback_used: bool,
+          ) -> void
+
         def enter_recovery: (StateSnapshot) -> void
       end
     end

--- a/sig/_private/stoplight/wiring/light_factory.rbs
+++ b/sig/_private/stoplight/wiring/light_factory.rbs
@@ -56,6 +56,7 @@ module Stoplight
       def green_run_strategy: -> Domain::Strategies::GreenRunStrategy
       def yellow_run_strategy: -> Domain::Strategies::YellowRunStrategy
       def red_run_strategy: -> Domain::Strategies::RedRunStrategy
+      def run_recorder: (color) -> Domain::Telemetry::RunRecorder
       def redis: -> redis
       def storage_scripting: -> Infrastructure::Redis::Storage::Scripting
       def failover_system: -> _System

--- a/sig/stoplight/telemetry/run_completed.rbs
+++ b/sig/stoplight/telemetry/run_completed.rbs
@@ -5,7 +5,9 @@ module Stoplight
       class RunCompleted < Data
         attr_reader outcome: run_outcome
         attr_reader color: color
-        # nil only when blocked (no user code ran).
+        # nil when blocked (no user code ran)
+        # @note For performance reasons, durations might not be measured if nobody was subscribed at the start
+        # of the run - e.g. due to a race condition between active light and new subscription.
         attr_reader duration_ms: Float?
         # Present on failures and on successes caused by untracked (skipped) errors (see Failure#tracked).
         attr_reader failure: Failure?

--- a/spec/support/adapters/test_telemetry_emitter.rb
+++ b/spec/support/adapters/test_telemetry_emitter.rb
@@ -7,6 +7,8 @@ class TestTelemetryEmitter
     @emitted = []
   end
 
+  def subscribed?(event_class) = true
+
   def emit(event_class)
     event = yield
     expect(event).to be_kind_of(event_class)

--- a/spec/unit/stoplight/domain/run_strategies/green_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/green_run_strategy_spec.rb
@@ -4,12 +4,17 @@ RSpec.describe Stoplight::Domain::Strategies::GreenRunStrategy do
   subject(:strategy) do
     described_class.new(
       error_tracking_policy:,
-      request_tracker:
+      request_tracker:,
+      run_recorder:,
+      clock:
     )
   end
 
   let(:error_tracking_policy) { instance_double(Stoplight::Domain::ErrorTrackingPolicy) }
   let(:request_tracker) { instance_double(Stoplight::Domain::Tracker::Request) }
+  let(:emitter) { TestTelemetryEmitter.new }
+  let(:run_recorder) { Stoplight::Domain::Telemetry::RunRecorder.new(emitter:, color: Stoplight::Color::GREEN) }
+  let(:clock) { instance_double(NullClock, monotonic_time: 1.4) }
 
   context "when code executes successfully" do
     subject(:result) { strategy.execute(nil, state_snapshot: nil, &code) }
@@ -18,6 +23,34 @@ RSpec.describe Stoplight::Domain::Strategies::GreenRunStrategy do
 
     it "returns result" do
       expect(request_tracker).to receive(:record_success)
+
+      expect(result).to eq("Success")
+    end
+
+    it "produces RunCompleted event" do
+      expect(request_tracker).to receive(:record_success)
+      expect(clock).to receive(:monotonic_time).and_return(1.4, 2.2)
+
+      expect { result }.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+        outcome: :success,
+        color: "green",
+        duration_ms: be_within(0.00001).of(0.8),
+        failure: nil,
+        fallback_used: false,
+        retry_after: nil
+      )
+    end
+  end
+
+  context "when nobody is subscribed to telemetry" do
+    subject(:result) { strategy.execute(nil, state_snapshot: nil, &code) }
+
+    let(:code) { -> { "Success" } }
+    let(:run_recorder) { instance_double(Stoplight::Domain::Telemetry::RunRecorder, subscribed?: false, record_success: nil) }
+
+    it "does not measure duration" do
+      expect(request_tracker).to receive(:record_success)
+      expect(clock).not_to receive(:monotonic_time)
 
       expect(result).to eq("Success")
     end
@@ -42,8 +75,18 @@ RSpec.describe Stoplight::Domain::Strategies::GreenRunStrategy do
 
         it "records failure, notify and raises the error" do
           expect(request_tracker).to receive(:record_failure).with(error)
+          expect(clock).to receive(:monotonic_time).and_return(1.4, 2.2)
 
-          expect { result }.to raise_error(error)
+          expect do
+            expect { result }.to raise_error(error)
+          end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+            outcome: :failure,
+            color: "green",
+            duration_ms: be_within(0.00001).of(0.8),
+            failure: have_attributes(exception: error, tracked: true),
+            fallback_used: false,
+            retry_after: nil
+          )
         end
       end
 
@@ -57,8 +100,19 @@ RSpec.describe Stoplight::Domain::Strategies::GreenRunStrategy do
 
         it "records failure, notify and returns the fallback" do
           expect(request_tracker).to receive(:record_failure).with(error)
+          expect(clock).to receive(:monotonic_time).and_return(1.4, 2.2)
 
-          expect(result).to eq("Fallback")
+          expect do
+            expect(result).to eq("Fallback")
+          end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+            outcome: :failure,
+            color: "green",
+            duration_ms: be_within(0.00001).of(0.8),
+            failure: have_attributes(exception: error, tracked: true),
+            fallback_used: true,
+            retry_after: nil
+          )
+
           expect(@error).to eq(error)
         end
       end
@@ -70,8 +124,18 @@ RSpec.describe Stoplight::Domain::Strategies::GreenRunStrategy do
 
       it "records success and raises the error" do
         expect(request_tracker).to receive(:record_success)
+        expect(clock).to receive(:monotonic_time).and_return(1.4, 2.2)
 
-        expect { result }.to raise_error(StandardError, "Test error")
+        expect do
+          expect { result }.to raise_error(StandardError, "Test error")
+        end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+          outcome: :success,
+          color: "green",
+          duration_ms: be_within(0.00001).of(0.8),
+          failure: have_attributes(exception: error, tracked: false),
+          fallback_used: false,
+          retry_after: nil
+        )
       end
     end
   end

--- a/spec/unit/stoplight/domain/run_strategies/red_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/red_run_strategy_spec.rb
@@ -3,10 +3,18 @@
 RSpec.describe Stoplight::Domain::Strategies::RedRunStrategy, :freeze do
   subject(:result) { strategy.execute(fallback, state_snapshot:) { 42 } }
 
-  let(:strategy) { described_class.new(name:, cool_off_time:) }
+  let(:strategy) do
+    described_class.new(
+      name:,
+      cool_off_time:,
+      run_recorder:
+    )
+  end
   let(:state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot, recovery_scheduled_after: Time.now) }
   let(:name) { SecureRandom.uuid }
   let(:cool_off_time) { 60 }
+  let(:emitter) { TestTelemetryEmitter.new }
+  let(:run_recorder) { Stoplight::Domain::Telemetry::RunRecorder.new(emitter:, color: Stoplight::Color::RED) }
 
   context "when fallback is provided" do
     let(:fallback) {
@@ -21,6 +29,17 @@ RSpec.describe Stoplight::Domain::Strategies::RedRunStrategy, :freeze do
 
       expect(@error).to eq(nil)
     end
+
+    it "produces RunCompleted event" do
+      expect { result }.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+        outcome: :blocked,
+        color: "red",
+        duration_ms: nil,
+        failure: nil,
+        fallback_used: true,
+        retry_after: state_snapshot.recovery_scheduled_after
+      )
+    end
   end
 
   context "when fallback is not provided" do
@@ -31,6 +50,19 @@ RSpec.describe Stoplight::Domain::Strategies::RedRunStrategy, :freeze do
         expect(error.cool_off_time).to eq(cool_off_time)
         expect(error.retry_after).to eq(state_snapshot.recovery_scheduled_after)
       }
+    end
+
+    it "produces RunCompleted event" do
+      expect do
+        expect { result }.to raise_error(Stoplight::Error::RedLight)
+      end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+        outcome: :blocked,
+        color: "red",
+        duration_ms: nil,
+        failure: nil,
+        fallback_used: false,
+        retry_after: state_snapshot.recovery_scheduled_after
+      )
     end
   end
 end

--- a/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
       state_store:,
       metrics_store:,
       recovery_lock_store:,
-      config:
+      config:,
+      run_recorder:,
+      clock:
     )
   end
 
@@ -24,6 +26,9 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
   let(:request_tracker) { instance_double(Stoplight::Domain::Tracker::RecoveryProbe) }
   let(:cool_off_time) { 60 }
   let(:config) { instance_double(Stoplight::Domain::Config, name:, cool_off_time:) }
+  let(:emitter) { TestTelemetryEmitter.new }
+  let(:run_recorder) { Stoplight::Domain::Telemetry::RunRecorder.new(emitter:, color: Stoplight::Color::YELLOW) }
+  let(:clock) { instance_double(NullClock, monotonic_time: 1.4) }
 
   describe "#exceute" do
     before do
@@ -45,6 +50,36 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
         it "returns result" do
           expect(request_tracker).to receive(:record_success)
           expect(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
+
+          expect(result).to eq("Success")
+        end
+
+        it "produces RunCompleted event" do
+          allow(request_tracker).to receive(:record_success)
+          allow(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
+          expect(clock).to receive(:monotonic_time).and_return(1.4, 2.2)
+
+          expect { result }.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+            outcome: :success,
+            color: "yellow",
+            duration_ms: be_within(0.00001).of(0.8),
+            failure: nil,
+            fallback_used: false,
+            retry_after: nil
+          )
+        end
+      end
+
+      context "when nobody is subscribed to telemetry" do
+        subject(:result) { strategy.execute(nil, state_snapshot: nil, &code) }
+
+        let(:code) { -> { "Success" } }
+        let(:run_recorder) { instance_double(Stoplight::Domain::Telemetry::RunRecorder, subscribed?: false, record_success: nil) }
+
+        it "does not measure duration" do
+          expect(request_tracker).to receive(:record_success)
+          expect(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
+          expect(clock).not_to receive(:monotonic_time)
 
           expect(result).to eq("Success")
         end
@@ -72,6 +107,23 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
 
               expect { result }.to raise_error(error)
             end
+
+            it "produces RunCompleted event" do
+              expect(request_tracker).to receive(:record_failure).with(error)
+              allow(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
+              expect(clock).to receive(:monotonic_time).and_return(1.4, 2.2)
+
+              expect do
+                expect { result }.to raise_error(error)
+              end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+                outcome: :failure,
+                color: "yellow",
+                duration_ms: be_within(0.00001).of(0.8),
+                failure: have_attributes(exception: error, tracked: true),
+                fallback_used: false,
+                retry_after: nil
+              )
+            end
           end
 
           context "when fallback is provided" do
@@ -89,6 +141,21 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
               expect(result).to eq("Fallback")
               expect(@error).to eq(error)
             end
+
+            it "produces RunCompleted event" do
+              expect(request_tracker).to receive(:record_failure).with(error)
+              allow(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
+              expect(clock).to receive(:monotonic_time).and_return(1.4, 2.2)
+
+              expect { result }.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+                outcome: :failure,
+                color: "yellow",
+                duration_ms: be_within(0.00001).of(0.8),
+                failure: have_attributes(exception: error, tracked: true),
+                fallback_used: true,
+                retry_after: nil
+              )
+            end
           end
         end
 
@@ -99,8 +166,18 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
           it "records success and raises the error" do
             expect(request_tracker).to receive(:record_success)
             expect(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
+            expect(clock).to receive(:monotonic_time).and_return(1.4, 2.2)
 
-            expect { result }.to raise_error(StandardError, "Test error")
+            expect do
+              expect { result }.to raise_error(StandardError, "Test error")
+            end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+              outcome: :success,
+              color: "yellow",
+              duration_ms: be_within(0.00001).of(0.8),
+              failure: have_attributes(exception: error, tracked: false),
+              fallback_used: false,
+              retry_after: nil
+            )
           end
         end
       end
@@ -129,6 +206,25 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
 
           expect(@error).to eq(nil)
         end
+
+        it "does not measure duration for a blocked run" do
+          expect(clock).not_to receive(:monotonic_time)
+
+          strategy.execute(fallback, state_snapshot:) {}
+        end
+
+        it "produces RunCompleted event" do
+          expect {
+            strategy.execute(fallback, state_snapshot:) {}
+          }.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+            outcome: :blocked,
+            color: "yellow",
+            duration_ms: nil,
+            failure: nil,
+            fallback_used: true,
+            retry_after: state_snapshot.recovery_scheduled_after
+          )
+        end
       end
 
       context "when fallback is not provided" do
@@ -141,6 +237,31 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
               expect(error.retry_after).to eq(state_snapshot.recovery_scheduled_after)
             }
           end.not_to yield_control
+        end
+
+        it "does not measure duration for a blocked run" do
+          expect(clock).not_to receive(:monotonic_time)
+
+          begin
+            strategy.execute(fallback, state_snapshot:) {}
+          rescue Stoplight::Error::RedLight
+            nil
+          end
+        end
+
+        it "produces RunCompleted event" do
+          expect do
+            expect do
+              strategy.execute(fallback, state_snapshot:) {}
+            end.to raise_error(Stoplight::Error::RedLight, name)
+          end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+            outcome: :blocked,
+            color: "yellow",
+            duration_ms: nil,
+            failure: nil,
+            fallback_used: false,
+            retry_after: state_snapshot.recovery_scheduled_after
+          )
         end
       end
     end

--- a/spec/unit/stoplight/wiring/system_spec.rb
+++ b/spec/unit/stoplight/wiring/system_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Stoplight::Wiring::System do
   let(:registry) { instance_double(Stoplight::Infrastructure::Memory::Storage::Registry, register: nil) }
 
   describe "#light" do
-    let(:system_config) { Stoplight::Wiring::DefaultConfig }
+    let(:system_config) { Stoplight::Wiring::DefaultConfig.with(name: SecureRandom.uuid) }
 
     describe "caching behavior with same name and no settings" do
       let(:light) { system.light(name) }
@@ -156,7 +156,7 @@ RSpec.describe Stoplight::Wiring::System do
 
     describe "registry" do
       let(:registry) { instance_double(Stoplight::Infrastructure::Memory::Storage::Registry, register: nil) }
-      let(:system_config) { Stoplight::Wiring::DefaultConfig }
+      let(:system_config) { Stoplight::Wiring::DefaultConfig.with(name: SecureRandom.uuid) }
 
       subject!(:system) { described_class.new(config: system_config, failover_system:, registry:) }
 


### PR DESCRIPTION
Builds on #742 (`Telemetry::RunRecorder`, `Emitter#subscribed?`, merged).

Green, Yellow, and Red now emit a `RunCompleted` event on every outcome (success, failure, blocked) via a color-bound `RunRecorder`, the last piece wiring strategies into the telemetry bus set up in parts 2-3.

- Duration is timed via an injected clock, but only when `RunRecorder#subscribed?` says someone is listening for `RunCompleted` - no clock reads when telemetry is unused.