### PR TITLE
Telemetry (Part 4a) - Harden Emitter#emit and add RunRecorder

### DIFF
--- a/lib/stoplight/domain/telemetry/emitter.rb
+++ b/lib/stoplight/domain/telemetry/emitter.rb
@@ -4,16 +4,21 @@ module Stoplight
   module Domain
     class Telemetry
       class Emitter
-        def initialize(bus:, clock:, system_name:, light_name:)
+        def initialize(bus:, clock:, system_name:, light_name:, error_notifier:)
           @bus = bus
           @clock = clock
           @system_name = system_name
           @light_name = light_name
+          @error_notifier = error_notifier
         end
 
-        # Emits telemetry event.
+        # True when any subscriber would receive this event class.
+        def subscribed?(event_class) = @bus.subscribed?(event_class)
+
+        # Emits telemetry event. A failure to build or publish it is routed to the error
+        # notifier, never to the caller - the same isolation the bus gives subscriber handlers.
         def emit(event_class)
-          return unless @bus.subscribed?(event_class)
+          return unless subscribed?(event_class)
 
           @bus.publish(
             Envelope.new(
@@ -23,6 +28,16 @@ module Stoplight
               payload: yield
             )
           )
+        rescue => error
+          notify_error(error)
+        end
+
+        private
+
+        def notify_error(error)
+          @error_notifier.call(error)
+        rescue => notifier_error
+          warn "Stoplight telemetry error_notifier raised: #{notifier_error.message}"
         end
       end
     end

--- a/lib/stoplight/domain/telemetry/run_recorder.rb
+++ b/lib/stoplight/domain/telemetry/run_recorder.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class Telemetry
+      # Builds and emits RunCompleted events for one light color.
+      #
+      # @api private
+      class RunRecorder
+        def initialize(emitter:, color:)
+          @emitter = emitter
+          @color = color
+        end
+
+        # True when any subscriber would receive a RunCompleted event.
+        def subscribed? = @emitter.subscribed?(RunCompleted)
+
+        def record_success(duration_ms:, error: nil)
+          emit(
+            outcome: :success,
+            duration_ms:,
+            failure: error && Failure.new(exception: error, tracked: false),
+            fallback_used: false,
+            retry_after: nil
+          )
+        end
+
+        def record_failure(error, duration_ms:, fallback_used:)
+          emit(
+            outcome: :failure,
+            duration_ms:,
+            failure: Failure.new(exception: error, tracked: true),
+            fallback_used:,
+            retry_after: nil
+          )
+        end
+
+        def record_blocked(fallback_used:, retry_after:)
+          emit(
+            outcome: :blocked,
+            duration_ms: nil,
+            failure: nil,
+            fallback_used:,
+            retry_after:
+          )
+        end
+
+        private
+
+        def emit(outcome:, duration_ms:, failure:, fallback_used:, retry_after:)
+          @emitter.emit(RunCompleted) do
+            RunCompleted.new(outcome:, color: @color, duration_ms:, failure:, fallback_used:, retry_after:)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -31,7 +31,8 @@ module Stoplight
           bus: telemetry,
           system_name: system_name,
           light_name: config.name,
-          clock: @clock
+          clock: @clock,
+          error_notifier: @error_notifier
         )
         @wrapped_notifiers = nil
       end

--- a/sig/_private/stoplight/domain/telemetry/emitter.rbs
+++ b/sig/_private/stoplight/domain/telemetry/emitter.rbs
@@ -9,13 +9,18 @@ module Stoplight
         @clock: _Clock
         @system_name: String
         @light_name: String
+        @error_notifier: error_notifier
 
         def initialize: (
             bus: _TelemetryPublisher,
             clock: _Clock,
             system_name: String,
-            light_name: String
+            light_name: String,
+            error_notifier: error_notifier
           ) -> void
+
+        # True when any subscriber would receive this event class.
+        def subscribed?: (Telemetry::event_class) -> bool
 
         # Lazily yields the event's payload only when the bus has subscribers for this event class, then stamps
         # +occurred_at+ from the clock and publishes.
@@ -38,6 +43,8 @@ module Stoplight
                 | (singleton(LockChanged)) { () -> LockChanged } -> void
                 | (singleton(RecoveryProbeCompleted)) { () -> RecoveryProbeCompleted } -> void
                 | (singleton(LightRegistered)) { () -> LightRegistered } -> void
+
+        private def notify_error: (StandardError) -> void
       end
     end
   end

--- a/sig/_private/stoplight/domain/telemetry/run_recorder.rbs
+++ b/sig/_private/stoplight/domain/telemetry/run_recorder.rbs
@@ -1,0 +1,27 @@
+module Stoplight
+  module Domain
+    class Telemetry
+      # Builds and emits RunCompleted events for one light color.
+      class RunRecorder
+        @emitter: Telemetry::Emitter
+        @color: color
+
+        def initialize: (emitter: Telemetry::Emitter, color: color) -> void
+
+        def subscribed?: () -> bool
+
+        def record_success: (duration_ms: Float?, ?error: StandardError?) -> void
+        def record_failure: (StandardError, duration_ms: Float?, fallback_used: bool) -> void
+        def record_blocked: (fallback_used: bool, retry_after: Time?) -> void
+
+        private def emit: (
+            outcome: run_outcome,
+            duration_ms: Float?,
+            failure: Failure?,
+            fallback_used: bool,
+            retry_after: Time?
+          ) -> void
+      end
+    end
+  end
+end

