### PR TITLE
 Wire RecoverySucceeded event (#744)

### DIFF
--- a/lib/stoplight/domain/tracker/recovery_probe.rb
+++ b/lib/stoplight/domain/tracker/recovery_probe.rb
@@ -4,12 +4,13 @@ module Stoplight
   module Domain
     module Tracker
       class RecoveryProbe
-        def initialize(traffic_recovery:, notifiers:, config:, metrics_store:, state_store:)
+        def initialize(traffic_recovery:, notifiers:, config:, metrics_store:, state_store:, emitter:)
           @traffic_recovery = traffic_recovery
           @notifiers = notifiers
           @config = config
           @metrics_store = metrics_store
           @state_store = state_store
+          @emitter = emitter
         end
 
         # @param exception [Exception]
@@ -32,6 +33,7 @@ module Stoplight
         attr_reader :config
         attr_reader :metrics_store
         attr_reader :state_store
+        attr_reader :emitter
 
         def recover
           recovery_metrics = metrics_store.metrics_snapshot
@@ -51,6 +53,18 @@ module Stoplight
             info = LightInfo.new(name: config.name)
             notifiers.each do |notifier|
               notifier.notify(info, from_color, to_color, nil)
+            end
+            if to_color.to_sym == TrafficRecovery::GREEN
+              emitter.emit(Telemetry::RecoverySucceeded) do
+                Telemetry::RecoverySucceeded.new(from_color: Color::YELLOW, to_color: Color::GREEN,
+                  policy: TrafficRecovery::ConsecutiveSuccesses::NAME.to_s,
+                  metrics: Telemetry::Metrics.new(
+                    successes: recovery_metrics.successes,
+                    errors: recovery_metrics.errors,
+                    consecutive_errors: recovery_metrics.consecutive_errors,
+                    consecutive_successes: recovery_metrics.consecutive_successes
+                  ))
+              end
             end
           end
         end

--- a/lib/stoplight/domain/tracker/recovery_probe.rb
+++ b/lib/stoplight/domain/tracker/recovery_probe.rb
@@ -41,23 +41,13 @@ module Stoplight
 
           return if recovery_result == TrafficRecovery::YELLOW
 
-          from_color, to_color = case recovery_result
-          when TrafficRecovery::GREEN then [Color::YELLOW, Color::GREEN]
-          when TrafficRecovery::RED then [Color::YELLOW, Color::RED]
-          else
-            raise "recovery strategy returned unexpected color: #{recovery_result}"
-          end
-
-          if state_store.transition_to_color(to_color)
-            metrics_store.clear
-            info = LightInfo.new(name: config.name)
-            notifiers.each do |notifier|
-              notifier.notify(info, from_color, to_color, nil)
-            end
-            if to_color.to_sym == TrafficRecovery::GREEN
+          case recovery_result
+          when TrafficRecovery::GREEN
+            to_color = Color::GREEN
+            if transition(from_color: Color::YELLOW, to_color:)
               emitter.emit(Telemetry::RecoverySucceeded) do
-                Telemetry::RecoverySucceeded.new(from_color: Color::YELLOW, to_color: Color::GREEN,
-                  policy: TrafficRecovery::ConsecutiveSuccesses::NAME.to_s,
+                Telemetry::RecoverySucceeded.new(from_color: Color::YELLOW, to_color:,
+                  policy: traffic_recovery.name,
                   metrics: Telemetry::Metrics.new(
                     successes: recovery_metrics.successes,
                     errors: recovery_metrics.errors,
@@ -66,7 +56,21 @@ module Stoplight
                   ))
               end
             end
+          when TrafficRecovery::RED
+            transition(from_color: Color::YELLOW, to_color: Color::RED)
+          else
+            raise "recovery strategy returned unexpected color: #{recovery_result}"
           end
+        end
+
+        def transition(from_color:, to_color:)
+          return false unless state_store.transition_to_color(to_color)
+          metrics_store.clear
+          info = LightInfo.new(name: config.name)
+          notifiers.each do |notifier|
+            notifier.notify(info, from_color, to_color, nil)
+          end
+          true
         end
       end
     end

--- a/lib/stoplight/domain/traffic_recovery/consecutive_successes.rb
+++ b/lib/stoplight/domain/traffic_recovery/consecutive_successes.rb
@@ -60,6 +60,8 @@ module Stoplight
         def hash = self.class.hash
 
         def ==(other) = other.is_a?(self.class)
+
+        def name = NAME.to_s
       end
     end
   end

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -98,7 +98,8 @@ module Stoplight
           notifiers:,
           config:,
           metrics_store: recovery_metrics_store,
-          state_store:
+          state_store:,
+          emitter: @emitter
         )
       end
 

--- a/sig/stoplight/domain/ports/traffic_recovery.rbs
+++ b/sig/stoplight/domain/ports/traffic_recovery.rbs
@@ -40,6 +40,7 @@ module Stoplight
       # Object methods
       def ==: (untyped) -> bool
       def is_a?: (untyped) -> bool
+      def name: -> String
     end
   end
 end

--- a/sig/stoplight/domain/tracker/recovery_probe.rbs
+++ b/sig/stoplight/domain/tracker/recovery_probe.rbs
@@ -7,6 +7,7 @@ module Stoplight
         attr_reader config: Config
         attr_reader metrics_store: _MetricsStore
         attr_reader state_store: _StateStore
+        attr_reader emitter: Telemetry::Emitter
 
         def initialize: (
           config: Config,
@@ -14,6 +15,7 @@ module Stoplight
           notifiers: Array[_StateTransitionNotifier],
           metrics_store: _MetricsStore,
           state_store: _StateStore,
+          emitter: Telemetry::Emitter,
         ) -> void
 
         def record_failure: (StandardError exception) -> void

--- a/sig/stoplight/domain/tracker/recovery_probe.rbs
+++ b/sig/stoplight/domain/tracker/recovery_probe.rbs
@@ -21,6 +21,7 @@ module Stoplight
         def record_failure: (StandardError exception) -> void
         def record_success: -> void
         def recover: -> void
+        def transition: (from_color: color, to_color: color) -> bool
       end
     end
   end

--- a/spec/support/adapters/null_traffic_recovery.rb
+++ b/spec/support/adapters/null_traffic_recovery.rb
@@ -3,5 +3,6 @@
 class NullTrafficRecovery
   def check_compatibility = raise NotImplementedError
   def determine_color(config, metrics) = raise NotImplementedError
+  def name = raise NotImplementedError
   def ==(other) = raise NotImplementedError
 end

--- a/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
+++ b/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
   let(:config) { instance_double(Stoplight::Domain::Config, name: name) }
   let(:name) { SecureRandom.uuid }
   let(:emitter) { TestTelemetryEmitter.new }
+  let(:policy_name) { SecureRandom.uuid }
 
   shared_examples "when recover to" do |recover_to:, transition_from:, transition_to:|
     context "when recover to #{recover_to}" do
@@ -26,6 +27,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       before do
         allow(traffic_recovery).to receive(:determine_color).with(config, metrics_after_probe).and_return(recover_to)
         allow(state_store).to receive(:transition_to_color).with(transition_to).and_return(true)
+        allow(traffic_recovery).to receive(:name).and_return(policy_name)
       end
 
       it "sends notifications" do
@@ -136,13 +138,14 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       before do
         allow(traffic_recovery).to receive(:determine_color).and_return(Stoplight::Domain::TrafficRecovery::GREEN)
         allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::GREEN).and_return(true)
