### PR TITLE
feat: emit TrafficBreached telemetry

### DIFF
--- a/lib/stoplight/domain/tracker/request.rb
+++ b/lib/stoplight/domain/tracker/request.rb
@@ -10,12 +10,13 @@ module Stoplight
       #
       # @api private
       class Request
-        def initialize(traffic_control:, notifiers:, config:, metrics_store:, state_store:)
+        def initialize(traffic_control:, notifiers:, config:, metrics_store:, state_store:, emitter:)
           @traffic_control = traffic_control
           @notifiers = notifiers
           @config = config
           @metrics_store = metrics_store
           @state_store = state_store
+          @emitter = emitter
         end
 
         def record_failure(exception)
@@ -34,6 +35,7 @@ module Stoplight
         attr_reader :config
         attr_reader :metrics_store
         attr_reader :state_store
+        attr_reader :emitter
 
         def transition_to_red(exception, metrics:)
           if traffic_control.stop_traffic?(config, metrics)
@@ -44,8 +46,30 @@ module Stoplight
               notifiers.each do |notifier|
                 notifier.notify(info, Color::GREEN, Color::RED, exception)
               end
+              emitter.emit(Telemetry::TrafficBreached) do
+                Telemetry::TrafficBreached.new(
+                  from_color: Color::GREEN,
+                  to_color: Color::RED,
+                  policy: policy_name,
+                  failure: Telemetry::Failure.new(exception:, tracked: true),
+                  metrics: telemetry_metrics(metrics)
+                )
+              end
             end
           end
+        end
+
+        def policy_name
+          traffic_control.class.to_s.split("::").last.gsub(/([a-z\d])([A-Z])/, "\\1_\\2").downcase
+        end
+
+        def telemetry_metrics(metrics)
+          Telemetry::Metrics.new(
+            successes: metrics.successes,
+            errors: metrics.errors,
+            consecutive_errors: metrics.consecutive_errors,
+            consecutive_successes: metrics.consecutive_successes
+          )
         end
       end
     end

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -86,7 +86,7 @@ module Stoplight
       end
 
       def request_tracker
-        Domain::Tracker::Request.new(traffic_control:, notifiers:, config:, metrics_store:, state_store:)
+        Domain::Tracker::Request.new(traffic_control:, notifiers:, config:, metrics_store:, state_store:, emitter: @emitter)
       end
 
       def recovery_probe_tracker

--- a/sig/_private/stoplight/domain/ports/traffic_control.rbs
+++ b/sig/_private/stoplight/domain/ports/traffic_control.rbs
@@ -36,6 +36,7 @@ module Stoplight
       # Object methods
       def ==: (untyped) -> bool
       def is_a?: (untyped) -> bool
+      def class: -> Class
     end
   end
 end

--- a/sig/_private/stoplight/domain/tracker/request.rbs
+++ b/sig/_private/stoplight/domain/tracker/request.rbs
@@ -7,6 +7,7 @@ module Stoplight
         attr_reader notifiers: Array[state_transition_notifier]
         attr_reader metrics_store: _MetricsStore
         attr_reader state_store: _StateStore
+        attr_reader emitter: Telemetry::Emitter
 
         def initialize: (
           config: Config,
@@ -14,12 +15,15 @@ module Stoplight
           notifiers: Array[state_transition_notifier],
           metrics_store: _MetricsStore,
           state_store: _StateStore,
+          emitter: Telemetry::Emitter,
         ) -> void
 
         def record_failure: (StandardError exception) -> void
         def record_success: -> void
 
         private def transition_to_red: (StandardError exception, metrics: MetricsSnapshot) -> void
+        private def policy_name: -> String
+        private def telemetry_metrics: (MetricsSnapshot) -> Telemetry::Metrics
       end
     end
   end

