### PR TITLE
Remove unused config reader from GreenRunStrategy

### DIFF
--- a/lib/stoplight/domain/strategies/green_run_strategy.rb
+++ b/lib/stoplight/domain/strategies/green_run_strategy.rb
@@ -51,7 +51,6 @@ module Stoplight
 
         private
 
-        attr_reader :config
         attr_reader :request_tracker
 
         def capture_started_at


### PR DESCRIPTION
## Summary
- Remove the stray private `attr_reader :config` from `GreenRunStrategy`.
- `@config` is never assigned in `initialize`, so the reader is unused dead code and is not present in the RBS sig.
- Fixes #784

## Test plan
- [X] Confirm `attr_reader :config` is gone from `lib/stoplight/domain/strategies/green_run_strategy.rb`
- [x] Confirm `attr_reader :request_tracker` remains (still used)
- [x] `bundle exec rspec spec/unit/stoplight/domain/run_strategies/green_run_strategy_spec.rb`
- [x] `bundle exec steep check`