--- a/spec/unit/stoplight/domain/telemetry/emitter_spec.rb
+++ b/spec/unit/stoplight/domain/telemetry/emitter_spec.rb
@@ -1,12 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.describe Stoplight::Domain::Telemetry::Emitter do
-  subject(:emitter) { described_class.new(bus:, clock:, system_name:, light_name:) }
+  subject(:emitter) { described_class.new(bus:, clock:, system_name:, light_name:, error_notifier:) }
 
   let(:bus) { instance_double(Stoplight::Domain::Telemetry) }
   let(:clock) { instance_double(NullClock) }
   let(:system_name) { SecureRandom.uuid }
   let(:light_name) { SecureRandom.uuid }
+  let(:error_notifier) { instance_spy(Proc) }
+
+  describe "#subscribed?" do
+    let(:event_type) { Stoplight::Domain::Telemetry::RecoveryFailed }
+
+    it "delegates to the bus" do
+      allow(bus).to receive(:subscribed?).with(event_type).and_return(true)
+
+      expect(emitter).to be_subscribed(event_type)
+    end
+  end
 
   describe "#emit" do
     context "when subscribed to event" do
@@ -43,6 +54,30 @@ RSpec.describe Stoplight::Domain::Telemetry::Emitter do
         expect do |event_factory|
           emitter.emit(event_type, &event_factory)
         end.not_to yield_control
+      end
+    end
+
+    context "when building the event raises" do
+      let(:event_type) { Stoplight::Domain::Telemetry::RecoveryFailed }
+      let(:boom) { StandardError.new("boom") }
+
+      before do
+        allow(bus).to receive(:subscribed?).with(event_type).and_return(true)
+        allow(clock).to receive(:current_time).and_return(Time.at(0))
+      end
+
+      it "routes the error to the error notifier instead of the caller" do
+        expect(bus).not_to receive(:publish)
+
+        expect { emitter.emit(event_type) { raise boom } }.not_to raise_error
+
+        expect(error_notifier).to have_received(:call).with(boom)
+      end
+
+      it "does not raise when the error notifier itself raises" do
+        allow(error_notifier).to receive(:call).and_raise(StandardError.new("notifier boom"))
+
+        expect { emitter.emit(event_type) { raise boom } }.not_to raise_error
       end
     end
   end

--- a/spec/unit/stoplight/domain/telemetry/run_recorder_spec.rb
+++ b/spec/unit/stoplight/domain/telemetry/run_recorder_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Domain::Telemetry::RunRecorder do
+  subject(:run_recorder) { described_class.new(emitter:, color: Stoplight::Color::GREEN) }
+
+  let(:emitter) { TestTelemetryEmitter.new }
+
+  describe "#subscribed?" do
+    let(:emitter) { instance_double(Stoplight::Domain::Telemetry::Emitter) }
+
+    it "delegates to the emitter for RunCompleted" do
+      allow(emitter).to receive(:subscribed?).with(Stoplight::Domain::Telemetry::RunCompleted).and_return(true)
+
+      expect(run_recorder).to be_subscribed
+    end
+  end
+
+  describe "#record_success" do
+    it "emits a success event for the recorder's color" do
+      expect { run_recorder.record_success(duration_ms: 1.2) }.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+        outcome: :success,
+        color: "green",
+        duration_ms: 1.2,
+        failure: nil,
+        fallback_used: false,
+        retry_after: nil
+      )
+    end
+
+    it "attaches an untracked failure when given an error" do
+      error = StandardError.new("boom")
+
+      expect do
+        run_recorder.record_success(duration_ms: 1.2, error:)
+      end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+        outcome: :success,
+        color: "green",
+        duration_ms: 1.2,
+        failure: have_attributes(exception: error, tracked: false),
+        fallback_used: false,
+        retry_after: nil
+      )
+    end
+  end
+
+  describe "#record_failure" do
+    it "emits a failure event" do
+      error = StandardError.new("boom")
+
+      expect do
+        run_recorder.record_failure(error, duration_ms: 1.2, fallback_used: true)
+      end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+        outcome: :failure,
+        color: "green",
+        duration_ms: 1.2,
+        failure: have_attributes(exception: error, tracked: true),
+        fallback_used: true,
+        retry_after: nil
+      )
+    end
+  end
+
+  describe "#record_blocked" do
+    it "emits a blocked event" do
+      retry_after = Time.now
+
+      expect do
+        run_recorder.record_blocked(fallback_used: false, retry_after:)
+      end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
+        outcome: :blocked,
+        color: "green",
+        duration_ms: nil,
+        failure: nil,
+        fallback_used: false,
+        retry_after:
+      )
+    end
+  end
+end


### PR DESCRIPTION
Prep work for wiring `RunCompleted` emission into the run strategies (next PR).

- `Emitter#emit` had no error boundary of its own: a failure to build or publish an event propagated straight to the caller, indistinguishable from a genuine application error and outside the `error_notifier` channel the bus already uses for a raising subscriber handler. Route emit's own failures through that same `error_notifier`.
- Adds `Emitter#subscribed?` and `Telemetry::RunRecorder`, a collaborator that builds and emits a `RunCompleted` event for one light color so callers don't each hand-assemble the same six-field event shape. `RunRecorder` is not wired into the run strategies yet - unused in this PR.