### PR TITLE
fix: validate telemetry subscribe filter before mutating state

### DIFF
--- a/lib/stoplight/domain/telemetry.rb
+++ b/lib/stoplight/domain/telemetry.rb
@@ -28,6 +28,7 @@ module Stoplight
 
       def subscribe(filter = nil, &handler)
         raise ArgumentError, "nothing to subscribe. Please, pass a block into `Telemetry#subscribe`" unless handler
+        raise ArgumentError, "filter must be nil or a Module, got #{filter.inspect}" unless filter.nil? || filter.is_a?(Module)
 
         subscription = Subscription.new
         @mutex.synchronize do

--- a/spec/unit/stoplight/domain/telemetry_spec.rb
+++ b/spec/unit/stoplight/domain/telemetry_spec.rb
@@ -107,6 +107,36 @@ RSpec.describe Stoplight::Domain::Telemetry do
       end
     end
 
+    context "with an invalid filter" do
+      subject(:bus) { described_class.new(error_notifier:, max_subscriptions: 1) }
+
+      it "raises ArgumentError instead of comparing it against event classes" do
+        expect { bus.subscribe("not_a_class") {} }.to raise_error(ArgumentError, /filter/)
+      end
+
+      it "does not register the invalid subscription" do
+        expect { bus.subscribe("not_a_class") {} }.to raise_error(ArgumentError)
+        expect { bus.subscribe(described_class::RunCompleted) {} }.not_to raise_error
+      end
+
+      it "leaves the bus usable for subsequent subscribers" do
+        expect { bus.subscribe(42) {} }.to raise_error(ArgumentError)
+
+        expect do |handler|
+          bus.subscribe(described_class::RunCompleted, &handler)
+          bus.publish(envelope(run_completed))
+        end.to yield_control
+      end
+
+      it "does not break unsubscribe for subscriptions made before the bad call" do
+        subscription = bus.subscribe(described_class::RunCompleted) {}
+
+        expect { bus.subscribe(:invalid) {} }.to raise_error(ArgumentError)
+
+        expect { bus.unsubscribe(subscription) }.not_to raise_error
+      end
+    end
+
     context "when the subscription cap is reached" do
       subject(:bus) { described_class.new(error_notifier:, max_subscriptions: 1) }
 


### PR DESCRIPTION
Fixes [#768](https://github.com/bolshakov/stoplight/issues/768)

Hello! This PR adds a check in `Telemetry#subscribe` so that if a user passes in a filter that isn't a `Module` (or `nil`), it raises an `ArgumentError `instead of crashing later with a `TypeError`.

Also added some tests in `telemetry_spec.rb`, invalid filter raises the right error, it doesn't get stuck in the internal list, and normal `subscribe/publish/unsubscribe` still work after a bad call.

Let me know if I'm missing anything!