### PR TITLE
Introduce Domain::LockControl

### DIFF
--- a/lib/stoplight/domain/light.rb
+++ b/lib/stoplight/domain/light.rb
@@ -11,12 +11,13 @@ module Stoplight
       attr_reader :red_run_strategy
       attr_reader :state_store
 
-      def initialize(name, green_run_strategy:, yellow_run_strategy:, red_run_strategy:, state_store:)
+      def initialize(name, green_run_strategy:, yellow_run_strategy:, red_run_strategy:, state_store:, lock_control:)
         @name = name
         @green_run_strategy = green_run_strategy
         @yellow_run_strategy = yellow_run_strategy
         @red_run_strategy = red_run_strategy
         @state_store = state_store
+        @lock_control = lock_control
       end
 
       # Returns the current state of the light:
@@ -67,13 +68,7 @@ module Stoplight
       # @param color should be either +Color::RED+ or +Color::GREEN+
       # @return locked light
       def lock(color)
-        state = case color
-        when Color::RED then State::LOCKED_RED
-        when Color::GREEN then State::LOCKED_GREEN
-        else raise Error::IncorrectColor
-        end
-
-        state_store.set_state(state)
+        @lock_control.lock(color)
 
         self
       end
@@ -87,7 +82,7 @@ module Stoplight
       #
       # @return returns unlocked light (circuit breaker)
       def unlock
-        state_store.set_state(State::UNLOCKED)
+        @lock_control.unlock
 
         self
       end

--- a/lib/stoplight/domain/lock_control.rb
+++ b/lib/stoplight/domain/lock_control.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    # Pins a light to a color (or releases the pin), writing the lock state and emitting +Telemetry::LockChanged+.
+    #
+    # @example
+    #   lock_control = Stoplight::Domain::LockControl.new(state_store:, emitter:)
+    #   lock_control.lock(Stoplight::Color::RED)
+    #   lock_control.unlock
+    #
+    # @api private
+    class LockControl
+      def initialize(state_store:, emitter:)
+        @state_store = state_store
+        @emitter = emitter
+      end
+
+      # @param color - +Color::RED+ or +Color::GREEN+
+      # @raise [Stoplight::Error::IncorrectColor] for any other color
+      def lock(color)
+        state = case color
+        when Color::RED then State::LOCKED_RED
+        when Color::GREEN then State::LOCKED_GREEN
+        else raise Error::IncorrectColor
+        end
+
+        @emitter.emit(Telemetry::LockChanged) do
+          state_snapshot = @state_store.state_snapshot
+
+          Telemetry::LockChanged.new(from_color: state_snapshot.color, to_color: color,
+            from_state: state_snapshot.locked_state, to_state: state)
+        end
+
+        @state_store.set_state(state)
+      end
+
+      def unlock
+        @emitter.emit(Telemetry::LockChanged) do
+          state_snapshot = @state_store.state_snapshot
+          from_color = state_snapshot.color
+          from_state = state_snapshot.locked_state
+          to_state = State::UNLOCKED
+          # Reuses StateSnapshot#color instead of re-deriving it: unlocking can reveal a
+          # breach/recovery color that isn't RED or GREEN, unlike a lock's fixed color.
+          to_color = state_snapshot.with(locked_state: to_state).color
+
+          Telemetry::LockChanged.new(from_color:, to_color:, from_state:, to_state:)
+        end
+
+        @state_store.set_state(State::UNLOCKED)
+      end
+    end
+  end
+end

--- a/lib/stoplight/domain/telemetry/lock_changed.rb
+++ b/lib/stoplight/domain/telemetry/lock_changed.rb
@@ -8,8 +8,7 @@ module Stoplight
         :from_color,
         :to_color,
         :from_state,
-        :to_state,
-        :source
+        :to_state
       )
 
       class LockChanged

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -43,7 +43,8 @@ module Stoplight
           state_store:,
           green_run_strategy:,
           yellow_run_strategy:,
-          red_run_strategy:
+          red_run_strategy:,
+          lock_control: Domain::LockControl.new(state_store:, emitter: @emitter)
         )
       end
 

--- a/sig/_private/stoplight/domain/light.rbs
+++ b/sig/_private/stoplight/domain/light.rbs
@@ -5,15 +5,17 @@ module Stoplight
       attr_reader green_run_strategy: Strategies::GreenRunStrategy
       attr_reader yellow_run_strategy: Strategies::YellowRunStrategy
       attr_reader red_run_strategy: Strategies::RedRunStrategy
-      attr_reader state_store: Domain::_StateStore
+      attr_reader state_store: _StateStore
       @name: String
