### PR TITLE
fix: scope the rescue to the guarded call in run strategies

### DIFF
--- a/lib/stoplight/domain/strategies/green_run_strategy.rb
+++ b/lib/stoplight/domain/strategies/green_run_strategy.rb
@@ -28,9 +28,6 @@ module Stoplight
 
           begin
             result = code.call
-            record_success(duration_ms: duration_since(started_at))
-
-            result
           rescue => error
             if error_tracking_policy.track?(error)
               record_error(error, duration_ms: duration_since(started_at), fallback_used: !fallback.nil?)
@@ -45,6 +42,9 @@ module Stoplight
               record_success(duration_ms: duration_since(started_at), error: error)
               raise
             end
+          else
+            record_success(duration_ms: duration_since(started_at))
+            result
           end
         end
 

--- a/lib/stoplight/domain/strategies/yellow_run_strategy.rb
+++ b/lib/stoplight/domain/strategies/yellow_run_strategy.rb
@@ -49,21 +49,24 @@ module Stoplight
           with_recovery_lock(fallback:, state_snapshot:) do |started_at|
             enter_recovery(state_snapshot)
 
-            result = code.call
-            record_recovery_probe_success(duration_ms: duration_since(started_at))
-            result
-          rescue => error
-            if error_tracking_policy.track?(error)
-              record_recovery_probe_failure(error, duration_ms: duration_since(started_at), fallback_used: !fallback.nil?)
+            begin
+              result = code.call
+            rescue => error
+              if error_tracking_policy.track?(error)
+                record_recovery_probe_failure(error, duration_ms: duration_since(started_at), fallback_used: !fallback.nil?)
 
-              if fallback
-                fallback.call(error)
+                if fallback
+                  fallback.call(error)
+                else
+                  raise
+                end
               else
+                record_recovery_probe_success(duration_ms: duration_since(started_at), error:)
                 raise
               end
             else
-              record_recovery_probe_success(duration_ms: duration_since(started_at), error:)
-              raise
+              record_recovery_probe_success(duration_ms: duration_since(started_at))
+              result
             end
           end
         end

--- a/spec/unit/stoplight/domain/run_strategies/green_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/green_run_strategy_spec.rb
@@ -138,4 +138,27 @@ RSpec.describe Stoplight::Domain::Strategies::GreenRunStrategy do
       end
     end
   end
+
+  context "when success bookkeeping raises" do
+    subject(:result) { strategy.execute(fallback, state_snapshot: nil, error_tracking_policy:, &code) }
+
+    let(:code) { -> { "Success" } }
+    let(:bookkeeping_error) { StandardError.new("metrics store unavailable") }
+    let(:fallback_calls) { [] }
+    let(:fallback) { ->(error) { fallback_calls << error } }
+
+    before do
+      allow(request_tracker).to receive(:record_success).and_raise(bookkeeping_error)
+      allow(request_tracker).to receive(:record_failure)
+      allow(error_tracking_policy).to receive(:track?).and_return(true)
+    end
+
+    it "surfaces the bookkeeping error without misreporting it as a run failure" do
+      expect { result }.to raise_error(bookkeeping_error)
+
+      expect(error_tracking_policy).not_to have_received(:track?)
+      expect(request_tracker).not_to have_received(:record_failure)
+      expect(fallback_calls).to be_empty
+    end
+  end
 end

--- a/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
@@ -180,6 +180,56 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
           end
         end
       end
+
+      context "when success bookkeeping raises" do
+        subject(:result) { strategy.execute(fallback, state_snapshot: nil, error_tracking_policy:, &code) }
+
+        let(:code) { -> { "Success" } }
+        let(:bookkeeping_error) { StandardError.new("metrics store unavailable") }
+        let(:fallback_calls) { [] }
+        let(:fallback) { ->(error) { fallback_calls << error } }
+
+        before do
+          allow(request_tracker).to receive(:record_success).and_raise(bookkeeping_error)
+          allow(request_tracker).to receive(:record_failure)
+          allow(error_tracking_policy).to receive(:track?).and_return(true)
+        end
+
+        it "surfaces the bookkeeping error without misreporting it as a probe failure" do
+          expect(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
+
+          expect { result }.to raise_error(bookkeeping_error)
+
+          expect(error_tracking_policy).not_to have_received(:track?)
+          expect(request_tracker).not_to have_received(:record_failure)
+          expect(fallback_calls).to be_empty
+        end
+      end
+
+      context "when entering recovery raises" do
+        subject(:result) { strategy.execute(fallback, state_snapshot: nil, error_tracking_policy:, &code) }
+
+        let(:code) { -> { "Success" } }
+        let(:recovery_error) { StandardError.new("state store unavailable") }
+        let(:fallback_calls) { [] }
+        let(:fallback) { ->(error) { fallback_calls << error } }
+
+        before do
+          allow(strategy).to receive(:enter_recovery).and_raise(recovery_error)
+          allow(request_tracker).to receive(:record_failure)
+          allow(error_tracking_policy).to receive(:track?).and_return(true)
+        end
+
+        it "surfaces the recovery error without misreporting it as a probe failure" do
+          expect(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
+
+          expect { result }.to raise_error(recovery_error)
+
+          expect(error_tracking_policy).not_to have_received(:track?)
+          expect(request_tracker).not_to have_received(:record_failure)
+          expect(fallback_calls).to be_empty
+        end
+      end
     end
 
     context "when recovery lock is not acquired" do


### PR DESCRIPTION
Fixes #766.

## Problem

`GreenRunStrategy#execute` and `YellowRunStrategy#execute` wrapped the strategy's own post-success bookkeeping inside the same `begin`/`rescue` region as the user's guarded `code.call`. When a bookkeeping call raised on the success path, the exception was indistinguishable from a failure of the caller's code:

- it was passed to `error_tracking_policy.track?`,
- recorded via `record_error` / `record_recovery_probe_failure`, corrupting the success/failure metrics that drive tripping and recovery, and
- when a fallback was configured, the fallback was invoked with this synthetic error while the real, successful result was silently discarded.

Concretely:

- **Green** — the implicit `begin` covered `code.call` **and** the following `record_success`.
- **Yellow** — the recovery block covered `enter_recovery` (before the call) and `record_recovery_probe_success` (after it), not just `code.call`.

## Fix

Scope the `rescue` to `code.call` only and run the success bookkeeping in an `else` clause; for yellow, run `enter_recovery` ahead of the guarded region as well. A bookkeeping/recovery failure on a successful call now surfaces as itself instead of being reclassified as a tracked run failure. The recovery lock is still released by the existing `ensure` in `with_recovery_lock`. No method signatures or RBS changed.

## Tests

Added unit regressions that make a bookkeeping collaborator raise on the success path (as suggested in the issue):

- **green** — a raising `record_success` must surface the error, and must not consult `track?`, call `record_failure`, or invoke the fallback.
- **yellow** — the same for a raising `record_recovery_probe_success` and for a raising `enter_recovery`; both also assert the recovery lock is still released.

Each fails on the current code (the strategy swallows the error and returns the fallback value) and passes with the fix. The domain strategy files stay at 100% line coverage.

Validated with `bundle exec rspec` (712 examples, 0 failures), `STOPLIGHT_DATA_STORE=Memory` and `STOPLIGHT_DATA_STORE=Redis bundle exec cucumber` (62 scenarios each), `bundle exec standardrb`, and `bundle exec steep check` — all green.
