### PR TITLE
Validate tracked_errors/skipped_errors matchers at definition time

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,10 @@
   `#with_error_notifier`, `#with_tracked_errors`, `#with_skipped_errors`
 - Remove `data_store`, `notifiers`, and `error_notifier` parameters from `Stoplight()` and `Stoplight.light()` methods. 
   From now on this could be configured only on the Stoplight/System level
+- `tracked_errors` and `skipped_errors` passed to `Stoplight()` / `Stoplight.light()` must now be named `Class`/`Module` 
+  constants (e.g. `StandardError`, or a custom class/module overriding `===`). Procs, anonymous classes 
+  (`Class.new(StandardError)`), and instances no longer work here and raise `ArgumentError` - they have no stable name, 
+  which config-consistency checks and the admin registry depend on.
 
 ## Stoplight 5.0 
 

--- a/lib/stoplight/domain/matcher_validator.rb
+++ b/lib/stoplight/domain/matcher_validator.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    class MatcherValidator
+      class << self
+        def call(error_matcher)
+          name = error_matcher.is_a?(Module) ? error_matcher.name : nil
+          raise ArgumentError, message(error_matcher) if name.nil?
+
+          name
+        end
+
+        private
+
+        def message(error_matcher)
+          "error matcher #{error_matcher.inspect} must be a named class or module (e.g. StandardError, " \
+            "or a custom class/module overriding `===`) - procs, anonymous classes, and instances have no " \
+            "stable name and cannot be used here."
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/wiring/light_configuration_dsl.rb
+++ b/lib/stoplight/wiring/light_configuration_dsl.rb
@@ -14,17 +14,29 @@ module Stoplight
         traffic_control: T.undefined,
         traffic_recovery: T.undefined
       )
-        @digest = [
-          @name = name,
-          @cool_off_time = cool_off_time,
-          @threshold = threshold,
-          @recovery_threshold = recovery_threshold,
-          @window_size = window_size,
-          @tracked_errors = tracked_errors.is_a?(Undefined) ? tracked_errors : Array(tracked_errors),
-          @skipped_errors = skipped_errors.is_a?(Undefined) ? skipped_errors : Array(skipped_errors),
-          @traffic_control = traffic_control.is_a?(Undefined) ? traffic_control : TrafficControlDsl.call(traffic_control),
-          @traffic_recovery = traffic_recovery.is_a?(Undefined) ? traffic_recovery : TrafficRecoveryDsl.call(traffic_recovery)
-        ].hash
+        @name = name
+        @cool_off_time = cool_off_time
+        @threshold = threshold
+        @recovery_threshold = recovery_threshold
+        @window_size = window_size
+        @tracked_errors = if tracked_errors.is_a?(Undefined)
+          tracked_errors
+        elsif tracked_errors.is_a?(Array)
+          tracked_errors
+        else
+          [tracked_errors]
+        end
+        @skipped_errors = if skipped_errors.is_a?(Undefined)
+          skipped_errors
+        elsif skipped_errors.is_a?(Array)
+          skipped_errors
+        else
+          [skipped_errors]
+        end
+        @traffic_control = traffic_control.is_a?(Undefined) ? traffic_control : TrafficControlDsl.call(traffic_control)
+        @traffic_recovery = traffic_recovery.is_a?(Undefined) ? traffic_recovery : TrafficRecoveryDsl.call(traffic_recovery)
+
+        @digest = calculate_digest
       end
 
       def configure!(default_config)
@@ -47,6 +59,20 @@ module Stoplight
 
       private
 
+      def calculate_digest
+        [
+          @name,
+          @cool_off_time,
+          @threshold,
+          @recovery_threshold,
+          @window_size,
+          errors_for_digest(@tracked_errors),
+          errors_for_digest(@skipped_errors),
+          @traffic_control,
+          @traffic_recovery
+        ].hash
+      end
+
       attr_reader :name
       attr_reader :cool_off_time
       attr_reader :threshold
@@ -56,6 +82,14 @@ module Stoplight
       attr_reader :skipped_errors
       attr_reader :traffic_control
       attr_reader :traffic_recovery
