### PR TITLE
Reorder ConsecutiveSuccesses#check_compatibility type check before range

### DIFF
--- a/lib/stoplight/domain/traffic_recovery/consecutive_successes.rb
+++ b/lib/stoplight/domain/traffic_recovery/consecutive_successes.rb
@@ -35,10 +35,10 @@ module Stoplight
       # @api private
       class ConsecutiveSuccesses
         def check_compatibility(config)
-          if config.recovery_threshold <= 0
-            CompatibilityResult.incompatible("`recovery_threshold` should be bigger than 0")
-          elsif !config.recovery_threshold.is_a?(Integer)
+          if !config.recovery_threshold.is_a?(Integer)
             CompatibilityResult.incompatible("`recovery_threshold` should be an integer")
+          elsif config.recovery_threshold <= 0
+            CompatibilityResult.incompatible("`recovery_threshold` should be bigger than 0")
           else
             CompatibilityResult.compatible
           end

--- a/spec/unit/stoplight/domain/traffic_recovery/consecutive_successes_spec.rb
+++ b/spec/unit/stoplight/domain/traffic_recovery/consecutive_successes_spec.rb
@@ -26,6 +26,26 @@ RSpec.describe Stoplight::Domain::TrafficRecovery::ConsecutiveSuccesses do
         expect(strategy.error_messages).to eq("`recovery_threshold` should be an integer")
       end
     end
+
+    context "when recovery threshold is nil" do
+      let(:recovery_threshold) { nil }
+
+      it { is_expected.to be_incompatible }
+
+      it "returns an error message" do
+        expect(strategy.error_messages).to eq("`recovery_threshold` should be an integer")
+      end
+    end
+
+    context "when recovery threshold is a string" do
+      let(:recovery_threshold) { "3" }
+
+      it { is_expected.to be_incompatible }
+
+      it "returns an error message" do
+        expect(strategy.error_messages).to eq("`recovery_threshold` should be an integer")
+      end
+    end
   end
 
   describe "#determine_color" do


### PR DESCRIPTION
## Summary
- Run `recovery_threshold.is_a?(Integer)` before `recovery_threshold <= 0` in `ConsecutiveSuccesses#check_compatibility`.
- `nil` / non-Integer values now return `CompatibilityResult.incompatible` instead of raising `NoMethodError` / `ArgumentError`.
- Fixes #772

## Test plan
- [x] Specs cover `recovery_threshold: nil` and a non-Integer (e.g. `"3"`), expecting `` `recovery_threshold` should be an integer ``
- [x] Existing cases still pass (`0` => bigger than 0; `14.87` => should be an integer)
- [x] `bundle exec rspec spec/unit/stoplight/domain/traffic_recovery/consecutive_successes_spec.rb`
- [x] `bundle exec standardrb`
- [x] Smoke: `Stoplight("t3", traffic_recovery: :consecutive_successes, recovery_threshold: nil)` raises `ConfigurationError`, not `NoMethodError`