### PR TITLE
Add eql? and hash to Domain::Failure for value equality

### DIFF
--- a/lib/stoplight/domain/failure.rb
+++ b/lib/stoplight/domain/failure.rb
@@ -39,6 +39,10 @@ module Stoplight
           error_message == other.error_message &&
           time == other.time
       end
+
+      alias_method :eql?, :==
+
+      def hash = [self.class, error_class, error_message, time].hash
     end
   end
 end

--- a/sig/_private/stoplight/domain/failure.rbs
+++ b/sig/_private/stoplight/domain/failure.rbs
@@ -11,6 +11,8 @@ module Stoplight
       def initialize: (String error_class, String error_message, Time time) -> void
 
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
+      def hash: () -> Integer
     end
   end
 end

--- a/spec/unit/stoplight/domain/failure_spec.rb
+++ b/spec/unit/stoplight/domain/failure_spec.rb
@@ -90,4 +90,25 @@ RSpec.describe Stoplight::Domain::Failure do
       end
     end
   end
+
+  describe "#eql? and #hash" do
+    let(:failure) { described_class.new(error_class, error_message, time) }
+    let(:other) { described_class.new(error_class, error_message, time) }
+
+    it "is eql when equal" do
+      expect(failure).to eql(other)
+    end
+
+    it "has the same hash when equal" do
+      expect(failure.hash).to eq(other.hash)
+    end
+
+    it "collides as hash keys when equal" do
+      expect({failure => 1, other => 2}.size).to eq(1)
+    end
+
+    it "dedupes in an array when equal" do
+      expect([failure, other].uniq.size).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `eql?` and `hash` on `Domain::Failure` so they match field-based `==`.
- Value-equal failures now collide as Hash keys and dedupe via Set / `Array#uniq`.
- Fixes #781

## Test plan
- [x] Specs cover `eql?` and equal `hash` when `==` is true
- [x] Specs show Hash key collision / Set or `uniq` size of 1 for value-equal instances
- [x] `bundle exec rspec spec/unit/stoplight/domain/failure_spec.rb`
- [x] Update `sig/_private/stoplight/domain/failure.rbs` with `eql?` / `hash`
- [x] `bundle exec steep check`
- [x] `bundle exec standardrb`
- [x] Smoke in IRB: two equal Failures → `eql?` true, `hash` equal, `{a=>1,b=>2}.size == 1`