### PR TITLE
Fix tracker RBS to drop nonexistent Base superclass

### DIFF
--- a/sig/_private/stoplight/domain/tracker/base.rbs
+++ b/sig/_private/stoplight/domain/tracker/base.rbs
@@ -1,8 +1,0 @@
-module Stoplight
-  module Domain
-    module Tracker
-      class Base
-      end
-    end
-  end
-end

--- a/sig/_private/stoplight/domain/tracker/recovery_probe.rbs
+++ b/sig/_private/stoplight/domain/tracker/recovery_probe.rbs
@@ -1,7 +1,7 @@
 module Stoplight
   module Domain
     module Tracker
-      class RecoveryProbe < Base
+      class RecoveryProbe
         attr_reader traffic_recovery: _TrafficRecovery
         attr_reader notifiers: Array[state_transition_notifier]
         attr_reader config: Config

--- a/sig/_private/stoplight/domain/tracker/request.rbs
+++ b/sig/_private/stoplight/domain/tracker/request.rbs
@@ -1,7 +1,7 @@
 module Stoplight
   module Domain
     module Tracker
-      class Request < Base
+      class Request
         attr_reader config: Config
         attr_reader traffic_control: _TrafficControl
         attr_reader notifiers: Array[state_transition_notifier]


### PR DESCRIPTION
## Summary
- Align `Request` and `RecoveryProbe` RBS with the runtime classes by removing the obsolete `< Base` inheritance.
- Delete the orphaned `sig/_private/stoplight/domain/tracker/base.rbs` left behind after `lib/.../tracker/base.rb` was removed.
- Fixes #785

## Test plan
- [X] `bundle exec steep check` passes
- [X] Confirm `base.rbs` is gone and neither tracker `.rbs` file references `Base`
- [X] Spot-check that `lib/stoplight/domain/tracker/{request,recovery_probe}.rb` still declare plain classes with no superclass