### PR TITLE
Fix Generic notifier doc example to drop nonexistent superclass

### DIFF
--- a/lib/stoplight/infrastructure/notifier/generic.rb
+++ b/lib/stoplight/infrastructure/notifier/generic.rb
@@ -8,7 +8,7 @@ module Stoplight
       #
       # @example Custom Notifier Implementation and Usage
       #     # Custom notifier that writes notifications to a file
-      #     class FileNotifier < Stoplight::Domain::StateTransitionNotifier
+      #     class FileNotifier
       #       include Stoplight::Notifier::Generic
       #
       #       def initialize(file_path)


### PR DESCRIPTION
## Summary

The `@example` in `lib/stoplight/infrastructure/notifier/generic.rb` referenced
`Stoplight::Domain::StateTransitionNotifier`, which does not exist in `lib/` or
`sig/`. Running the example raised `NameError`, so it did not meet the project's
requirement that public API doc comments include a working usage example.

Notifiers satisfy the `_StateTransitionNotifier` via
`include Stoplight::Notifier::Generic`, matching the existing `IO` and
`Logger` implementations. This change removes the incorrect superclass from
the example.

Fixes #787

## Test plan

- [x]    Sanity check: verified updated example in `bundle exec irb -r stoplight` (no `NameError`)
- [x] `bundle exec standardrb`
- [x] `bundle exec rspec spec/unit/stoplight/infrastructure/notifier/generic_spec.rb`
- [x] `bundle exec rspec` (full suite)