### PR TITLE
Rescue raising error_notifier in FailSafe storage wrappers

### DIFF
--- a/lib/stoplight/infrastructure/fail_safe/error_notifier.rb
+++ b/lib/stoplight/infrastructure/fail_safe/error_notifier.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Infrastructure
+    module FailSafe
+      # Wraps a user-provided error notifier so a failure in the notifier itself
+      # cannot escape to callers of fail-safe components.
+      #
+      # @api private
+      class ErrorNotifier
+        attr_reader :error_notifier
+
+        def initialize(error_notifier:)
+          @error_notifier = error_notifier
+        end
+
+        def call(error)
+          error_notifier.call(error)
+        rescue => notifier_error
+          warn "Stoplight error_notifier raised: #{notifier_error.message}"
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -17,7 +17,9 @@ module Stoplight
         @cool_off_time = config.cool_off_time
 
         @data_store_config = config.data_store
-        @error_notifier = config.error_notifier
+        @error_notifier = Infrastructure::FailSafe::ErrorNotifier.new(
+          error_notifier: config.error_notifier
+        )
         @notifiers = config.notifiers
         @traffic_recovery = config.traffic_recovery
         @traffic_control = config.traffic_control

--- a/sig/stoplight/domain/ports/error_notifier.rbs
+++ b/sig/stoplight/domain/ports/error_notifier.rbs
@@ -1,0 +1,12 @@
+module Stoplight
+  module Domain
+    # Called when Stoplight internals fail (e.g. Redis unavailable, notifier I/O).
+    interface _ErrorNotifier
+      def call: (StandardError) -> void
+
+      # Object methods
+      def ==: (untyped) -> bool
+      def is_a?: (untyped) -> bool
+    end
+  end
+end

--- a/sig/stoplight/domain/telemetry/bus.rbs
+++ b/sig/stoplight/domain/telemetry/bus.rbs
@@ -24,7 +24,7 @@ module Stoplight
         # The producer side (publish/subscribed?), what wiring injects into Emitter.
         include _TelemetryPublisher
 
-        @error_notifier: ^(StandardError) -> void
+        @error_notifier: error_notifier
         @mutex: Mutex
         @max_subscriptions: Integer
         @subscriptions: Array[[Subscription, subscription_filter, subscription_handler]]

--- a/sig/stoplight/domain/types.rbs
+++ b/sig/stoplight/domain/types.rbs
@@ -17,7 +17,7 @@ module Stoplight
     type state = unlocked | locked_green | locked_red
 
     type recovery_decision = :green | :yellow | :red
-    type error_notifier = ^(StandardError) -> void
+    type error_notifier = _ErrorNotifier
 
     # Percentage as decimal (0.0 to 1.0)
     type percentage = Float

--- a/sig/stoplight/infrastructure/fail_safe/error_notifier.rbs
+++ b/sig/stoplight/infrastructure/fail_safe/error_notifier.rbs
@@ -1,0 +1,13 @@
+module Stoplight
+  module Infrastructure
+    module FailSafe
+      class ErrorNotifier
+        include Domain::_ErrorNotifier
+
+        attr_reader error_notifier: Domain::error_notifier
+
+        def initialize: (error_notifier: Domain::error_notifier) -> void
+      end
+    end
+  end
+end

--- a/spec/unit/stoplight/infrastructure/fail_safe/error_notifier_spec.rb
+++ b/spec/unit/stoplight/infrastructure/fail_safe/error_notifier_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Infrastructure::FailSafe::ErrorNotifier do
+  subject(:fail_safe_error_notifier) { described_class.new(error_notifier: underlying_error_notifier) }
+
+  let(:error) { StandardError.new("store failed") }
+
+  context "when the underlying error notifier succeeds" do
+    let(:underlying_error_notifier) { instance_double(Proc) }
+
+    it "forwards the error" do
+      allow(underlying_error_notifier).to receive(:call)
+
+      fail_safe_error_notifier.call(error)
+
+      expect(underlying_error_notifier).to have_received(:call).with(error)
+    end
+  end
+
+  context "when the underlying error notifier raises" do
+    let(:underlying_error_notifier) { ->(_) { raise StandardError.new("notifier boom") } }
+
+    it "does not propagate the exception" do
+      expect { fail_safe_error_notifier.call(error) }.not_to raise_error
+    end
+
+    it "warns when the underlying error notifier raises" do
+      expect { fail_safe_error_notifier.call(error) }
+        .to output(/Stoplight error_notifier raised: notifier boom/).to_stderr
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Infrastructure::FailSafe::ErrorNotifier` so a raising user `error_notifier` is swallowed and cannot escape fail-safe paths.
- Inject it once in `LightFactory` (same `#call` interface); storage and notifier FailSafe call sites stay unchanged.
- Introduce `Domain::_ErrorNotifier` (with Object methods like other ports) and point `Domain::error_notifier` at it so the wrapper can be injected like `Notifier::FailSafe`.
- Align `Telemetry::Bus` RBS ivar with the shared `error_notifier` type (types only; Bus still receives the raw config notifier).
- Left `GlobalState` / `FailSafe::Storage::Registry` alone for now to avoid conflicting with systems work.
- Fixes #773 (also covers the notifier FailSafe case from #775 for lights built via `LightFactory`).

## Test plan
- [x] `bundle exec steep check`
- [x] `bundle exec rbs -I sig validate` (locally)
- [x] `bundle exec rspec` (full suite)
- [x] `STOPLIGHT_DATA_STORE=Memory bundle exec cucumber features/stoplight`
- [x] `STOPLIGHT_DATA_STORE=Redis bundle exec cucumber features/stoplight`
- [x] `bundle exec standardrb`