### PR TITLE
Allow per-call error tracking overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,16 @@ light = Stoplight("Example API", tracked_errors: [NetworkError, Timeout::Error])
 
 When both methods are used, `skipped_errors` takes precedence over `tracked_errors`.
 
+Either list can be replaced for a single call without changing the light's configuration:
+
+```ruby
+light.run(tracked_errors: [Timeout::Error]) { fetch_data }
+light.run(skipped_errors: [ValidationError]) { process_data }
+```
+
+Any list omitted from `run` keeps its configured value. The provided list is replaced only for that call, and
+`skipped_errors` still takes precedence over `tracked_errors`.
+
 ## Advanced Configuration
 
 ### Traffic Control Strategies

--- a/features/stoplight/configuration.feature
+++ b/features/stoplight/configuration.feature
@@ -86,6 +86,33 @@ Feature: Stoplight Custom Configuration
     And 1 request is made
     Then the light color is green
 
+  Scenario: Per-call tracked errors replace the registered list and preserve registered skipped errors
+    Given a light configured with:
+      | Tracked Errors | KeyError       |
+      | Skipped Errors | Timeout::Error |
+      | Threshold      | 1              |
+    When the service starts failing with:
+      | Type | Timeout::Error |
+    And 1 request is made with:
+      | Tracked Errors | StandardError |
+    Then the light color is green
+    When the service starts failing with:
+      | Type | KeyError |
+    And 1 request is made with:
+      | Tracked Errors | Timeout::Error |
+    Then the light color is green
+
+  Scenario: Per-call skipped errors replace the registered list and preserve registered tracked errors
+    Given a light configured with:
+      | Tracked Errors | StandardError  |
+      | Skipped Errors | Timeout::Error |
+      | Threshold      | 1              |
+    When the service starts failing with:
+      | Type | Timeout::Error |
+    And 1 request is made with:
+      | Skipped Errors | KeyError |
+    Then the light color is red
+
   Scenario: System-level exceptions don't trigger circuit breaker
     Given a light configured with:
       | Threshold   | 1             |

--- a/features/stoplight/step_definitions/circuit_breaker_steps.rb
+++ b/features/stoplight/step_definitions/circuit_breaker_steps.rb
@@ -58,6 +58,18 @@ And(/^(\d+) request(?:s)? (?:is|are) made(?: with "([^"]+)" message)?(?: (?:with
   end
 end
 
