### PR TITLE
Trigger ProQuo on pull_request_target so fork PRs get a write-capable token

### DIFF
--- a/.github/workflows/proquo.yml
+++ b/.github/workflows/proquo.yml
@@ -1,10 +1,11 @@
 name: 🏷️ ProQuo
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 jobs:
   price:
     name: Review Price Tag


### PR DESCRIPTION
Fixes ProQuo failing with "Resource not accessible by integration" on fork PRs (e.g. #758), since GitHub forces `GITHUB_TOKEN` read-only for `pull_request`-triggered runs on forks regardless of declared permissions.