### PR TITLE
fix: Prevent unbounded retries in Scripting#call on persistent NOSCRIPT errors

### DIFF
--- a/lib/stoplight/infrastructure/redis/storage/scripting.rb
+++ b/lib/stoplight/infrastructure/redis/storage/scripting.rb
@@ -11,6 +11,9 @@ module Stoplight
           INCLUDE_DIRECTIVE = /^--\s*@include\s+([\w\-\/]+)$/
           private_constant :INCLUDE_DIRECTIVE
 
+          REDIS_NOSCRIPT_MAX_RETRY = 1
+          private_constant :REDIS_NOSCRIPT_MAX_RETRY
+
           class << self
             def default_scripts_root = SCRIPTS_ROOT
           end
@@ -22,15 +25,21 @@ module Stoplight
           end
 
           def call(script_name, keys: [], args: [])
-            redis.then do |client|
-              client.evalsha(script_sha(script_name), keys: keys.map(&:to_s), argv: args.map(&:to_s))
-            end
-          rescue ::Redis::CommandError => error
-            if error.message.include?("NOSCRIPT")
-              reload_script(script_name)
-              retry
-            else
-              raise
+            retries = 0
+
+            begin
+              redis.then do |client|
+                client.evalsha(script_sha(script_name), keys: keys.map(&:to_s), argv: args.map(&:to_s))
+              end
+            rescue ::Redis::CommandError => error
+              if error.message.include?("NOSCRIPT") && retries < REDIS_NOSCRIPT_MAX_RETRY
+                retries += 1
+                warn "Stoplight is unable to find the script '#{script_name}' in Redis's script cache. Reloading and retrying..."
+                reload_script(script_name)
+                retry
+              else
+                raise error
+              end
             end
           end
 

--- a/lib/stoplight/infrastructure/redis/storage/scripting.rb
+++ b/lib/stoplight/infrastructure/redis/storage/scripting.rb
@@ -11,9 +11,6 @@ module Stoplight
           INCLUDE_DIRECTIVE = /^--\s*@include\s+([\w\-\/]+)$/
           private_constant :INCLUDE_DIRECTIVE
 
-          REDIS_NOSCRIPT_MAX_RETRY = 1
-          private_constant :REDIS_NOSCRIPT_MAX_RETRY
-
           class << self
             def default_scripts_root = SCRIPTS_ROOT
           end
@@ -25,15 +22,15 @@ module Stoplight
           end
 
           def call(script_name, keys: [], args: [])
-            retries = 0
+            retried = false
 
             begin
               redis.then do |client|
                 client.evalsha(script_sha(script_name), keys: keys.map(&:to_s), argv: args.map(&:to_s))
               end
             rescue ::Redis::CommandError => error
-              if error.message.include?("NOSCRIPT") && retries < REDIS_NOSCRIPT_MAX_RETRY
-                retries += 1
+              if error.message.include?("NOSCRIPT") && !retried
+                retried = true
                 warn "Stoplight is unable to find the script '#{script_name}' in Redis's script cache. Reloading and retrying..."
                 reload_script(script_name)
                 retry

--- a/lib/stoplight/wiring/system.rb
+++ b/lib/stoplight/wiring/system.rb
@@ -51,7 +51,7 @@ module Stoplight
       #   of this system. For example if your system uses Redis data store, or notifiers that
       #   communicate with external systems, they could go off. Failover system hosts
       #   all the circuit breakers that are needed to protect these dependencies from failing.
-      #   Failover system itself never uses external dependencies and thereforec does not need
+      #   Failover system itself never uses external dependencies and therefore does not need
       #   external failover.
       def initialize(config:, failover_system:, registry:)
         @name = config.name

--- a/sig/stoplight/infrastructure/redis/storage/scripting.rbs
+++ b/sig/stoplight/infrastructure/redis/storage/scripting.rbs
@@ -7,6 +7,8 @@ module Stoplight
 
           INCLUDE_DIRECTIVE: Regexp
 
+          REDIS_NOSCRIPT_MAX_RETRY: Integer
+
           def self.default_scripts_root: -> String
 
           attr_reader scripts_root: String