+And(/^(\d+) request(?:s)? (?:is|are) made with:$/) do |count, table|
+  settings = collect_settings(table).slice(:tracked_errors, :skipped_errors)
+
+  count.to_i.times do |x|
+    capture_result do
+      current_light.run(**settings) do
+        echo_service.call("hello #{x}")
+      end
+    end
+  end
+end
+
 When(/^I lock the light to ([^"]*)$/) do |color|
   current_light.lock(color)
 end

--- a/lib/stoplight/domain/error_tracking_policy.rb
+++ b/lib/stoplight/domain/error_tracking_policy.rb
@@ -9,6 +9,15 @@ module Stoplight
         @skipped = skipped
       end
 
+      def with(tracked: T.undefined, skipped: T.undefined)
+        return self if tracked.is_a?(Undefined) && skipped.is_a?(Undefined)
+
+        self.class.new(
+          tracked: tracked.is_a?(Undefined) ? @tracked : Array(tracked),
+          skipped: skipped.is_a?(Undefined) ? @skipped : Array(skipped)
+        )
+      end
+
       def track?(error)
         !skipped?(error) && tracked?(error)
       end

--- a/lib/stoplight/domain/light.rb
+++ b/lib/stoplight/domain/light.rb
@@ -11,13 +11,22 @@ module Stoplight
       attr_reader :red_run_strategy
       attr_reader :state_store
 
-      def initialize(name, green_run_strategy:, yellow_run_strategy:, red_run_strategy:, state_store:, lock_control:)
+      def initialize(
+        name,
+        green_run_strategy:,
+        yellow_run_strategy:,
+        red_run_strategy:,
+        state_store:,
+        lock_control:,
+        error_tracking_policy:
+      )
         @name = name
         @green_run_strategy = green_run_strategy
         @yellow_run_strategy = yellow_run_strategy
         @red_run_strategy = red_run_strategy
         @state_store = state_store
         @lock_control = lock_control
+        @error_tracking_policy = error_tracking_policy
       end
 
       # Returns the current state of the light:
@@ -48,14 +57,20 @@ module Stoplight
       #   light = Stoplight('example')
       #   light.run(->(error) { 0 }) { 1 / 0 } #=> 0
       #
+      # @example Overriding tracked errors for one run
+      #   light.run(tracked_errors: [Timeout::Error]) { fetch_data }
+      #
       # @param fallback fallback code to run if the circuit breaker is open
+      # @param tracked_errors errors to track for this run; replaces the configured list
+      # @param skipped_errors errors to skip for this run; replaces the configured list
       # @raise [Stoplight::Error::RedLight]
-      def run(fallback = nil, &code)
+      def run(fallback = nil, tracked_errors: T.undefined, skipped_errors: T.undefined, &code)
         raise ArgumentError, "nothing to run. Please, pass a block into `Light#run`" unless block_given?
 
         state_snapshot.then do |state_snapshot|
           strategy = state_strategy_factory(state_snapshot.color)
-          strategy.execute(fallback, state_snapshot:, &code)
+          error_tracking_policy = @error_tracking_policy.with(tracked: tracked_errors, skipped: skipped_errors)
+          strategy.execute(fallback, state_snapshot:, error_tracking_policy:, &code)
         end
       end
 

--- a/lib/stoplight/domain/strategies/green_run_strategy.rb
+++ b/lib/stoplight/domain/strategies/green_run_strategy.rb
@@ -10,8 +10,7 @@ module Stoplight
       #
       # @api private
       class GreenRunStrategy
-        def initialize(error_tracking_policy:, request_tracker:, run_recorder:, clock:)
-          @error_tracking_policy = error_tracking_policy
+        def initialize(request_tracker:, run_recorder:, clock:)
           @request_tracker = request_tracker
           @run_recorder = run_recorder
           @clock = clock
@@ -24,7 +23,7 @@ module Stoplight
         # @yield The code block to execute.
         # @return The result of the code block if successful.
         # @raise re-raises the error if it is not tracked or no fallback is provided.
-        def execute(fallback, state_snapshot:, &code)
+        def execute(fallback, state_snapshot:, error_tracking_policy:, &code)
           started_at = capture_started_at
 
           begin
@@ -33,7 +32,7 @@ module Stoplight
 
             result
           rescue => error
-            if @error_tracking_policy.track?(error)
+            if error_tracking_policy.track?(error)
               record_error(error, duration_ms: duration_since(started_at), fallback_used: !fallback.nil?)
 
               if fallback

--- a/lib/stoplight/domain/strategies/red_run_strategy.rb
+++ b/lib/stoplight/domain/strategies/red_run_strategy.rb
@@ -22,7 +22,7 @@ module Stoplight
         # @param state_snapshot
         # @return The result of the fallback proc if provided.
         # @raise [Stoplight::Error::RedLight] Raises an error if no fallback is provided.
-        def execute(fallback, state_snapshot:)
+        def execute(fallback, state_snapshot:, error_tracking_policy:)
           @run_recorder.record_blocked(
             fallback_used: !fallback.nil?,
             retry_after: state_snapshot.recovery_scheduled_after

--- a/lib/stoplight/domain/strategies/yellow_run_strategy.rb
+++ b/lib/stoplight/domain/strategies/yellow_run_strategy.rb
@@ -13,7 +13,6 @@ module Stoplight
       class YellowRunStrategy
         def initialize(
           name:,
-          error_tracking_policy:,
           notifiers:,
           request_tracker:,
           state_store:,
@@ -29,7 +28,6 @@ module Stoplight
           @metrics_store = metrics_store
           @recovery_lock_store = recovery_lock_store
           @name = name
-          @error_tracking_policy = error_tracking_policy
           @config = config
           @clock = clock
           @run_recorder = run_recorder
@@ -42,7 +40,7 @@ module Stoplight
         # @yield The code block to execute.
         # @return The result of the code block if successful.
         # @raise Re-raises the error if it is not tracked or no fallback is provided.
-        def execute(fallback, state_snapshot:, &code)
+        def execute(fallback, state_snapshot:, error_tracking_policy:, &code)
           # Everything withing this block executed exclusively:
           #   - enter recovery
           #   - execute user's code
@@ -55,7 +53,7 @@ module Stoplight
             record_recovery_probe_success(duration_ms: duration_since(started_at))
             result
           rescue => error
-            if @error_tracking_policy.track?(error)
+            if error_tracking_policy.track?(error)
               record_recovery_probe_failure(error, duration_ms: duration_since(started_at), fallback_used: !fallback.nil?)
 
               if fallback

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -44,7 +44,8 @@ module Stoplight
           green_run_strategy:,
           yellow_run_strategy:,
           red_run_strategy:,
-          lock_control:
+          lock_control:,
+          error_tracking_policy: @error_tracking_policy
         )
       end
 
@@ -103,7 +104,6 @@ module Stoplight
 
       def green_run_strategy
         Domain::Strategies::GreenRunStrategy.new(
-          error_tracking_policy: @error_tracking_policy,
           request_tracker:,
           clock:,
           run_recorder: run_recorder(Color::GREEN)
@@ -113,7 +113,6 @@ module Stoplight
       def yellow_run_strategy
         Domain::Strategies::YellowRunStrategy.new(
           name: @name,
-          error_tracking_policy: @error_tracking_policy,
           notifiers:,
           request_tracker: recovery_probe_tracker,
           state_store:,

--- a/sig/_private/stoplight/domain/error_tracking_policy.rbs
+++ b/sig/_private/stoplight/domain/error_tracking_policy.rbs
@@ -5,6 +5,10 @@ module Stoplight
       @skipped: Array[_ExceptionMatcher]
 
       def initialize: (tracked: Array[_ExceptionMatcher], skipped: Array[_ExceptionMatcher]) -> void
+      def with: (
+        ?tracked: optional[Array[_ExceptionMatcher] | _ExceptionMatcher],
+        ?skipped: optional[Array[_ExceptionMatcher] | _ExceptionMatcher]
+      ) -> ErrorTrackingPolicy
       def track?: (StandardError) -> bool
 
       def skipped?: (StandardError) -> bool

--- a/sig/_private/stoplight/domain/light.rbs
+++ b/sig/_private/stoplight/domain/light.rbs
@@ -8,6 +8,7 @@ module Stoplight
       attr_reader state_store: _StateStore
       @name: String
       @lock_control: LockControl
+      @error_tracking_policy: ErrorTrackingPolicy
 
       def initialize: (
         String name,
@@ -15,7 +16,8 @@ module Stoplight
         yellow_run_strategy: Strategies::YellowRunStrategy,
         red_run_strategy: Strategies::RedRunStrategy,
         state_store: _StateStore,
-        lock_control: LockControl
+        lock_control: LockControl,
+        error_tracking_policy: ErrorTrackingPolicy
       ) -> void
 
       private def state_strategy_factory: (color) -> _RunStrategy

--- a/sig/_private/stoplight/domain/ports/run_strategy.rbs
+++ b/sig/_private/stoplight/domain/ports/run_strategy.rbs
@@ -7,7 +7,8 @@ module Stoplight
       # @param fallback A fallback proc to execute in case of an error.
       def execute: [T] (
         (^(StandardError?) -> T)? fallback,
-        state_snapshot: StateSnapshot
+        state_snapshot: StateSnapshot,
+        error_tracking_policy: ErrorTrackingPolicy
       ) { () -> T } -> T
     end
   end

--- a/sig/_private/stoplight/domain/strategies/green_run_strategy.rbs
+++ b/sig/_private/stoplight/domain/strategies/green_run_strategy.rbs
@@ -5,11 +5,10 @@ module Stoplight
         include _RunStrategy
 
         attr_reader request_tracker: Tracker::Request
-        @error_tracking_policy: ErrorTrackingPolicy
         @run_recorder: Telemetry::RunRecorder
         @clock: _Clock
 
-        def initialize: (error_tracking_policy: ErrorTrackingPolicy, request_tracker: Tracker::Request,
+        def initialize: (request_tracker: Tracker::Request,
             run_recorder: Telemetry::RunRecorder, clock: _Clock) -> void
 
         def capture_started_at: () -> Float?

--- a/sig/_private/stoplight/domain/strategies/yellow_run_strategy.rbs
+++ b/sig/_private/stoplight/domain/strategies/yellow_run_strategy.rbs
@@ -12,13 +12,11 @@ module Stoplight
 
         @name: String
         @config: Domain::Config
-        @error_tracking_policy: ErrorTrackingPolicy
         @clock: _Clock
         @run_recorder: Telemetry::RunRecorder
 
         def initialize: (
           name: String,
-          error_tracking_policy: ErrorTrackingPolicy,
           notifiers: Array[state_transition_notifier],
           request_tracker: Tracker::RecoveryProbe,
           state_store: _StateStore,

--- a/sig/stoplight/ports/light.rbs
+++ b/sig/stoplight/ports/light.rbs
@@ -4,7 +4,11 @@ module Stoplight
 
     def state: -> state
     def color: -> color
-    def run: [T] (?(^(StandardError?) -> T)?) { () -> T } -> T
+    def run: [T] (
+      ?(^(StandardError?) -> T)?,
+      ?tracked_errors: optional[Array[_ExceptionMatcher] | _ExceptionMatcher],
+      ?skipped_errors: optional[Array[_ExceptionMatcher] | _ExceptionMatcher]
+    ) { () -> T } -> T
     def lock: (color) -> _Light
     def unlock: -> _Light
   end

--- a/spec/integration/light_spec.rb
+++ b/spec/integration/light_spec.rb
@@ -67,6 +67,76 @@ RSpec.describe "Light" do
       end.not_to raise_error
     end
 
+    specify "with per-call tracked_errors" do
+      light = Stoplight(SecureRandom.uuid, tracked_errors: KeyError)
+
+      expect do
+        light.run(fallback, tracked_errors: [Timeout::Error]) { raise Timeout::Error }
+      end.not_to raise_error
+
+      expect do
+        light.run(fallback, tracked_errors: [Timeout::Error]) { raise KeyError }
+      end.to raise_error(KeyError)
+
+      expect do
+        light.run(fallback, tracked_errors: []) { raise Timeout::Error }
+      end.to raise_error(Timeout::Error)
+
+      expect do
+        light.run(fallback) { raise KeyError }
+      end.not_to raise_error
+    end
+
+    specify "with per-call skipped_errors" do
+      light = Stoplight(SecureRandom.uuid, tracked_errors: StandardError, skipped_errors: Timeout::Error)
+
+      expect do
+        light.run(fallback, skipped_errors: [KeyError]) { raise Timeout::Error }
+      end.not_to raise_error
+
+      expect do
+        light.run(fallback, skipped_errors: [KeyError]) { raise KeyError }
+      end.to raise_error(KeyError)
+
+      expect do
+        light.run(fallback) { raise Timeout::Error }
+      end.to raise_error(Timeout::Error)
+    end
+
+    specify "with per-call tracked_errors while yellow" do
+      light = Stoplight(
+        SecureRandom.uuid,
+        tracked_errors: Timeout::Error,
+        traffic_control: :consecutive_errors,
+        threshold: 1,
+        cool_off_time: 1
+      )
+      light.run(fallback) { raise Timeout::Error }
+
+      Timecop.travel(Time.now + 2) do
+        expect(light.color).to eq(Stoplight::Color::YELLOW)
+        expect do
+          light.run(fallback, tracked_errors: [KeyError]) { raise KeyError }
+        end.not_to raise_error
+        expect(light.color).to eq(Stoplight::Color::RED)
+      end
+    end
+
+    specify "with per-call error tracking while red" do
+      light = Stoplight(
+        SecureRandom.uuid,
+        traffic_control: :consecutive_errors,
+        threshold: 1
+      )
+      light.run(fallback) { raise StandardError }
+
+      code_executed = false
+      light.run(fallback, skipped_errors: [KeyError]) { code_executed = true }
+
+      expect(code_executed).to be false
+      expect(light.color).to eq(Stoplight::Color::RED)
+    end
+
     context "with traffic control" do
       specify "with error rate" do
         light = Stoplight(SecureRandom.uuid, traffic_control: :error_rate, threshold: 0.5, window_size: 60)

--- a/spec/unit/stoplight/domain/error_tracking_policy_spec.rb
+++ b/spec/unit/stoplight/domain/error_tracking_policy_spec.rb
@@ -46,4 +46,33 @@ RSpec.describe Stoplight::Domain::ErrorTrackingPolicy do
       it { is_expected.to be false }
     end
   end
+
+  describe "#with" do
+    let(:tracked_errors) { [StandardError] }
+    let(:skipped_errors) { [Timeout::Error] }
+
+    it "returns itself when no overrides are provided" do
+      expect(policy.with).to equal(policy)
+    end
+
+    it "replaces tracked errors and preserves skipped errors" do
+      overridden = policy.with(tracked: KeyError)
+
+      expect(overridden).to satisfy { |candidate|
+        candidate.track?(KeyError.new) &&
+          !candidate.track?(ArgumentError.new) &&
+          !candidate.track?(Timeout::Error.new)
+      }
+    end
+
+    it "replaces skipped errors and preserves tracked errors" do
+      overridden = policy.with(skipped: KeyError)
+
+      expect(overridden).to satisfy { |candidate|
+        candidate.track?(Timeout::Error.new) &&
+          candidate.track?(ArgumentError.new) &&
+          !candidate.track?(KeyError.new)
+      }
+    end
+  end
 end

--- a/spec/unit/stoplight/domain/light_spec.rb
+++ b/spec/unit/stoplight/domain/light_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Stoplight::Domain::Light do
       yellow_run_strategy:,
       red_run_strategy:,
       state_store:,
-      lock_control:
+      lock_control:,
+      error_tracking_policy:
     )
   end
   let(:config) { instance_double(Stoplight::Domain::Config) }
@@ -17,6 +18,9 @@ RSpec.describe Stoplight::Domain::Light do
   let(:red_run_strategy) { instance_double(Stoplight::Domain::Strategies::RedRunStrategy) }
   let(:state_store) { instance_double(NullStateStore) }
   let(:lock_control) { instance_double(Stoplight::Domain::LockControl) }
+  let(:error_tracking_policy) do
+    Stoplight::Domain::ErrorTrackingPolicy.new(tracked: [StandardError], skipped: [Timeout::Error])
+  end
 
   describe "#lock" do
     let(:color) { Stoplight::Color::GREEN }
@@ -50,6 +54,7 @@ RSpec.describe Stoplight::Domain::Light do
 
   describe "#run" do
     let(:state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot, color:) }
+    let(:color) { Stoplight::Color::GREEN }
     let(:fallback) { ->(_error) { "fallback" } }
     let(:code) { -> { "result" } }
 
@@ -62,7 +67,7 @@ RSpec.describe Stoplight::Domain::Light do
         let(:color) { current_color }
 
         it "executes green run strategy" do
-          expect(strategy).to receive(:execute).with(fallback, state_snapshot:) { |_, _, &block|
+          expect(strategy).to receive(:execute).with(fallback, state_snapshot:, error_tracking_policy:) { |_, _, &block|
             expect(block).to eq(code)
             "result"
           }
@@ -82,6 +87,20 @@ RSpec.describe Stoplight::Domain::Light do
 
     it_behaves_like "delegates to the run strategy", Stoplight::Color::RED do
       let(:strategy) { red_run_strategy }
+    end
+
+    it "uses per-call overrides with registered values as partial fallbacks" do
+      expect(green_run_strategy).to receive(:execute).with(
+        fallback,
+        state_snapshot:,
+        error_tracking_policy: satisfy { |policy|
+          policy.track?(KeyError.new) &&
+            !policy.track?(ArgumentError.new) &&
+            !policy.track?(Timeout::Error.new)
+        }
+      ) { "result" }
+
+      expect(light.run(fallback, tracked_errors: [KeyError], &code)).to eq("result")
     end
   end
 end

--- a/spec/unit/stoplight/domain/run_strategies/green_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/green_run_strategy_spec.rb
@@ -3,7 +3,6 @@
 RSpec.describe Stoplight::Domain::Strategies::GreenRunStrategy do
   subject(:strategy) do
     described_class.new(
-      error_tracking_policy:,
       request_tracker:,
       run_recorder:,
       clock:
@@ -17,7 +16,7 @@ RSpec.describe Stoplight::Domain::Strategies::GreenRunStrategy do
   let(:clock) { instance_double(NullClock, monotonic_time: 1.4) }
 
   context "when code executes successfully" do
-    subject(:result) { strategy.execute(nil, state_snapshot: nil, &code) }
+    subject(:result) { strategy.execute(nil, state_snapshot: nil, error_tracking_policy:, &code) }
 
     let(:code) { -> { "Success" } }
 
@@ -43,7 +42,7 @@ RSpec.describe Stoplight::Domain::Strategies::GreenRunStrategy do
   end
 
   context "when nobody is subscribed to telemetry" do
-    subject(:result) { strategy.execute(nil, state_snapshot: nil, &code) }
+    subject(:result) { strategy.execute(nil, state_snapshot: nil, error_tracking_policy:, &code) }
 
     let(:code) { -> { "Success" } }
     let(:run_recorder) { instance_double(Stoplight::Domain::Telemetry::RunRecorder, subscribed?: false, record_success: nil) }
@@ -57,7 +56,7 @@ RSpec.describe Stoplight::Domain::Strategies::GreenRunStrategy do
   end
 
   context "when code fails" do
-    subject(:result) { strategy.execute(fallback, state_snapshot: nil, &code) }
+    subject(:result) { strategy.execute(fallback, state_snapshot: nil, error_tracking_policy:, &code) }
 
     let(:error) { StandardError.new("Test error") }
     let(:code) { -> { raise error } }

--- a/spec/unit/stoplight/domain/run_strategies/red_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/red_run_strategy_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Stoplight::Domain::Strategies::RedRunStrategy, :freeze do
-  subject(:result) { strategy.execute(fallback, state_snapshot:) { 42 } }
+  subject(:result) { strategy.execute(fallback, state_snapshot:, error_tracking_policy:) { 42 } }
 
   let(:strategy) do
     described_class.new(
@@ -11,6 +11,7 @@ RSpec.describe Stoplight::Domain::Strategies::RedRunStrategy, :freeze do
     )
   end
   let(:state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot, recovery_scheduled_after: Time.now) }
+  let(:error_tracking_policy) { instance_double(Stoplight::Domain::ErrorTrackingPolicy) }
   let(:name) { SecureRandom.uuid }
   let(:cool_off_time) { 60 }
   let(:emitter) { TestTelemetryEmitter.new }

--- a/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
   subject(:strategy) do
     described_class.new(
       name:,
-      error_tracking_policy:,
       notifiers: notifiers,
       request_tracker:,
       state_store:,
@@ -43,7 +42,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
       end
 
       context "when code executes successfully" do
-        subject(:result) { strategy.execute(nil, state_snapshot: nil, &code) }
+        subject(:result) { strategy.execute(nil, state_snapshot: nil, error_tracking_policy:, &code) }
 
         let(:code) { -> { "Success" } }
 
@@ -71,7 +70,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
       end
 
       context "when nobody is subscribed to telemetry" do
-        subject(:result) { strategy.execute(nil, state_snapshot: nil, &code) }
+        subject(:result) { strategy.execute(nil, state_snapshot: nil, error_tracking_policy:, &code) }
 
         let(:code) { -> { "Success" } }
         let(:run_recorder) { instance_double(Stoplight::Domain::Telemetry::RunRecorder, subscribed?: false, record_success: nil) }
@@ -86,7 +85,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
       end
 
       context "when code fails" do
-        subject(:result) { strategy.execute(fallback, state_snapshot: nil, &code) }
+        subject(:result) { strategy.execute(fallback, state_snapshot: nil, error_tracking_policy:, &code) }
 
         let(:error) { StandardError.new("Test error") }
         let(:code) { -> { raise error } }
@@ -200,7 +199,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
 
         it "returns the fallback result without yielding" do
           expect do |code|
-            result = strategy.execute(fallback, state_snapshot:, &code)
+            result = strategy.execute(fallback, state_snapshot:, error_tracking_policy:, &code)
             expect(result).to eq("Fallback")
           end.not_to yield_control
 
@@ -210,12 +209,12 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
         it "does not measure duration for a blocked run" do
           expect(clock).not_to receive(:monotonic_time)
 
-          strategy.execute(fallback, state_snapshot:) {}
+          strategy.execute(fallback, state_snapshot:, error_tracking_policy:) {}
         end
 
         it "produces RunCompleted event" do
           expect {
-            strategy.execute(fallback, state_snapshot:) {}
+            strategy.execute(fallback, state_snapshot:, error_tracking_policy:) {}
           }.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
             outcome: :blocked,
             color: "yellow",
@@ -232,7 +231,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
 
         it "raises RedLight without yielding" do
           expect do |code|
-            expect { strategy.execute(fallback, state_snapshot:, &code) }.to raise_error(Stoplight::Error::RedLight, name) { |error|
+            expect { strategy.execute(fallback, state_snapshot:, error_tracking_policy:, &code) }.to raise_error(Stoplight::Error::RedLight, name) { |error|
               expect(error.cool_off_time).to eq(cool_off_time)
               expect(error.retry_after).to eq(state_snapshot.recovery_scheduled_after)
             }
@@ -243,7 +242,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
           expect(clock).not_to receive(:monotonic_time)
 
           begin
-            strategy.execute(fallback, state_snapshot:) {}
+            strategy.execute(fallback, state_snapshot:, error_tracking_policy:) {}
           rescue Stoplight::Error::RedLight
             nil
           end
@@ -252,7 +251,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
         it "produces RunCompleted event" do
           expect do
             expect do
-              strategy.execute(fallback, state_snapshot:) {}
+              strategy.execute(fallback, state_snapshot:, error_tracking_policy:) {}
             end.to raise_error(Stoplight::Error::RedLight, name)
           end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
             outcome: :blocked,


### PR DESCRIPTION
## Summary

- allow `Light#run` to replace `tracked_errors` or `skipped_errors` for one invocation while omitted values fall back to the registered configuration
- keep the default error-tracking policy as one shared value and derive per-call replacements through `ErrorTrackingPolicy#with`
- synchronize RBS and README documentation and cover replacement, partial fallback, empty lists, isolation, and all light colors

Closes #738

## Testing

- `bundle exec rspec` (624 examples)
- `bundle exec steep check`
- `bundle exec standardrb`
- full Cucumber matrix with Memory and Redis using both `Stoplight()` and `System#light` (62 scenarios per run; four expected global-configuration scenarios pending for `System#light`)
- `git diff --check`