### PR TITLE
fix: bucket alignment at hour boundaries

### DIFF
--- a/lib/stoplight/infrastructure/redis/storage/window_metrics.rb
+++ b/lib/stoplight/infrastructure/redis/storage/window_metrics.rb
@@ -119,7 +119,7 @@ module Stoplight
           # @param time [Time, Numeric] The time for which to generate the key.
           # @return [String] The generated Redis key.
           def bucket_key(metric:, time:)
-            key_space.key(:window_metrics, metric, (time.to_i / bucket_size) * bucket_size)
+            key_space.key(:window_metrics, metric, bucket_start_for(time))
           end
 
           # Retrieves the list of Redis bucket keys required to cover a specific time window.
@@ -133,10 +133,10 @@ module Stoplight
             window_start_ts = window_end_ts - @window_size
 
             # Find bucket timestamps that contain any part of the window
-            start_bucket = (window_start_ts / bucket_size) * bucket_size
+            start_bucket = bucket_start_for(window_start_ts)
 
-            # End bucket is the last bucket that contains data within our window
-            end_bucket = ((window_end_ts - 1) / bucket_size) * bucket_size
+            # End bucket is the bucket that window_end itself falls into, so it's always included
+            end_bucket = bucket_start_for(window_end_ts)
 
             (start_bucket..end_bucket).step(bucket_size).map do |bucket_start|
               bucket_key(metric: metric, time: bucket_start)
@@ -150,6 +150,8 @@ module Stoplight
           attr_reader :metrics_key
           attr_reader :clock
           attr_reader :key_space
+
+          def bucket_start_for(time) = (time.to_i / bucket_size) * bucket_size
 
           def bucket_size = 3600 # 1 hour
           def bucket_ttl = @window_size + bucket_size

--- a/sig/_private/stoplight/infrastructure/redis/storage/window_metrics.rbs
+++ b/sig/_private/stoplight/infrastructure/redis/storage/window_metrics.rbs
@@ -22,6 +22,7 @@ module Stoplight
           ) -> void
 
           def bucket_key: (metric: Symbol, time: _ToI) -> String
+          def bucket_start_for: (_ToI time) -> Integer
           def bucket_size: -> Integer
           def bucket_ttl: -> Integer
           def buckets_for_window: (metric: Symbol, window_end: _ToI) -> Array[String]

--- a/spec/properties/window_metrics_bucket_alignment_spec.rb
+++ b/spec/properties/window_metrics_bucket_alignment_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rantly/rspec_extensions"
+
+RSpec.describe "Stoplight::Infrastructure::Redis::Storage::WindowMetrics bucket alignment", :redis do
+  let(:key_space) { Stoplight::Infrastructure::Redis::Storage::KeySpace.build(light_name:, system_name:) }
+  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
+  let(:scripting) { Stoplight::Infrastructure::Redis::Storage::Scripting.new(redis:) }
+
+  let(:light_name) { SecureRandom.uuid }
+  let(:system_name) { SecureRandom.uuid }
+
+  let(:metric) { "failures" }
+
+  specify "bucket_key and buckets_for_window stay aligned" do
+    property_of {
+      hour_start = range(1, 100_000) * 3600
+      offset = choose(0, range(1, 3599))
+      window_size_in_buckets = range(1, 5)
+
+      [hour_start + offset, window_size_in_buckets * 3600]
+    }.check do |(window_end_ts, window_size)|
+      metrics = Stoplight::Infrastructure::Redis::Storage::WindowMetrics.new(
+        scripting:, redis:, clock:, key_space:,
+        config: instance_double(Stoplight::Domain::Config, window_size:)
+      )
+
+      written_bucket = metrics.bucket_key(metric: metric, time: window_end_ts)
+      scanned_buckets = metrics.buckets_for_window(metric: metric, window_end: window_end_ts)
+
+      expect(scanned_buckets).to include(written_bucket),
+        "Expected #{scanned_buckets.inspect} to include #{written_bucket.inspect}"
+    end
+  end
+end

--- a/spec/unit/stoplight/infrastructure/redis/storage/window_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/window_metrics_spec.rb
@@ -53,7 +53,8 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::WindowMetrics, :redis 
           "stoplight:v5:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696140000",
           "stoplight:v5:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696143600",
           "stoplight:v5:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696147200",
-          "stoplight:v5:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696150800"
+          "stoplight:v5:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696150800",
+          "stoplight:v5:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696154400"
         )
       end
     end
@@ -62,9 +63,10 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::WindowMetrics, :redis 
       let(:window_end) { Time.at(1696154400) }
       let(:window_size) { 3600 } # Exactly one bucket size
 
-      it "returns the single bucket key" do
+      it "returns both bucket keys" do
         is_expected.to contain_exactly(
-          "stoplight:v5:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696150800"
+          "stoplight:v5:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696150800",
+          "stoplight:v5:#{key_space.system_id}:{#{key_space.light_id}}:window_metrics:failures:1696154400"
         )
       end
     end


### PR DESCRIPTION
Fixes #778 

This PR extracts a shared `bucket_start_for` helper and has both `bucket_key` and `buckets_for_window` use it, removing the mismatched `-1` in `buckets_for_window`'s end bucket calculation so the two stay aligned.

Also added a property test in `spec/properties/window_metrics_bucket_alignment_spec.rb` that checks `bucket_key` and `buckets_for_window` always agree on which bucket a timestamp belongs to, and fixed two existing tests in `window_metrics_spec.rb` that were asserting the old behavior at an hour boundary.

Let me know if it needs any changes!