--- a/sig/stoplight/infrastructure/redis/storage/scripting.rbs
+++ b/sig/stoplight/infrastructure/redis/storage/scripting.rbs
@@ -7,8 +7,6 @@ module Stoplight
 
           INCLUDE_DIRECTIVE: Regexp
 
-          REDIS_NOSCRIPT_MAX_RETRY: Integer
-
           def self.default_scripts_root: -> String
 
           attr_reader scripts_root: String

--- a/spec/unit/stoplight/infrastructure/redis/storage/scripting_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/scripting_spec.rb
@@ -188,15 +188,13 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::Scripting, :redis do
   end
 
   context "when the script is not loaded" do
-    let(:retry_attempts) { 1 }
+    # Initial call plus one retry
+    let(:total_attempts) { 2 }
 
-    # Initial call plus retries
-    let(:total_attempts) { 1 + retry_attempts }
-
-    it "does not propagate error if retries succeed within REDIS_NOSCRIPT_MAX_RETRY attempts" do
+    it "does not propagate error if retry succeeds" do
       responses = [
         -> { raise ::Redis::CommandError.new("NOSCRIPT") },    # Initial call fails
-        -> { "success" }                                       # First retry succeeds
+        -> { "success" }                                       # retry succeeds
       ]
 
       allow(redis).to receive(:evalsha) { responses.shift.call }
@@ -208,7 +206,7 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::Scripting, :redis do
     it "propagates error if retries are exhausted" do
       responses = [
         -> { raise ::Redis::CommandError.new("NOSCRIPT") },    # Initial call fails
-        -> { raise ::Redis::CommandError.new("NOSCRIPT") }     # First retry also fails => raise
+        -> { raise ::Redis::CommandError.new("NOSCRIPT") }     # retry also fails => raise
       ]
 
       allow(redis).to receive(:evalsha) { responses.shift.call }

--- a/spec/unit/stoplight/infrastructure/redis/storage/scripting_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/scripting_spec.rb
@@ -186,4 +186,37 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::Scripting, :redis do
       end.to raise_error(::Redis::CommandError) { |error| expect(error.message).not_to include("NOSCRIPT") }
     end
   end
+
+  context "when the script is not loaded" do
+    let(:retry_attempts) { 1 }
+
+    # Initial call plus retries
+    let(:total_attempts) { 1 + retry_attempts }
+
+    it "does not propagate error if retries succeed within REDIS_NOSCRIPT_MAX_RETRY attempts" do
+      responses = [
+        -> { raise ::Redis::CommandError.new("NOSCRIPT") },    # Initial call fails
+        -> { "success" }                                       # First retry succeeds
+      ]
+
+      allow(redis).to receive(:evalsha) { responses.shift.call }
+
+      script_manager.call(script_name, args: [value], keys: [key])
+      expect(redis).to have_received(:evalsha).exactly(total_attempts).times
+    end
+
+    it "propagates error if retries are exhausted" do
+      responses = [
+        -> { raise ::Redis::CommandError.new("NOSCRIPT") },    # Initial call fails
+        -> { raise ::Redis::CommandError.new("NOSCRIPT") }     # First retry also fails => raise
+      ]
+
+      allow(redis).to receive(:evalsha) { responses.shift.call }
+
+      expect do
+        script_manager.call(script_name, args: [value], keys: [key])
+      end.to raise_error(::Redis::CommandError)
+      expect(redis).to have_received(:evalsha).exactly(total_attempts).times
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/bolshakov/stoplight/issues/777

### Problem description:
`Scripting#call` could retry indefinitely on `NOSCRIPT` errors as long as scripts weren't loaded. It did not gracefully fall back to the Failsafe store as documented.

### Changes made:
- Upon persistent `NOSCRIPT` errors from Redis, do not retry more than 1 (`REDIS_NOSCRIPT_MAX_RETRY`) times. The retry doesn't include the first call made to Redis
- ~The retries have delays of 0.2, 0.4, and 0.8 seconds between each attempt -- a total of 1.4 seconds before falling back to failsafe.~ Backoff was not helpful and hence decided unnecessary. See https://github.com/bolshakov/stoplight/pull/846#discussion_r3654726364
- Added specs covering both scenarios -- recovery within allowed retries and exhaustion after allowed retries

### Other changes:
- Fixed a minor typo in wiring/system.rb (not relevant to the issue, but still included it)