### PR TITLE
Guard ErrorRate#check_compatibility against non-numeric threshold

### DIFF
--- a/lib/stoplight/domain/traffic_control/error_rate.rb
+++ b/lib/stoplight/domain/traffic_control/error_rate.rb
@@ -26,6 +26,8 @@ module Stoplight
         def check_compatibility(config)
           if config.window_size.nil?
             CompatibilityResult.incompatible("`window_size` should be set")
+          elsif !config.threshold.is_a?(Numeric)
+            CompatibilityResult.incompatible("`threshold` should be a number")
           elsif config.threshold < 0 || config.threshold > 1
             CompatibilityResult.incompatible("`threshold` should be between 0 and 1")
           else

--- a/spec/unit/stoplight/domain/traffic_control/error_rate_spec.rb
+++ b/spec/unit/stoplight/domain/traffic_control/error_rate_spec.rb
@@ -59,6 +59,26 @@ RSpec.describe Stoplight::Domain::TrafficControl::ErrorRate do
 
       it { is_expected.to be_compatible }
     end
+
+    context "when threshold is nil" do
+      let(:threshold) { nil }
+
+      it { is_expected.to be_incompatible }
+
+      it "returns an error message" do
+        expect(availability.error_messages).to eq("`threshold` should be a number")
+      end
+    end
+
+    context "when threshold is not numeric" do
+      let(:threshold) { "0.7" }
+
+      it { is_expected.to be_incompatible }
+
+      it "returns an error message" do
+        expect(availability.error_messages).to eq("`threshold` should be a number")
+      end
+    end
   end
 
   describe "#stop_traffic?" do


### PR DESCRIPTION
## Summary
- Add a `Numeric` type guard in `ErrorRate#check_compatibility` before the `0..1` range check.
- Non-numeric / `nil` thresholds now return `CompatibilityResult.incompatible` instead of raising `NoMethodError`.
- Fixes #771

## Test plan
- [x] Unit specs cover `threshold: nil` and a non-numeric value (e.g. `"0.5"`), expecting `` `threshold` should be a number ``
- [x] Existing out-of-range cases still return `` `threshold` should be between 0 and 1 ``
- [x] `bundle exec rspec spec/unit/stoplight/domain/traffic_control/error_rate_spec.rb`
- [x] Smoke: `Stoplight("t2", traffic_control: :error_rate, threshold: nil, window_size: 60)` raises `ConfigurationError`, not `NoMethodError`