### PR TITLE
feat: emit RecoveryFailed telemetry

### DIFF
--- a/lib/stoplight/domain/tracker/recovery_probe.rb
+++ b/lib/stoplight/domain/tracker/recovery_probe.rb
@@ -4,19 +4,20 @@ module Stoplight
   module Domain
     module Tracker
       class RecoveryProbe
-        def initialize(traffic_recovery:, notifiers:, config:, metrics_store:, state_store:)
+        def initialize(traffic_recovery:, notifiers:, config:, metrics_store:, state_store:, emitter:)
           @traffic_recovery = traffic_recovery
           @notifiers = notifiers
           @config = config
           @metrics_store = metrics_store
           @state_store = state_store
+          @emitter = emitter
         end
 
         # @param exception [Exception]
         def record_failure(exception)
           metrics_store.record_failure(exception)
 
-          recover
+          recover(exception)
         end
 
         def record_success
@@ -32,8 +33,9 @@ module Stoplight
         attr_reader :config
         attr_reader :metrics_store
         attr_reader :state_store
+        attr_reader :emitter
 
-        def recover
+        def recover(exception = nil)
           recovery_metrics = metrics_store.metrics_snapshot
           recovery_result = traffic_recovery.determine_color(config, recovery_metrics)
 
@@ -46,12 +48,37 @@ module Stoplight
             raise "recovery strategy returned unexpected color: #{recovery_result}"
           end
 
-          state_store.transition_to_color(to_color)
+          transitioned = state_store.transition_to_color(to_color)
           metrics_store.clear
           info = LightInfo.new(name: config.name)
           notifiers.each do |notifier|
             notifier.notify(info, from_color, to_color, nil)
           end
+
+          return unless transitioned && to_color == Color::RED
+
+          emitter.emit(Telemetry::RecoveryFailed) do
+            Telemetry::RecoveryFailed.new(
+              from_color: Color::YELLOW,
+              to_color: Color::RED,
+              policy: policy_name,
+              failure: exception && Telemetry::Failure.new(exception:, tracked: true),
+              metrics: telemetry_metrics(recovery_metrics)
+            )
+          end
+        end
+
+        def policy_name
+          traffic_recovery.class.to_s.split("::").last.gsub(/([a-z\d])([A-Z])/, "\\1_\\2").downcase
+        end
+
+        def telemetry_metrics(metrics)
+          Telemetry::Metrics.new(
+            successes: metrics.successes,
+            errors: metrics.errors,
+            consecutive_errors: metrics.consecutive_errors,
+            consecutive_successes: metrics.consecutive_successes
+          )
         end
       end
     end

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -95,7 +95,8 @@ module Stoplight
           notifiers:,
           config:,
           metrics_store: recovery_metrics_store,
-          state_store:
+          state_store:,
+          emitter: @emitter
         )
       end
 

--- a/sig/_private/stoplight/domain/ports/traffic_recovery.rbs
+++ b/sig/_private/stoplight/domain/ports/traffic_recovery.rbs
@@ -42,6 +42,7 @@ module Stoplight
       # Object methods
       def ==: (untyped) -> bool
       def is_a?: (untyped) -> bool
+      def class: -> Class
     end
   end
 end

--- a/sig/_private/stoplight/domain/tracker/recovery_probe.rbs
+++ b/sig/_private/stoplight/domain/tracker/recovery_probe.rbs
@@ -7,6 +7,7 @@ module Stoplight
         attr_reader config: Config
         attr_reader metrics_store: _MetricsStore
         attr_reader state_store: _StateStore
+        attr_reader emitter: Telemetry::Emitter
 
         def initialize: (
           config: Config,
@@ -14,11 +15,14 @@ module Stoplight
           notifiers: Array[state_transition_notifier],
           metrics_store: _MetricsStore,
           state_store: _StateStore,
+          emitter: Telemetry::Emitter,
         ) -> void
 
         def record_failure: (StandardError exception) -> void
         def record_success: -> void
-        def recover: -> void
+        private def recover: (?StandardError? exception) -> void
+        private def policy_name: -> String
+        private def telemetry_metrics: (MetricsSnapshot) -> Telemetry::Metrics
       end
     end
   end

--- a/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
+++ b/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
-  subject(:recorder) { described_class.new(state_store:, traffic_recovery:, notifiers:, config:, metrics_store:) }
+  subject(:recorder) do
+    described_class.new(state_store:, traffic_recovery:, notifiers:, config:, metrics_store:, emitter:)
+  end
 
   let(:metrics_store) { instance_double(NullMetricsStore) }
   let(:state_store) { instance_double(NullStateStore) }