+      @lock_control: LockControl
 
       def initialize: (
         String name,
         green_run_strategy: Strategies::GreenRunStrategy,
         yellow_run_strategy: Strategies::YellowRunStrategy,
         red_run_strategy: Strategies::RedRunStrategy,
-        state_store: Domain::_StateStore
+        state_store: _StateStore,
+        lock_control: LockControl
       ) -> void
 
       private def state_strategy_factory: (color) -> _RunStrategy

--- a/sig/_private/stoplight/domain/lock_control.rbs
+++ b/sig/_private/stoplight/domain/lock_control.rbs
@@ -1,0 +1,16 @@
+module Stoplight
+  module Domain
+    class LockControl
+      @state_store: _StateStore
+      @emitter: Telemetry::Emitter
+
+      def initialize: (
+          state_store: _StateStore,
+          emitter: Telemetry::Emitter
+        ) -> void
+
+      def lock: (color) -> void
+      def unlock: -> void
+    end
+  end
+end

--- a/sig/stoplight/telemetry/lock_changed.rbs
+++ b/sig/stoplight/telemetry/lock_changed.rbs
@@ -11,15 +11,12 @@ module Stoplight
         attr_reader to_color: color
         attr_reader from_state: state
         attr_reader to_state: state
-        # Open set: "api", "admin", custom.
-        attr_reader source: String
 
         def self.new: (
             from_color: color,
             to_color: color,
             from_state: state,
             to_state: state,
-            source: String
           ) -> instance
 
         def initialize: (
@@ -27,7 +24,6 @@ module Stoplight
             to_color: color,
             from_state: state,
             to_state: state,
-            source: String
           ) -> void
       end
     end

--- a/spec/unit/stoplight/domain/light_spec.rb
+++ b/spec/unit/stoplight/domain/light_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Stoplight::Domain::Light do
       green_run_strategy:,
       yellow_run_strategy:,
       red_run_strategy:,
-      state_store:
+      state_store:,
+      lock_control:
     )
   end
   let(:config) { instance_double(Stoplight::Domain::Config) }
@@ -15,49 +16,20 @@ RSpec.describe Stoplight::Domain::Light do
   let(:yellow_run_strategy) { instance_double(Stoplight::Domain::Strategies::YellowRunStrategy) }
   let(:red_run_strategy) { instance_double(Stoplight::Domain::Strategies::RedRunStrategy) }
   let(:state_store) { instance_double(NullStateStore) }
+  let(:lock_control) { instance_double(Stoplight::Domain::LockControl) }
 
   describe "#lock" do
     let(:color) { Stoplight::Color::GREEN }
 
-    context "with correct color" do
-      context "with green color" do
-        let(:color) { Stoplight::Color::GREEN }
+    it "delegates to lock_control" do
+      expect(lock_control).to receive(:lock).with(color)
 
-        it "locks green color" do
-          expect(state_store).to receive(:set_state).with(Stoplight::State::LOCKED_GREEN)
-
-          expect(light.lock(color)).to be_a Stoplight::Domain::Light
-        end
-      end
-
-      context "with red color" do
-        let(:color) { Stoplight::Color::RED }
-
-        it "locks red color" do
-          expect(state_store).to receive(:set_state).with(Stoplight::State::LOCKED_RED)
-
-          expect(light.lock(color)).to be_a Stoplight::Domain::Light
-        end
-      end
-    end
-
-    context "with incorrect color" do
-      let(:color) { "incorrect-color" }
-
-      it "raises Error::IncorrectColor error" do
-        expect { light.lock(color) }.to raise_error(Stoplight::Error::IncorrectColor)
-      end
-
-      it "does not lock color" do
-        expect(state_store).to_not receive(:set_state)
-
-        suppress(Stoplight::Error::IncorrectColor) { light.lock(color) }
-      end
+      expect(light.lock(color)).to be_a Stoplight::Domain::Light
     end
   end
 
   specify "#unlock" do
-    expect(state_store).to receive(:set_state).with(Stoplight::State::UNLOCKED)
+    expect(lock_control).to receive(:unlock)
 
     expect(light.unlock).to be_a Stoplight::Domain::Light
   end

