### PR TITLE
Validate ErrorRate#check_compatibility against invalid min_requests

### DIFF
--- a/lib/stoplight/domain/traffic_control/error_rate.rb
+++ b/lib/stoplight/domain/traffic_control/error_rate.rb
@@ -32,6 +32,10 @@ module Stoplight
             CompatibilityResult.incompatible("`threshold` should be a number")
           elsif config.threshold < 0 || config.threshold > 1
             CompatibilityResult.incompatible("`threshold` should be between 0 and 1")
+          elsif !min_requests.is_a?(Integer)
+            CompatibilityResult.incompatible("`min_requests` should be an integer")
+          elsif min_requests <= 0
+            CompatibilityResult.incompatible("`min_requests` should be bigger than 0")
           else
             CompatibilityResult.compatible
           end

--- a/spec/unit/stoplight/domain/traffic_control/error_rate_spec.rb
+++ b/spec/unit/stoplight/domain/traffic_control/error_rate_spec.rb
@@ -79,6 +79,30 @@ RSpec.describe Stoplight::Domain::TrafficControl::ErrorRate do
         expect(availability.error_messages).to eq("`threshold` should be a number")
       end
     end
+
+    context "when min_requests is less then 1" do
+      let(:min_requests) { 0 }
+      it { is_expected.to be_incompatible }
+      it "returns an error message" do
+        expect(availability.error_messages).to eq("`min_requests` should be bigger than 0")
+      end
+    end
+
+    context "when min_requests is negative" do
+      let(:min_requests) { -5 }
+      it { is_expected.to be_incompatible }
+      it "returns an error message" do
+        expect(availability.error_messages).to eq("`min_requests` should be bigger than 0")
+      end
+    end
+
+    context "when min_requests is not an integer" do
+      let(:min_requests) { 10.5 }
+      it { is_expected.to be_incompatible }
+      it "returns an error message" do
+        expect(availability.error_messages).to eq("`min_requests` should be an integer")
+      end
+    end
   end
 
   describe "#stop_traffic?" do


### PR DESCRIPTION
## Summary
- Validate `min_requests` in `ErrorRate#check_compatibility` (Integer and `> 0`).
- Negative or zero `min_requests` no longer silently defeats the warm-up safeguard; light creation returns `CompatibilityResult.incompatible` / `ConfigurationError`.
- Fixes #770

## Test plan
- [x] Specs cover `min_requests: 0`, negative, and non-Integer (e.g. `10.5`)
- [x] Default `min_requests: 10` and other positive integers still compatible
- [x] `bundle exec rspec spec/unit/stoplight/domain/traffic_control/error_rate_spec.rb`
- [x] `bundle exec standardrb`
- [x] Smoke: `Stoplight("x", traffic_control: { error_rate: { min_requests: -5 } }, threshold: 0.5, window_size: 60)` raises `ConfigurationError`