### PR TITLE
Require Digest dependency explicitly in SystemKeySpace

### DIFF
--- a/lib/stoplight/infrastructure/redis/storage/system_key_space.rb
+++ b/lib/stoplight/infrastructure/redis/storage/system_key_space.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "digest"
+
 module Stoplight
   module Infrastructure
     module Redis

--- a/spec/unit/stoplight/infrastructure/redis/storage/system_key_space_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/system_key_space_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Infrastructure::Redis::Storage::SystemKeySpace do
+  describe ".build" do
+    subject { described_class.build(system_name: system_name) }
+
+    let(:system_name) { "ABCD" }
+
+    it { is_expected.to be_a(described_class).and have_attributes(system_id: instance_of(String)) }
+  end
+
+  describe ".hash_name" do
+    subject { described_class.hash_name(name) }
+
+    let(:name) { "ABCD" }
+
+    it { is_expected.to be_a(String).and have_attributes(size: 12) }
+  end
+
+  describe "#key" do
+    subject { described_class.build(system_name: system_name).key(pieces) }
+
+    let(:system_name) { "ABCD" }
+    let(:pieces) { %w[a b] }
+
+    it { is_expected.to eq("stoplight:v5:e12e115acf45:a:b") }
+  end
+end


### PR DESCRIPTION
* Fixes https://github.com/bolshakov/stoplight/issues/776 by requiring `digest` dependency explicitly. 
* Adds unit test for `Stoplight::Infrastructure::Redis::Storage::SystemKeySpace`