--- a/spec/unit/stoplight/domain/lock_control_spec.rb
+++ b/spec/unit/stoplight/domain/lock_control_spec.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Domain::LockControl do
+  subject(:lock_control) { described_class.new(state_store:, emitter:) }
+
+  let(:state_store) { instance_double(NullStateStore) }
+  let(:emitter) { TestTelemetryEmitter.new }
+  let(:state_snapshot) do
+    Stoplight::Domain::StateSnapshot.new(
+      breached_at: nil,
+      locked_state: Stoplight::State::UNLOCKED,
+      recovery_scheduled_after: nil,
+      recovery_started_at: nil,
+      time: Time.now
+    )
+  end
+
+  before do
+    allow(state_store).to receive(:state_snapshot).and_return(state_snapshot)
+  end
+
+  describe "#lock" do
+    context "with green color" do
+      it "locks green color" do
+        expect(state_store).to receive(:set_state).with(Stoplight::State::LOCKED_GREEN)
+
+        lock_control.lock(Stoplight::Color::GREEN)
+      end
+    end
+
+    context "with red color" do
+      it "locks red color" do
+        expect(state_store).to receive(:set_state).with(Stoplight::State::LOCKED_RED)
+
+        lock_control.lock(Stoplight::Color::RED)
+      end
+    end
+
+    context "with incorrect color" do
+      let(:color) { "incorrect-color" }
+
+      it "raises Error::IncorrectColor and does not write state" do
+        expect(state_store).to_not receive(:set_state)
+
+        expect { lock_control.lock(color) }.to raise_error(Stoplight::Error::IncorrectColor)
+      end
+    end
+
+    it "emits a LockChanged event describing the transition" do
+      allow(state_store).to receive(:set_state)
+
+      expect { lock_control.lock(Stoplight::Color::GREEN) }.to emit(Stoplight::Domain::Telemetry::LockChanged).with(
+        from_color: Stoplight::Color::GREEN,
+        to_color: Stoplight::Color::GREEN,
+        from_state: Stoplight::State::UNLOCKED,
+        to_state: Stoplight::State::LOCKED_GREEN
+      )
+    end
+
+    it "reports the from_color/from_state read before the write, not the state left behind by it" do
+      written = false
+      post_write_snapshot = Stoplight::Domain::StateSnapshot.new(
+        breached_at: nil,
+        locked_state: Stoplight::State::LOCKED_RED,
+        recovery_scheduled_after: nil,
+        recovery_started_at: nil,
+        time: Time.now
+      )
+      allow(state_store).to receive(:set_state) { written = true }
+      allow(state_store).to receive(:state_snapshot) { written ? post_write_snapshot : state_snapshot }
+
+      expect { lock_control.lock(Stoplight::Color::GREEN) }.to emit(Stoplight::Domain::Telemetry::LockChanged).with(
+        from_color: Stoplight::Color::GREEN,
+        to_color: Stoplight::Color::GREEN,
+        from_state: Stoplight::State::UNLOCKED,
+        to_state: Stoplight::State::LOCKED_GREEN
+      )
+    end
+
+    context "when locking an unlocked, already-red light to red" do
+      let(:state_snapshot) do
+        Stoplight::Domain::StateSnapshot.new(
+          breached_at: Time.now,
+          locked_state: Stoplight::State::UNLOCKED,
+          recovery_scheduled_after: nil,
+          recovery_started_at: nil,
+          time: Time.now
+        )
+      end
+
+      it "reports the from_color/from_state read from the snapshot before the write" do
+        allow(state_store).to receive(:set_state)
+
+        expect { lock_control.lock(Stoplight::Color::RED) }.to emit(Stoplight::Domain::Telemetry::LockChanged).with(
+          from_color: Stoplight::Color::RED,
+          to_color: Stoplight::Color::RED,
+          from_state: Stoplight::State::UNLOCKED,
+          to_state: Stoplight::State::LOCKED_RED
+        )
+      end
+    end
+
+    context "when locking an unlocked, green light to red" do
+      it "reports from_color distinctly from to_color" do
+        allow(state_store).to receive(:set_state)
+
+        expect { lock_control.lock(Stoplight::Color::RED) }.to emit(Stoplight::Domain::Telemetry::LockChanged).with(
+          from_color: Stoplight::Color::GREEN,
+          to_color: Stoplight::Color::RED,
+          from_state: Stoplight::State::UNLOCKED,
+          to_state: Stoplight::State::LOCKED_RED
+        )
+      end
+    end
+
+    context "when locking an already-locked-green light to green again" do
+      let(:state_snapshot) do
+        Stoplight::Domain::StateSnapshot.new(
+          breached_at: nil,
+          locked_state: Stoplight::State::LOCKED_GREEN,
+          recovery_scheduled_after: nil,
+          recovery_started_at: nil,
+          time: Time.now
+        )
+      end
+
+      it "still emits a LockChanged event, even though the lock state does not change" do
+        allow(state_store).to receive(:set_state)
+
+        expect { lock_control.lock(Stoplight::Color::GREEN) }.to emit(Stoplight::Domain::Telemetry::LockChanged).with(
+          from_color: Stoplight::Color::GREEN,
+          to_color: Stoplight::Color::GREEN,
+          from_state: Stoplight::State::LOCKED_GREEN,
+          to_state: Stoplight::State::LOCKED_GREEN
+        )
+      end
+    end
+
+    context "when nobody is subscribed to LockChanged" do
+      let(:emitter) { instance_double(Stoplight::Domain::Telemetry::Emitter, subscribed?: false, emit: nil) }
+
+      it "does not pay for a state snapshot read nobody will see" do
+        expect(state_store).to_not receive(:state_snapshot)
+        allow(state_store).to receive(:set_state)
+
+        lock_control.lock(Stoplight::Color::GREEN)
+      end
+    end
+  end
+
+  describe "#unlock" do
+    it "sets state to unlocked" do
+      expect(state_store).to receive(:set_state).with(Stoplight::State::UNLOCKED)
+
+      lock_control.unlock
+    end
+
+    it "emits a LockChanged event describing the transition" do
+      allow(state_store).to receive(:set_state)
+
+      expect { lock_control.unlock }.to emit(Stoplight::Domain::Telemetry::LockChanged).with(
+        from_color: Stoplight::Color::GREEN,
+        to_color: Stoplight::Color::GREEN,
+        from_state: Stoplight::State::UNLOCKED,
+        to_state: Stoplight::State::UNLOCKED
+      )
+    end
+
+    it "reports the from_color/from_state read before the write, not the state left behind by it" do
+      written = false
+      pre_write_snapshot = Stoplight::Domain::StateSnapshot.new(
+        breached_at: nil,
+        locked_state: Stoplight::State::LOCKED_RED,
+        recovery_scheduled_after: nil,
+        recovery_started_at: nil,
+        time: Time.now
+      )
+      post_write_snapshot = Stoplight::Domain::StateSnapshot.new(
+        breached_at: nil,
+        locked_state: Stoplight::State::UNLOCKED,
+        recovery_scheduled_after: nil,
+        recovery_started_at: nil,
+        time: Time.now
+      )
+      allow(state_store).to receive(:set_state) { written = true }
+      allow(state_store).to receive(:state_snapshot) { written ? post_write_snapshot : pre_write_snapshot }
+
+      expect { lock_control.unlock }.to emit(Stoplight::Domain::Telemetry::LockChanged).with(
+        from_color: Stoplight::Color::RED,
+        to_color: Stoplight::Color::GREEN,
+        from_state: Stoplight::State::LOCKED_RED,
+        to_state: Stoplight::State::UNLOCKED
+      )
+    end
+
+    context "when unlocking a red-locked light with no breach underneath" do
+      let(:state_snapshot) do
+        Stoplight::Domain::StateSnapshot.new(
+          breached_at: nil,
+          locked_state: Stoplight::State::LOCKED_RED,
+          recovery_scheduled_after: nil,
+          recovery_started_at: nil,
+          time: Time.now
+        )
+      end
+
+      it "derives to_color from the state that results after unlocking, not the pre-unlock color" do
+        allow(state_store).to receive(:set_state)
+
+        expect { lock_control.unlock }.to emit(Stoplight::Domain::Telemetry::LockChanged).with(
+          from_color: Stoplight::Color::RED,
+          to_color: Stoplight::Color::GREEN,
+          from_state: Stoplight::State::LOCKED_RED,
+          to_state: Stoplight::State::UNLOCKED
+        )
+      end
+    end
+
+    context "when unlocking a red-locked light with a recovery already started underneath" do
+      let(:state_snapshot) do
+        Stoplight::Domain::StateSnapshot.new(
+          breached_at: Time.now,
+          locked_state: Stoplight::State::LOCKED_RED,
+          recovery_scheduled_after: nil,
+          recovery_started_at: Time.now,
+          time: Time.now
+        )
+      end
+
+      it "derives to_color as yellow, not red or green" do
+        allow(state_store).to receive(:set_state)
+
+        expect { lock_control.unlock }.to emit(Stoplight::Domain::Telemetry::LockChanged).with(
+          from_color: Stoplight::Color::RED,
+          to_color: Stoplight::Color::YELLOW,
+          from_state: Stoplight::State::LOCKED_RED,
+          to_state: Stoplight::State::UNLOCKED
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #796 
Fixes #751

Introduce `Domain::LockControl` that could be used by both `Light#lock/unlock` and admin dashboard