--- a/spec/unit/stoplight/domain/tracker/request_spec.rb
+++ b/spec/unit/stoplight/domain/tracker/request_spec.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Stoplight::Domain::Tracker::Request do
-  subject(:request_tracker) { described_class.new(state_store:, traffic_control:, notifiers:, config:, metrics_store:) }
+  subject(:request_tracker) do
+    described_class.new(state_store:, traffic_control:, notifiers:, config:, metrics_store:, emitter:)
+  end
 
   let(:metrics_store) { instance_double(NullMetricsStore) }
   let(:state_store) { instance_double(NullStateStore) }
-  let(:traffic_control) { instance_double(NullTrafficControl) }
+  let(:traffic_control) { Stoplight::Domain::TrafficControl::ConsecutiveErrors.new }
+  let(:emitter) { TestTelemetryEmitter.new }
   let(:notifiers) { [notifier] }
   let(:notifier) { instance_double(NullNotifier) }
   let(:config) { instance_double(Stoplight::Domain::Config, name: name) }
@@ -19,7 +22,16 @@ RSpec.describe Stoplight::Domain::Tracker::Request do
 
   describe "#record_failure" do
     let(:exception) { KeyError.new("something went wrong") }
-    let(:metrics) { instance_double(Stoplight::Domain::MetricsSnapshot) }
+    let(:metrics) do
+      Stoplight::Domain::MetricsSnapshot.new(
+        successes: 2,
+        errors: 3,
+        consecutive_errors: 3,
+        consecutive_successes: 0,
+        last_error: nil,
+        last_success_at: nil
+      )
+    end
 
     before do
       allow(metrics_store).to receive(:record_failure).with(exception)
@@ -38,12 +50,31 @@ RSpec.describe Stoplight::Domain::Tracker::Request do
 
           request_tracker.record_failure(exception)
         end
+
+        it "emits a TrafficBreached event" do
+          allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::RED).and_return(true)
+          allow(notifier).to receive(:notify)
+
+          expect { request_tracker.record_failure(exception) }.to emit(Stoplight::Domain::Telemetry::TrafficBreached).with(
+            from_color: Stoplight::Color::GREEN,
+            to_color: Stoplight::Color::RED,
+            policy: "consecutive_errors",
+            failure: Stoplight::Domain::Telemetry::Failure.new(exception:, tracked: true),
+            metrics: Stoplight::Domain::Telemetry::Metrics.new(
+              successes: metrics.successes,
+              errors: metrics.errors,
+              consecutive_errors: metrics.consecutive_errors,
+              consecutive_successes: metrics.consecutive_successes
+            )
+          )
+        end
       end
 
       context "when failed to transition to RED" do
         it "does not send notification about transition" do
           allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::RED).and_return(false)
           expect(notifier).not_to receive(:notify)
+          expect(emitter).not_to receive(:emit)
 
           request_tracker.record_failure(exception)
         end
@@ -52,6 +83,7 @@ RSpec.describe Stoplight::Domain::Tracker::Request do
 
     specify "when traffic control decides to continue the traffic flow" do
       expect(traffic_control).to receive(:stop_traffic?).with(config, metrics).and_return(false)
+      expect(emitter).not_to receive(:emit)
 
       request_tracker.record_failure(exception)
     end


### PR DESCRIPTION
## Summary

Emit `TrafficBreached` when traffic control successfully transitions a light from green to red. The event carries the normalized traffic-control policy name, tracked failure, and a serializable snapshot of the metrics used for the breach decision.

The emit remains inside `transition_to_color`'s existing dedup guard, so a lost concurrent transition or a decision to continue traffic emits nothing.

Fixes #743.

## Verification

- `bundle exec rspec spec/unit/stoplight/domain` — 151 examples, 0 failures
- `bundle exec standardrb lib/stoplight/domain/tracker/request.rb lib/stoplight/wiring/light_factory.rb spec/unit/stoplight/domain/tracker/request_spec.rb`
- `bundle exec steep check` — changed files clean; five existing errors remain in Redis key-space, notifier fail-safe, and telemetry table code
- `git diff --check`

The broader wiring slice passed 27 non-Redis examples; its Redis-backed example requires a local Redis server and was not run successfully in this environment.

AI assistance disclosure: OpenAI Codex assisted with implementation; I reviewed the diff and verification results.