+
+      def errors_for_digest(errors)
+        if errors.is_a?(Undefined)
+          errors
+        else
+          errors.map { |matcher| Domain::MatcherValidator.call(matcher) }
+        end
+      end
     end
   end
 end

--- a/sig/_private/stoplight/domain/matcher_validator.rbs
+++ b/sig/_private/stoplight/domain/matcher_validator.rbs
@@ -1,0 +1,11 @@
+module Stoplight
+  module Domain
+    class MatcherValidator
+      def self.call: (Module) -> String
+
+      private
+
+      def self.message: (Module) -> String
+    end
+  end
+end

--- a/sig/_private/stoplight/wiring/light_configuration_dsl.rbs
+++ b/sig/_private/stoplight/wiring/light_configuration_dsl.rbs
@@ -7,8 +7,8 @@ module Stoplight
         ?threshold: optional[percentage | Integer],
         ?recovery_threshold: optional[Integer],
         ?window_size: optional[duration?],
-        ?tracked_errors: optional[Array[_ExceptionMatcher] | _ExceptionMatcher],
-        ?skipped_errors: optional[Array[_ExceptionMatcher] | _ExceptionMatcher],
+        ?tracked_errors: optional[Array[Module] | Module],
+        ?skipped_errors: optional[Array[Module] | Module],
         ?traffic_control: optional[traffic_control],
         ?traffic_recovery: optional[traffic_recovery],
       ) -> void
@@ -24,10 +24,13 @@ module Stoplight
       attr_reader threshold: optional[percentage | Integer]
       attr_reader recovery_threshold: optional[Integer]
       attr_reader window_size: optional[duration?]
-      attr_reader tracked_errors: optional[Array[_ExceptionMatcher]]
-      attr_reader skipped_errors: optional[Array[_ExceptionMatcher]]
+      attr_reader tracked_errors: optional[Array[Module]]
+      attr_reader skipped_errors: optional[Array[Module]]
       attr_reader traffic_control: optional[Domain::_TrafficControl]
       attr_reader traffic_recovery: optional[Domain::_TrafficRecovery]
+
+      def calculate_digest: -> Integer
+      def errors_for_digest: (optional[Array[Module]]) -> optional[Array[String]]
     end
   end
 end

--- a/sig/stoplight.rbs
+++ b/sig/stoplight.rbs
@@ -36,8 +36,8 @@ module Stoplight
       ?threshold: optional[percentage | Integer],
       ?recovery_threshold: optional[Integer],
       ?window_size: optional[duration?],
-      ?tracked_errors: optional[Array[_ExceptionMatcher] | _ExceptionMatcher],
-      ?skipped_errors: optional[Array[_ExceptionMatcher] | _ExceptionMatcher],
+      ?tracked_errors: optional[Array[Module] | Module],
+      ?skipped_errors: optional[Array[Module] | Module],
       ?traffic_control: optional[traffic_control],
       ?traffic_recovery: optional[traffic_recovery],
     ) -> _Light
@@ -51,8 +51,8 @@ module Kernel
       ?threshold: Stoplight::optional[Stoplight::percentage | Integer],
       ?recovery_threshold: Stoplight::optional[Integer],
       ?window_size: Stoplight::optional[Stoplight::duration?],
-      ?tracked_errors: Stoplight::optional[Array[Stoplight::_ExceptionMatcher] | Stoplight::_ExceptionMatcher],
-      ?skipped_errors: Stoplight::optional[Array[Stoplight::_ExceptionMatcher] | Stoplight::_ExceptionMatcher],
+      ?tracked_errors: Stoplight::optional[Array[Module] | Module],
+      ?skipped_errors: Stoplight::optional[Array[Module] | Module],
       ?traffic_control: Stoplight::optional[Stoplight::traffic_control],
       ?traffic_recovery: Stoplight::optional[Stoplight::traffic_recovery],
   ) -> Stoplight::_Light

--- a/sig/stoplight/ports/system.rbs
+++ b/sig/stoplight/ports/system.rbs
@@ -12,8 +12,8 @@ module Stoplight
       ?threshold: optional[percentage | Integer],
       ?recovery_threshold: optional[Integer],
       ?window_size: optional[duration?],
