### PR TITLE
Wire LightRegistered telemetry event

### DIFF
--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -38,13 +38,17 @@ module Stoplight
       end
 
       def build
-        Stoplight::Domain::Light.new(
+        light = Stoplight::Domain::Light.new(
           @name,
           state_store:,
           green_run_strategy:,
           yellow_run_strategy:,
           red_run_strategy:
         )
+        @emitter.emit(Domain::Telemetry::LightRegistered) do
+          Domain::Telemetry::LightRegistered.new(settings: telemetry_settings)
+        end
+        light
       end
 
       def state_store = storage_set.state_store
@@ -133,6 +137,36 @@ module Stoplight
 
       def run_recorder(color)
         Domain::Telemetry::RunRecorder.new(emitter: @emitter, color:)
+      end
+
+      def telemetry_settings
+        Domain::Telemetry::Settings.new(
+          cool_off_time: config.cool_off_time,
+          threshold: config.threshold,
+          recovery_threshold: config.recovery_threshold,
+          window_size: config.window_size,
+          tracked_errors: matcher_names(config.tracked_errors),
+          skipped_errors: matcher_names(config.skipped_errors),
+          traffic_control: policy_name(config.traffic_control),
+          traffic_control_params: policy_params(config.traffic_control),
+          traffic_recovery: policy_name(config.traffic_recovery),
+          traffic_recovery_params: policy_params(config.traffic_recovery)
+        )
+      end
+
+      def matcher_names(matchers) = matchers.map { |matcher| matcher.to_s }
+
+      def policy_name(policy)
+        T.must(policy.class.name).split("::").last.gsub(/([a-z\d])([A-Z])/, "\\1_\\2").downcase
+      end
+
+      def policy_params(policy)
+        case policy
+        when Domain::TrafficControl::ErrorRate
+          {"min_requests" => policy.instance_variable_get(:@min_requests)}
+        else
+          {}
+        end
       end
 
       def redis

--- a/sig/_private/stoplight/wiring/light_factory.rbs
+++ b/sig/_private/stoplight/wiring/light_factory.rbs
@@ -57,6 +57,10 @@ module Stoplight
       def yellow_run_strategy: -> Domain::Strategies::YellowRunStrategy
       def red_run_strategy: -> Domain::Strategies::RedRunStrategy
       def run_recorder: (color) -> Domain::Telemetry::RunRecorder
+      def telemetry_settings: -> Domain::Telemetry::Settings
+      def matcher_names: (Array[_ExceptionMatcher]) -> Array[String]
+      def policy_name: (untyped) -> String
+      def policy_params: (untyped) -> Hash[String, untyped]
       def redis: -> redis
       def storage_scripting: -> Infrastructure::Redis::Storage::Scripting
       def failover_system: -> _System

--- a/sig/stoplight/ports/exception_matcher.rbs
+++ b/sig/stoplight/ports/exception_matcher.rbs
@@ -4,5 +4,6 @@ module Stoplight
 
     # Object methods
     def is_a?: (untyped) -> bool
+    def to_s: () -> String
   end
 end

--- a/spec/unit/stoplight/wiring/system_spec.rb
+++ b/spec/unit/stoplight/wiring/system_spec.rb
@@ -173,5 +173,54 @@ RSpec.describe Stoplight::Wiring::System do
         expect(registry).to have_received(:register).once
       end
     end
+
+    describe "telemetry" do
+      let(:events) { [] }
+
+      before do
+        telemetry = system.instance_variable_get(:@telemetry)
+        telemetry.subscribe(Stoplight::Telemetry::LightRegistered) { |event| events << event }
+      end
+
+      it "emits one LightRegistered event with the normalized settings" do
+        system.light(
+          "stripe",
+          cool_off_time: 30,
+          threshold: 0.25,
+          recovery_threshold: 4,
+          window_size: 60,
+          tracked_errors: RuntimeError,
+          skipped_errors: ArgumentError,
+          traffic_control: {error_rate: {min_requests: 17}}
+        )
+        system.light(
+          "stripe",
+          cool_off_time: 30,
+          threshold: 0.25,
+          recovery_threshold: 4,
+          window_size: 60,
+          tracked_errors: RuntimeError,
+          skipped_errors: ArgumentError,
+          traffic_control: {error_rate: {min_requests: 17}}
+        )
+
+        expect(events.size).to eq(1)
+        expect(events.first).to have_attributes(system_name: system.name, light_name: "stripe")
+        expect(events.first.payload.settings).to eq(
+          Stoplight::Domain::Telemetry::Settings.new(
+            cool_off_time: 30,
+            threshold: 0.25,
+            recovery_threshold: 4,
+            window_size: 60,
+            tracked_errors: ["RuntimeError"],
+            skipped_errors: ["ArgumentError"],
+            traffic_control: "error_rate",
+            traffic_control_params: {"min_requests" => 17},
+            traffic_recovery: "consecutive_successes",
+            traffic_recovery_params: {}
+          )
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- emit `LightRegistered` through each light's own emitter after construction
- include the normalized, serializable light configuration in `Telemetry::Settings`
- preserve once-per-light behavior through `System#light`'s existing cache-miss boundary

Closes #752.

## Validation

- focused registration spec: 1 example, 0 failures
- `bundle exec standardrb lib/stoplight/wiring/light_factory.rb spec/unit/stoplight/wiring/system_spec.rb`
- `bundle exec steep check lib/stoplight/wiring/light_factory.rb`
- `ruby -c lib/stoplight/wiring/light_factory.rb`
- `git diff --check`

The full Steep run still reports five existing errors outside this diff (`fail_safe.rb`, Redis key-space signatures, and `domain/telemetry.rb`). The complete `system_spec` also requires a local Redis server for its pre-existing Redis-tagged example; the new telemetry example passes in isolation.
