### PR TITLE
Reject telemetry subscribe filters that match no event class

### DIFF
--- a/lib/stoplight/domain/telemetry.rb
+++ b/lib/stoplight/domain/telemetry.rb
@@ -29,6 +29,9 @@ module Stoplight
       def subscribe(filter = nil, &handler)
         raise ArgumentError, "nothing to subscribe. Please, pass a block into `Telemetry#subscribe`" unless handler
         raise ArgumentError, "filter must be nil or a Module, got #{filter.inspect}" unless filter.nil? || filter.is_a?(Module)
+        unless filter.nil? || EVENT_CLASSES.any? { |event_class| event_class <= filter }
+          raise ArgumentError, "filter #{filter.inspect} does not match any telemetry event class"
+        end
 
         subscription = Subscription.new
         @mutex.synchronize do

--- a/spec/unit/stoplight/domain/telemetry_spec.rb
+++ b/spec/unit/stoplight/domain/telemetry_spec.rb
@@ -137,6 +137,12 @@ RSpec.describe Stoplight::Domain::Telemetry do
       end
     end
 
+    context "with a filter that matches no event class" do
+      it "raises ArgumentError instead of registering a dead subscription" do
+        expect { bus.subscribe(Comparable) {} }.to raise_error(ArgumentError, /does not match/)
+      end
+    end
+
     context "when the subscription cap is reached" do
       subject(:bus) { described_class.new(error_notifier:, max_subscriptions: 1) }
 


### PR DESCRIPTION
Closes #767.

`Telemetry#subscribe` already rejects non-Module filters, but a valid Module that isn't one of the event classes (or an ancestor of one) still passes and registers a subscription that can never fire. This adds a guard that raises `ArgumentError` when the filter matches none of `EVENT_CLASSES`, using the same `event_class <= filter` check `rebuild` uses, so a typo'd filter fails at subscription time instead of silently going dead. `nil` (firehose) and `StateTransitioned` still work.