### PR TITLE
fix: deduplicate recovery probe notifications

### DIFF
--- a/lib/stoplight/domain/tracker/recovery_probe.rb
+++ b/lib/stoplight/domain/tracker/recovery_probe.rb
@@ -46,11 +46,12 @@ module Stoplight
             raise "recovery strategy returned unexpected color: #{recovery_result}"
           end
 
-          state_store.transition_to_color(to_color)
-          metrics_store.clear
-          info = LightInfo.new(name: config.name)
-          notifiers.each do |notifier|
-            notifier.notify(info, from_color, to_color, nil)
+          if state_store.transition_to_color(to_color)
+            metrics_store.clear
+            info = LightInfo.new(name: config.name)
+            notifiers.each do |notifier|
+              notifier.notify(info, from_color, to_color, nil)
+            end
           end
         end
       end

--- a/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
+++ b/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
 
       before do
         allow(traffic_recovery).to receive(:determine_color).with(config, metrics_after_probe).and_return(recover_to)
-        allow(state_store).to receive(:transition_to_color).with(transition_to)
+        allow(state_store).to receive(:transition_to_color).with(transition_to).and_return(true)
       end
 
       it "sends notifications" do
@@ -25,6 +25,19 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
         expect(notifier).to receive(:notify).with(have_attributes(name:), transition_from, transition_to, nil)
 
         record_probe
+      end
+
+      context "when failed to transition to #{transition_to}" do
+        before do
+          allow(state_store).to receive(:transition_to_color).with(transition_to).and_return(false)
+        end
+
+        it "does not clear metrics or send notifications" do
+          expect(metrics_store).not_to receive(:clear)
+          expect(notifier).not_to receive(:notify)
+
+          record_probe
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
- guard recovery probe cleanup and notification on `transition_to_color` returning true
- add regression coverage for duplicate recovery transitions that return false

Closes #748.

## Validation
- `git diff --check`
- `bundle exec rspec spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb` in `ruby:3.4` Docker container: 12 examples, 0 failures
- `bundle exec standardrb lib/stoplight/domain/tracker/recovery_probe.rb spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb` in `ruby:3.4` Docker container