-  let(:traffic_recovery) { instance_double(NullTrafficRecovery) }
+  let(:traffic_recovery) { Stoplight::Domain::TrafficRecovery::ConsecutiveSuccesses.new }
+  let(:emitter) { TestTelemetryEmitter.new }
   let(:notifiers) { [notifier] }
   let(:notifier) { instance_double(NullNotifier) }
   let(:config) { instance_double(Stoplight::Domain::Config, name: name) }
@@ -13,11 +16,20 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
 
   shared_examples "when recover to" do |recover_to:, transition_from:, transition_to:|
     context "when recover to #{recover_to}" do
-      let(:metrics_after_probe) { instance_double(Stoplight::Domain::MetricsSnapshot) }
+      let(:metrics_after_probe) do
+        Stoplight::Domain::MetricsSnapshot.new(
+          successes: 0,
+          errors: 1,
+          consecutive_errors: 1,
+          consecutive_successes: 0,
+          last_error: nil,
+          last_success_at: nil
+        )
+      end
 
       before do
         allow(traffic_recovery).to receive(:determine_color).with(config, metrics_after_probe).and_return(recover_to)
-        allow(state_store).to receive(:transition_to_color).with(transition_to)
+        allow(state_store).to receive(:transition_to_color).with(transition_to).and_return(true)
       end
 
       it "sends notifications" do
@@ -25,6 +37,34 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
         expect(notifier).to receive(:notify).with(have_attributes(name:), transition_from, transition_to, nil)
 
         record_probe
+      end
+
+      if recover_to == Stoplight::Domain::TrafficRecovery::RED
+        it "emits RecoveryFailed after transitioning to red" do
+          allow(metrics_store).to receive(:clear)
+          allow(notifier).to receive(:notify)
+
+          expect { record_probe }.to emit(Stoplight::Domain::Telemetry::RecoveryFailed).with(
+            from_color: Stoplight::Color::YELLOW,
+            to_color: Stoplight::Color::RED,
+            policy: "consecutive_successes",
+            failure: expected_failure,
+            metrics: Stoplight::Domain::Telemetry::Metrics.new(
+              successes: metrics_after_probe.successes,
+              errors: metrics_after_probe.errors,
+              consecutive_errors: metrics_after_probe.consecutive_errors,
+              consecutive_successes: metrics_after_probe.consecutive_successes
+            )
+          )
+        end
+
+        it "does not emit RecoveryFailed when another process already transitioned" do
+          allow(state_store).to receive(:transition_to_color).with(transition_to).and_return(false)
+          allow(metrics_store).to receive(:clear)
+          allow(notifier).to receive(:notify)
+
+          expect { record_probe }.not_to emit(Stoplight::Domain::Telemetry::RecoveryFailed)
+        end
       end
     end
   end
@@ -54,7 +94,16 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
     end
 
     context "when recover to YELLOW (needs more probes)" do
-      let(:metrics_after_probe) { instance_double(Stoplight::Domain::MetricsSnapshot) }
+      let(:metrics_after_probe) do
+        Stoplight::Domain::MetricsSnapshot.new(
+          successes: 0,
+          errors: 0,
+          consecutive_errors: 0,
+          consecutive_successes: 1,
+          last_error: nil,
+          last_success_at: nil
+        )
+      end
       let(:recover_to) { Stoplight::Domain::TrafficRecovery::YELLOW }
 
       before do
@@ -68,11 +117,17 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
 
         record_probe
       end
+
+      it "does not emit RecoveryFailed" do
+        expect { record_probe }.not_to emit(Stoplight::Domain::Telemetry::RecoveryFailed)
+      end
     end
   end
 
   describe "#record_success" do
     subject(:record_probe) { recorder.record_success }
+
+    let(:expected_failure) { nil }
 
     before do
       allow(metrics_store).to receive(:record_success)
@@ -86,6 +141,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
     subject(:record_probe) { recorder.record_failure(exception) }
 
     let(:exception) { KeyError.new("bang") }
+    let(:expected_failure) { Stoplight::Domain::Telemetry::Failure.new(exception:, tracked: true) }
 
     before do
       allow(metrics_store).to receive(:record_failure).with(exception)


### PR DESCRIPTION
## Summary

- inject the existing per-light telemetry emitter into `RecoveryProbe`
- emit `RecoveryFailed` only after this process successfully transitions a light from yellow to red
- include the normalized recovery-policy name, triggering failure, and decision-point metrics in the event payload
- keep RBS signatures in sync and cover successful, lost-race, and still-yellow paths

## Validation

- `bundle exec rspec spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb` — 14 examples, 0 failures
- `STOPLIGHT_REDIS_URL=redis://127.0.0.1:6379/0 bundle exec rspec` — 613 examples, 0 failures
- `bundle exec standardrb lib/stoplight/domain/tracker/recovery_probe.rb lib/stoplight/wiring/light_factory.rb spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb`
- `bundle exec steep check --no-daemon --jobs=2`
- `git diff --check`

Fixes #750
