### PR TITLE
Reorder ConsecutiveErrors#check_compatibility type check before range

### DIFF
--- a/lib/stoplight/domain/traffic_control/consecutive_errors.rb
+++ b/lib/stoplight/domain/traffic_control/consecutive_errors.rb
@@ -28,10 +28,10 @@ module Stoplight
       # @api private
       class ConsecutiveErrors
         def check_compatibility(config)
-          if config.threshold <= 0
-            CompatibilityResult.incompatible("`threshold` should be bigger than 0")
-          elsif !config.threshold.is_a?(Integer)
+          if !config.threshold.is_a?(Integer)
             CompatibilityResult.incompatible("`threshold` should be an integer")
+          elsif config.threshold <= 0
+            CompatibilityResult.incompatible("`threshold` should be bigger than 0")
           else
             CompatibilityResult.compatible
           end

--- a/spec/unit/stoplight/domain/traffic_control/consecutive_errors_spec.rb
+++ b/spec/unit/stoplight/domain/traffic_control/consecutive_errors_spec.rb
@@ -39,6 +39,26 @@ RSpec.describe Stoplight::Domain::TrafficControl::ConsecutiveErrors do
         expect(strategy.error_messages).to eq("`threshold` should be an integer")
       end
     end
+
+    context "when threshold is nil" do
+      let(:threshold) { nil }
+
+      it { is_expected.to be_incompatible }
+
+      it "returns an error message" do
+        expect(strategy.error_messages).to eq("`threshold` should be an integer")
+      end
+    end
+
+    context "when threshold is a string" do
+      let(:threshold) { "3" }
+
+      it { is_expected.to be_incompatible }
+
+      it "returns an error message" do
+        expect(strategy.error_messages).to eq("`threshold` should be an integer")
+      end
+    end
   end
 
   describe "#stop_traffic?" do


### PR DESCRIPTION
## Summary
- Run `threshold.is_a?(Integer)` before `threshold <= 0` in `ConsecutiveErrors#check_compatibility`.
- `nil` / non-Integer thresholds now return `CompatibilityResult.incompatible` instead of raising `NoMethodError` / `ArgumentError`.
- Fixes #769

## Test plan
- [x] Specs cover `threshold: nil` and a non-Integer (e.g. `"3"`), expecting `` `threshold` should be an integer ``
- [x] Existing cases still pass (`0` => bigger than 0; `14.87` => should be an integer)
- [x] `bundle exec rspec spec/unit/stoplight/domain/traffic_control/consecutive_errors_spec.rb`
- [x] `bundle exec standardrb`
- [x] Smoke: `Stoplight("t1", threshold: nil)` raises `ConfigurationError`, not `NoMethodError`