### PR TITLE
Wire LockChanged telemetry event

### DIFF
--- a/lib/stoplight/domain/light.rb
+++ b/lib/stoplight/domain/light.rb
@@ -11,12 +11,13 @@ module Stoplight
       attr_reader :red_run_strategy
       attr_reader :state_store
 
-      def initialize(name, green_run_strategy:, yellow_run_strategy:, red_run_strategy:, state_store:)
+      def initialize(name, green_run_strategy:, yellow_run_strategy:, red_run_strategy:, state_store:, emitter:)
         @name = name
         @green_run_strategy = green_run_strategy
         @yellow_run_strategy = yellow_run_strategy
         @red_run_strategy = red_run_strategy
         @state_store = state_store
+        @emitter = emitter
       end
 
       # Returns the current state of the light:
@@ -73,7 +74,7 @@ module Stoplight
         else raise Error::IncorrectColor
         end
 
-        state_store.set_state(state)
+        change_lock(state)
 
         self
       end
@@ -87,7 +88,7 @@ module Stoplight
       #
       # @return returns unlocked light (circuit breaker)
       def unlock
-        state_store.set_state(State::UNLOCKED)
+        change_lock(State::UNLOCKED)
 
         self
       end
@@ -106,6 +107,20 @@ module Stoplight
       end
 
       def state_snapshot = state_store.state_snapshot
+
+      def change_lock(state)
+        before = state_snapshot
+        state_store.set_state(state)
+        after = state_snapshot
+        @emitter.emit(Telemetry::LockChanged) do
+          Telemetry::LockChanged.new(
+            from_color: before.color,
+            to_color: after.color,
+            from_state: before.locked_state,
+            to_state: after.locked_state
+          )
+        end
+      end
     end
   end
 end

--- a/lib/stoplight/domain/telemetry/lock_changed.rb
+++ b/lib/stoplight/domain/telemetry/lock_changed.rb
@@ -8,8 +8,7 @@ module Stoplight
         :from_color,
         :to_color,
         :from_state,
-        :to_state,
-        :source
+        :to_state
       )
 
       class LockChanged

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -43,7 +43,8 @@ module Stoplight
           state_store:,
           green_run_strategy:,
           yellow_run_strategy:,
-          red_run_strategy:
+          red_run_strategy:,
+          emitter: @emitter
         )
       end
 

--- a/sig/_private/stoplight/domain/light.rbs
+++ b/sig/_private/stoplight/domain/light.rbs
@@ -7,17 +7,20 @@ module Stoplight
       attr_reader red_run_strategy: Strategies::RedRunStrategy
       attr_reader state_store: Domain::_StateStore
       @name: String
+      @emitter: Telemetry::Emitter
 
       def initialize: (
         String name,
         green_run_strategy: Strategies::GreenRunStrategy,
         yellow_run_strategy: Strategies::YellowRunStrategy,
         red_run_strategy: Strategies::RedRunStrategy,
-        state_store: Domain::_StateStore
+        state_store: Domain::_StateStore,
+        emitter: Telemetry::Emitter
       ) -> void
 
       private def state_strategy_factory: (color) -> _RunStrategy
       private def state_snapshot: -> StateSnapshot
+      private def change_lock: (state) -> void
     end
   end
 end

--- a/sig/stoplight/telemetry/lock_changed.rbs
+++ b/sig/stoplight/telemetry/lock_changed.rbs
@@ -11,23 +11,19 @@ module Stoplight
         attr_reader to_color: color
         attr_reader from_state: state
         attr_reader to_state: state
-        # Open set: "api", "admin", custom.
-        attr_reader source: String
 
         def self.new: (
             from_color: color,
             to_color: color,
             from_state: state,
-            to_state: state,
-            source: String
+            to_state: state
           ) -> instance
 
         def initialize: (
             from_color: color,
             to_color: color,
             from_state: state,
-            to_state: state,
-            source: String
+            to_state: state
           ) -> void
       end
     end