+        allow(traffic_recovery).to receive(:name).and_return(policy_name)
       end
 
       it "emits a RecoverySucceeded event with the transition details" do
         expect { recorder.record_success }.to emit(Stoplight::Domain::Telemetry::RecoverySucceeded).with(
           from_color: Stoplight::Color::YELLOW,
           to_color: Stoplight::Color::GREEN,
-          policy: "consecutive_successes",
+          policy: policy_name,
           metrics: Stoplight::Domain::Telemetry::Metrics.new(
             successes: metrics_after_probe.successes,
             errors: metrics_after_probe.errors,
@@ -173,6 +176,17 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
     context "when the light stays yellow" do
       before do
         allow(traffic_recovery).to receive(:determine_color).and_return(Stoplight::Domain::TrafficRecovery::YELLOW)
+      end
+
+      it "does not emit a RecoverySucceeded event" do
+        expect { recorder.record_success }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
+      end
+    end
+
+    context "when the probe changes from yellow to red" do
+      before do
+        allow(traffic_recovery).to receive(:determine_color).and_return(Stoplight::Domain::TrafficRecovery::RED)
+        allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::RED).and_return(true)
       end
 
       it "does not emit a RecoverySucceeded event" do

--- a/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
+++ b/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
-  subject(:recorder) { described_class.new(state_store:, traffic_recovery:, notifiers:, config:, metrics_store:) }
+  subject(:recorder) { described_class.new(state_store:, traffic_recovery:, notifiers:, config:, metrics_store:, emitter:) }
 
   let(:metrics_store) { instance_double(NullMetricsStore) }
   let(:state_store) { instance_double(NullStateStore) }
@@ -10,11 +10,19 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
   let(:notifier) { instance_double(NullNotifier) }
   let(:config) { instance_double(Stoplight::Domain::Config, name: name) }
   let(:name) { SecureRandom.uuid }
+  let(:emitter) { TestTelemetryEmitter.new }
 
   shared_examples "when recover to" do |recover_to:, transition_from:, transition_to:|
     context "when recover to #{recover_to}" do
-      let(:metrics_after_probe) { instance_double(Stoplight::Domain::MetricsSnapshot) }
-
+      let(:metrics_after_probe) {
+        instance_double(Stoplight::Domain::MetricsSnapshot,
+          successes: 5,
+          errors: 2,
+          consecutive_errors: 0,
+          consecutive_successes: 3,
+          last_error: nil,
+          last_success_at: nil)
+      }
       before do
         allow(traffic_recovery).to receive(:determine_color).with(config, metrics_after_probe).and_return(recover_to)
         allow(state_store).to receive(:transition_to_color).with(transition_to).and_return(true)
@@ -106,5 +114,70 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
     end
 
     include_examples "recovering after probe"
+  end
+
+  describe "RecoverySucceeded telemetry" do
+    let(:metrics_after_probe) {
+      instance_double(Stoplight::Domain::MetricsSnapshot,
+        successes: 5,
+        errors: 2,
+        consecutive_errors: 0,
+        consecutive_successes: 3)
+    }
+
+    before do
+      allow(metrics_store).to receive(:record_success)
+      allow(metrics_store).to receive(:metrics_snapshot).and_return(metrics_after_probe)
+      allow(metrics_store).to receive(:clear)
+      allow(notifier).to receive(:notify)
+    end
+
+    context "when the probe changes from yellow to green" do
+      before do
+        allow(traffic_recovery).to receive(:determine_color).and_return(Stoplight::Domain::TrafficRecovery::GREEN)
+        allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::GREEN).and_return(true)
+      end
+
+      it "emits a RecoverySucceeded event with the transition details" do
+        expect { recorder.record_success }.to emit(Stoplight::Domain::Telemetry::RecoverySucceeded).with(
+          from_color: Stoplight::Color::YELLOW,
+          to_color: Stoplight::Color::GREEN,
+          policy: "consecutive_successes",
+          metrics: Stoplight::Domain::Telemetry::Metrics.new(
+            successes: metrics_after_probe.successes,
+            errors: metrics_after_probe.errors,
+            consecutive_errors: metrics_after_probe.consecutive_errors,
+            consecutive_successes: metrics_after_probe.consecutive_successes
+          )
+        )
+      end
+
+      it "emits exactly one RecoverySucceeded event" do
+        recorder.record_success
+
+        count = emitter.emitted.count { |event| event.instance_of?(Stoplight::Domain::Telemetry::RecoverySucceeded) }
+        expect(count).to eq(1)
+      end
+
+      context "when state store fails to transition" do
+        before do
+          allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::GREEN).and_return(false)
+        end
+
+        it "does not emit a RecoverySucceeded event" do
+          expect { recorder.record_success }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
+        end
+      end
+    end
+
+    context "when the light stays yellow" do
+      before do
+        allow(traffic_recovery).to receive(:determine_color).and_return(Stoplight::Domain::TrafficRecovery::YELLOW)
+      end
+
+      it "does not emit a RecoverySucceeded event" do
+        expect { recorder.record_success }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #744, Wires up the `RecoverySucceeded` telemetry event so it fires when a light recovers

What I did:
1. `RecoveryProbe` now takes an `emitter`, and emits `RecoverySucceeded` when it successfully transitions the light to green.
2. The emit sits *inside* the `state_store.transition_to_color(...)` guard, so it only fires when this probe actually won the transition.
3.  Added the matching RBS for the new `emitter` param/reader.

**Policy name is hardcoded** to `"consecutive_successes"`. Right now that's the only recovery policy that exists, so I didn't want to build indirection for a single case. Happy to wire it to the actual policy if/when there's more than one.