-      ?skipped_errors: optional[Array[_ExceptionMatcher] | _ExceptionMatcher],
-      ?tracked_errors: optional[Array[_ExceptionMatcher] | _ExceptionMatcher],
+      ?skipped_errors: optional[Array[Module] | Module],
+      ?tracked_errors: optional[Array[Module] | Module],
       ?traffic_control: optional[traffic_control],
       ?traffic_recovery: optional[traffic_recovery]
     ) -> _Light

--- a/spec/unit/stoplight/domain/matcher_validator_spec.rb
+++ b/spec/unit/stoplight/domain/matcher_validator_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Domain::MatcherValidator do
+  subject(:validate) { described_class.call(matcher) }
+
+  context "when the matcher is a named class" do
+    let(:matcher) { StandardError }
+
+    it "returns its name" do
+      expect(validate).to eq("StandardError")
+    end
+  end
+
+  context "when the matcher is a custom class overriding #===" do
+    let(:matcher) do
+      Class.new(StandardError) do
+        def self.name = "CustomMatcher"
+
+        def self.===(other) = other.is_a?(StandardError)
+      end
+    end
+
+    it "returns its name" do
+      expect(validate).to eq("CustomMatcher")
+    end
+  end
+
+  context "when the matcher is a bare module" do
+    let(:matcher) do
+      Module.new do
+        def self.name = "CustomModule"
+      end
+    end
+
+    it "returns its name" do
+      expect(validate).to eq("CustomModule")
+    end
+  end
+
+  context "when the matcher does not respond to #name" do
+    let(:matcher) { ->(error) { error.is_a?(StandardError) } }
+
+    it "raises ArgumentError naming the offending value" do
+      expect { validate }.to raise_error(ArgumentError, a_string_matching(/#{Regexp.escape(matcher.inspect)}/))
+    end
+  end
+
+  context "when the matcher is an instance with a #name method" do
+    let(:matcher) { Struct.new(:name).new("StandardError") }
+
+    it "raises ArgumentError naming the offending value" do
+      expect { validate }.to raise_error(ArgumentError, a_string_matching(/#{Regexp.escape(matcher.inspect)}/))
+    end
+  end
+
+  context "when the matcher is an anonymous class" do
+    let(:matcher) { Class.new(StandardError) }
+
+    it "raises ArgumentError naming the offending value" do
+      expect { validate }.to raise_error(ArgumentError, a_string_matching(/#{Regexp.escape(matcher.inspect)}/))
+    end
+  end
+end

--- a/spec/unit/stoplight/wiring/light_configuration_dsl_spec.rb
+++ b/spec/unit/stoplight/wiring/light_configuration_dsl_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Wiring::LightConfigurationDsl do
+  describe "#initialize" do
+    context "when tracked_errors contains an anonymous class" do
+      subject(:dsl) { described_class.new(name: "light", tracked_errors: [Class.new(StandardError)]) }
+
+      it "raises ArgumentError" do
+        expect { dsl }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when tracked_errors contains an instance with a #name method" do
+      subject(:dsl) { described_class.new(name: "light", tracked_errors: [Struct.new(:name).new("StandardError")]) }
+
+      it "raises ArgumentError" do
+        expect { dsl }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when skipped_errors contains an anonymous class" do
+      subject(:dsl) { described_class.new(name: "light", skipped_errors: [Class.new(StandardError)]) }
+
+      it "raises ArgumentError" do
+        expect { dsl }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when skipped_errors contains an instance with a #name method" do
+      subject(:dsl) { described_class.new(name: "light", skipped_errors: [Struct.new(:name).new("StandardError")]) }
+
+      it "raises ArgumentError" do
+        expect { dsl }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #794 

Digest-based config-consistency checks and the planned admin registry both need a stable string identity for each matcher, which only named classes/modules provide. Procs, anonymous classes, and instances used to pass through silently and could produce colliding or unstable identities.

Domain::MatcherValidator rejects anything that isn't a named Module, raising ArgumentError with the offending value. It runs unconditionally inside `LightConfigurationDsl`'s digest calculation, which executes on every Stoplight()/system.light() call regardless of whether the light is already registered, so invalid matchers can't slip through on a cache hit.

Breaking change documented in UPGRADING.md.