--- a/spec/unit/stoplight/domain/light_spec.rb
+++ b/spec/unit/stoplight/domain/light_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Stoplight::Domain::Light do
       green_run_strategy:,
       yellow_run_strategy:,
       red_run_strategy:,
-      state_store:
+      state_store:,
+      emitter:
     )
   end
   let(:config) { instance_double(Stoplight::Domain::Config) }
@@ -15,6 +16,17 @@ RSpec.describe Stoplight::Domain::Light do
   let(:yellow_run_strategy) { instance_double(Stoplight::Domain::Strategies::YellowRunStrategy) }
   let(:red_run_strategy) { instance_double(Stoplight::Domain::Strategies::RedRunStrategy) }
   let(:state_store) { instance_double(NullStateStore) }
+  let(:emitter) { TestTelemetryEmitter.new }
+
+  before do
+    allow(state_store).to receive(:state_snapshot).and_return(
+      instance_double(
+        Stoplight::Domain::StateSnapshot,
+        color: Stoplight::Color::GREEN,
+        locked_state: Stoplight::State::UNLOCKED
+      )
+    )
+  end
 
   describe "#lock" do
     let(:color) { Stoplight::Color::GREEN }
@@ -39,6 +51,28 @@ RSpec.describe Stoplight::Domain::Light do
           expect(light.lock(color)).to be_a Stoplight::Domain::Light
         end
       end
+
+      it "emits LockChanged even when the effective color stays the same" do
+        before = instance_double(
+          Stoplight::Domain::StateSnapshot,
+          color: Stoplight::Color::RED,
+          locked_state: Stoplight::State::LOCKED_RED
+        )
+        after = instance_double(
+          Stoplight::Domain::StateSnapshot,
+          color: Stoplight::Color::RED,
+          locked_state: Stoplight::State::LOCKED_RED
+        )
+        allow(state_store).to receive(:state_snapshot).and_return(before, after)
+        allow(state_store).to receive(:set_state)
+
+        expect { light.lock(Stoplight::Color::RED) }.to emit(Stoplight::Telemetry::LockChanged).with(
+          from_color: Stoplight::Color::RED,
+          to_color: Stoplight::Color::RED,
+          from_state: Stoplight::State::LOCKED_RED,
+          to_state: Stoplight::State::LOCKED_RED
+        )
+      end
     end
 
     context "with incorrect color" do
@@ -60,6 +94,28 @@ RSpec.describe Stoplight::Domain::Light do
     expect(state_store).to receive(:set_state).with(Stoplight::State::UNLOCKED)
 
     expect(light.unlock).to be_a Stoplight::Domain::Light
+  end
+
+  specify "#unlock emits LockChanged" do
+    before = instance_double(
+      Stoplight::Domain::StateSnapshot,
+      color: Stoplight::Color::RED,
+      locked_state: Stoplight::State::LOCKED_RED
+    )
+    after = instance_double(
+      Stoplight::Domain::StateSnapshot,
+      color: Stoplight::Color::GREEN,
+      locked_state: Stoplight::State::UNLOCKED
+    )
+    allow(state_store).to receive(:state_snapshot).and_return(before, after)
+    allow(state_store).to receive(:set_state)
+
+    expect { light.unlock }.to emit(Stoplight::Telemetry::LockChanged).with(
+      from_color: Stoplight::Color::RED,
+      to_color: Stoplight::Color::GREEN,
+      from_state: Stoplight::State::LOCKED_RED,
+      to_state: Stoplight::State::UNLOCKED
+    )
   end
 
   specify "#state" do


### PR DESCRIPTION
## Summary

- emit `LockChanged` for both manual lock and unlock operations
- capture state and effective color before and after the write
- emit even when relocking to the same effective color
- remove the abandoned `source` field from the event contract as requested

Closes #751.

## Validation

- `bundle exec rspec spec/unit/stoplight/domain/light_spec.rb` — 12 examples, 0 failures
- `bundle exec standardrb` on all changed Ruby/spec files
- `bundle exec steep check` on all changed library files — no type errors
- `git diff --check`
