### PR TITLE
Add Stoplight.telemetry / System#telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Full detail: `docs/architecture.md`.
 - Let zeitwerk autoload - no manual `require` inside `lib/`. File path = constant path.
 - Internal-but-public plumbing uses the `__stoplight__` prefix.
 - Public surface is only: `Stoplight()`, `Stoplight.register`, `Stoplight.light`,
-  `Stoplight.configure`, `Light#run`
+  `Stoplight.configure`, `Stoplight.telemetry`, `Light#run`
 - Public API methods require a doc comment with at least one usage example -
   see `lib/stoplight.rb` for the pattern. Document behavior, not types - types
   belong in RBS (`docs/types_and_rbs.md`).

--- a/docs/types_and_rbs.md
+++ b/docs/types_and_rbs.md
@@ -22,6 +22,14 @@ Stoplight ships type signatures and checks them with Steep under strict mode.
   spend effort typing them, but don't move typed code into them to avoid checks.
 - Workflow when editing `lib/`: change code - update `sig/` -> `bundle exec steep check`
   -> `bundle exec standardrb`.
+- To check the exact type Steep inferred at a position - e.g. confirming an overloaded
+  method's block argument narrows to the right event class, or that a value isn't silently
+  `untyped` (`steep check` passing only proves no diagnostic fired, and `untyped` never
+  fires one) - run `bundle exec steep server start`, then
+  `bundle exec steep query hover path/to/file.rb:LINE:COLUMN`, then
+  `bundle exec steep server stop`. `steep query` is marked experimental upstream (output
+  format may change without deprecation), so treat it as an ad hoc verification tool, not
+  as the basis for a permanent automated test.
 - To distinguish `nil` and undefined values, use `optional[T]` type and `T.undefined` helper
 - To unwrap nilable values, use `T.must()` helper - raises TypeError when nil.
 

--- a/features/stoplight/step_definitions/telemetry_steps.rb
+++ b/features/stoplight/step_definitions/telemetry_steps.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Given(/^I subscribe to RunCompleted telemetry events$/) do
+  Stoplight.telemetry.subscribe(Stoplight::Telemetry::RunCompleted) { |envelope| received_telemetry_events << envelope }
+end
+
+Then(/^I received (\d+) RunCompleted telemetry event(?:s)?$/) do |count|
+  expect(received_telemetry_events.size).to eq(count.to_i)
+end

--- a/features/stoplight/support/stoplight_world.rb
+++ b/features/stoplight/support/stoplight_world.rb
@@ -29,6 +29,10 @@ module StoplightWorld
   #   @return [any] the last argument received by a fallback function
   attr_accessor :last_fallback_received_argument
 
+  # @!attribute received_telemetry_events
+  #   @return [Array<Stoplight::Domain::Telemetry::Envelope>] events captured by scenario telemetry subscriptions
+  attr_reader :received_telemetry_events
+
   # Provides access to the echo service used for testing.
   #
   # @return [EchoService] The echo service instance.
@@ -58,6 +62,7 @@ module StoplightWorld
     @last_exception = nil
     @last_result = nil
     @last_fallback_received_argument = :nothing
+    @received_telemetry_events = []
     Stoplight.configure(trust_me_im_an_engineer: true) do |config|
       config.data_store = case ENV.fetch("STOPLIGHT_DATA_STORE", "Memory")
       when "Memory"

--- a/features/stoplight/telemetry.feature
+++ b/features/stoplight/telemetry.feature
@@ -1,0 +1,12 @@
+Feature: Telemetry
+  As a Ruby developer using Stoplight
+  I want to subscribe to telemetry events
+  So that I can observe circuit breaker activity without reaching into internals
+
+  @global_configuration
+  Scenario: Subscribing to run completion events
+    Given a light "telemetry-service" configured with:
+      | Threshold | 5 |
+    And I subscribe to RunCompleted telemetry events
+    When 1 request is made with "Hi!" message
+    Then I received 1 RunCompleted telemetry event

--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -46,8 +46,7 @@ module Stoplight # rubocop:disable Style/Documentation
     #   it will not be possible to change the configuration of existing circuit breakers. If you do so, the method
     #   produces a warning:
     #
-    #     "Stoplight reconfigured. Existing circuit breakers will not see the new configuration. New
-    #       configuration: ...f
+    #     "Stoplight reconfigured. Existing circuit breakers will not see new configuration"
     #
     #   If you really know what you are doing, you can pass the +trust_me_im_an_engineer+ parameter as +true+ to
     #   suppress this warning, which could be useful in test environments.

--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -68,29 +68,7 @@ module Stoplight # rubocop:disable Style/Documentation
     # @example
     #   Stoplight.register("stripe", threshold: 5, cool_off_time: 60)
     #
-    def register(
-      name,
-      cool_off_time: T.undefined,
-      threshold: T.undefined,
-      recovery_threshold: T.undefined,
-      window_size: T.undefined,
-      tracked_errors: T.undefined,
-      skipped_errors: T.undefined,
-      traffic_control: T.undefined,
-      traffic_recovery: T.undefined
-    )
-      state.default_system.register(
-        name,
-        cool_off_time:,
-        threshold:,
-        recovery_threshold:,
-        window_size:,
-        tracked_errors:,
-        skipped_errors:,
-        traffic_control:,
-        traffic_recovery:
-      )
-    end
+    def register(...) = state.default_system.register(...)
 
     # Returns a Light previously registered.
     #
@@ -100,7 +78,14 @@ module Stoplight # rubocop:disable Style/Documentation
     #   Stoplight.register("stripe", threshold: 5)
     #   Stoplight.light("stripe")
     #
-    def light(name) = state.default_system.light(name)
+    def light(...) = state.default_system.light(...)
+
+    # Returns the consumer side of the default system's telemetry bus.
+    #
+    # @example
+    #   Stoplight.telemetry.subscribe(Stoplight::Telemetry::RunCompleted) { |envelope| track(envelope) }
+    #
+    def telemetry = state.default_system.telemetry
 
     # Creates a new named system with the given configuration.
     #

--- a/lib/stoplight/domain/telemetry/consumer.rb
+++ b/lib/stoplight/domain/telemetry/consumer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Domain
+    module Telemetry
+      # Consumer-only view of a telemetry bus - forwards subscribe/unsubscribe, never publish.
+      class Consumer
+        def initialize(telemetry)
+          @telemetry = telemetry
+        end
+
+        def subscribe(...) = @telemetry.subscribe(...)
+
+        def unsubscribe(...) = @telemetry.unsubscribe(...)
+      end
+    end
+  end
+end

--- a/lib/stoplight/wiring/system.rb
+++ b/lib/stoplight/wiring/system.rb
@@ -47,6 +47,11 @@ module Stoplight
       #   @api private
       attr_reader :system_config
 
+      # Returns the consumer (subscribe-only) side of the telemetry bus.
+      def telemetry
+        Domain::Telemetry::Consumer.new(@telemetry)
+      end
+
       # @param failover_system is a system used to create lights that protects components
       #   of this system. For example if your system uses Redis data store, or notifiers that
       #   communicate with external systems, they could go off. Failover system hosts

--- a/sig/stoplight.rbs
+++ b/sig/stoplight.rbs
@@ -1,4 +1,6 @@
 module Stoplight
+  extend _System
+
   T: singleton(Types)
   CONFIG_MUTEX: Mutex
 
@@ -28,20 +30,6 @@ module Stoplight
   type optional[T] = Undefined | T
 
   def self.configure: (?trust_me_im_an_engineer: bool) ?{ (Wiring::DefaultConfiguration) -> void } -> void
-
-  def self.register: (
-      String name,
-      ?cool_off_time: optional[Domain::duration_seconds],
-      ?threshold: optional[Domain::percentage | Integer],
-      ?recovery_threshold: optional[Integer],
-      ?window_size: optional[Domain::duration_seconds?],
-      ?tracked_errors: optional[Array[Module] | Module],
-      ?skipped_errors: optional[Array[Module] | Module],
-      ?traffic_control: optional[Wiring::traffic_control],
-      ?traffic_recovery: optional[Wiring::traffic_recovery],
-    ) -> Domain::Light
-
-  def self.light: (String name) -> Domain::Light
 end
 
 module Kernel

--- a/sig/stoplight/domain/telemetry/consumer.rbs
+++ b/sig/stoplight/domain/telemetry/consumer.rbs
@@ -4,8 +4,6 @@ module Stoplight
       class Consumer
         include _Telemetry
 
-        # untyped, not _Telemetry: forwarding (...) can't statically resolve which of
-        # _Telemetry#subscribe's per-event-class overloads a given call site picked.
         @telemetry: untyped
 
         def initialize: (_Telemetry) -> void

--- a/sig/stoplight/domain/telemetry/consumer.rbs
+++ b/sig/stoplight/domain/telemetry/consumer.rbs
@@ -1,0 +1,15 @@
+module Stoplight
+  module Domain
+    module Telemetry
+      class Consumer
+        include _Telemetry
+
+        # untyped, not _Telemetry: forwarding (...) can't statically resolve which of
+        # _Telemetry#subscribe's per-event-class overloads a given call site picked.
+        @telemetry: untyped
+
+        def initialize: (_Telemetry) -> void
+      end
+    end
+  end
+end

--- a/sig/stoplight/wiring/system.rbs
+++ b/sig/stoplight/wiring/system.rbs
@@ -7,7 +7,7 @@ module Stoplight
       @lights: Concurrent::Map[String, [Domain::Light, Integer, String?]]
       @failover_system: _System?
       @registry: Domain::_Registry
-      @telemetry: Domain::_TelemetryPublisher
+      @telemetry: Domain::Telemetry::Bus
 
       attr_reader system_config: Domain::Config
 

--- a/spec/unit/stoplight/domain/telemetry/consumer_spec.rb
+++ b/spec/unit/stoplight/domain/telemetry/consumer_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Domain::Telemetry::Consumer do
+  subject(:consumer) { described_class.new(bus) }
+
+  let(:bus) { Stoplight::Domain::Telemetry::Bus.new(error_notifier: instance_spy(Proc)) }
+
+  def envelope(payload)
+    Stoplight::Domain::Telemetry::Envelope.new(
+      system_name: "sys",
+      light_name: "light",
+      occurred_at: Time.at(0),
+      payload:
+    )
+  end
+
+  let(:run_completed) do
+    Stoplight::Domain::Telemetry::RunCompleted.new(
+      outcome: :success,
+      color: "green",
+      duration_ms: 1.0,
+      failure: nil,
+      fallback_used: false,
+      retry_after: nil
+    )
+  end
+
+  describe "#subscribe" do
+    it "forwards to the wrapped bus" do
+      expect do |handler|
+        consumer.subscribe(Stoplight::Domain::Telemetry::RunCompleted, &handler)
+        bus.publish(envelope(run_completed))
+      end.to yield_with_args(envelope(run_completed))
+    end
+  end
+
+  describe "#unsubscribe" do
+    it "forwards to the wrapped bus, removing the subscription" do
+      received = []
+      subscription = consumer.subscribe(Stoplight::Domain::Telemetry::RunCompleted) { |e| received << e }
+
+      consumer.unsubscribe(subscription)
+      bus.publish(envelope(run_completed))
+
+      expect(received).to be_empty
+    end
+  end
+
+  describe "producer-side isolation" do
+    it "does not expose #publish" do
+      expect(consumer).not_to respond_to(:publish)
+    end
+
+    it "does not expose #subscribed?" do
+      expect(consumer).not_to respond_to(:subscribed?)
+    end
+  end
+end

--- a/spec/unit/stoplight/wiring/system_spec.rb
+++ b/spec/unit/stoplight/wiring/system_spec.rb
@@ -175,6 +175,26 @@ RSpec.describe Stoplight::Wiring::System do
     end
   end
 
+  describe "#telemetry" do
+    let(:system_config) { Stoplight::Wiring::DefaultConfig.with(name: SecureRandom.uuid) }
+    let(:received) { [] }
+
+    it "delivers events published while running a light registered on this system" do
+      system.telemetry.subscribe(Stoplight::Telemetry::RunCompleted) { |envelope| received << envelope }
+
+      system.register("stripe")
+      system.light("stripe").run { "ok" }
+
+      expect(received.size).to eq(1)
+      expect(received.first.payload).to be_a(Stoplight::Telemetry::RunCompleted)
+    end
+
+    it "does not expose the producer side of the bus" do
+      expect(system.telemetry).not_to respond_to(:publish)
+      expect(system.telemetry).not_to respond_to(:subscribed?)
+    end
+  end
+
   describe "#light" do
     let(:system_config) { Stoplight::Wiring::DefaultConfig.with(name: SecureRandom.uuid) }
     let(:light) { system.light("stripe") }

--- a/spec/unit/stoplight_spec.rb
+++ b/spec/unit/stoplight_spec.rb
@@ -54,6 +54,16 @@ RSpec.describe "Stoplight" do
         .to_stderr
     end
 
+    it "drops telemetry subscriptions made before reconfiguring" do
+      received = []
+      Stoplight.telemetry.subscribe(Stoplight::Telemetry::RunCompleted) { |envelope| received << envelope }
+
+      Stoplight.configure(trust_me_im_an_engineer: true) {}
+      Stoplight(SecureRandom.uuid).run { "ok" }
+
+      expect(received).to be_empty
+    end
+
     it "allows configuration with a block" do
       Stoplight.configure(trust_me_im_an_engineer: true) do |config|
         config.window_size = 30
@@ -104,6 +114,23 @@ RSpec.describe "Stoplight" do
       it "raises an error" do
         expect { Stoplight.light(name) }.to raise_error(Stoplight::Error::UnregisteredLightError, /#{name}/)
       end
+    end
+  end
+
+  describe ".telemetry" do
+    it "delivers events published while running a registered light" do
+      received = []
+      Stoplight.telemetry.subscribe(Stoplight::Telemetry::RunCompleted) { |envelope| received << envelope }
+
+      Stoplight(name).run { "ok" }
+
+      expect(received.size).to eq(1)
+      expect(received.first.payload).to be_a(Stoplight::Telemetry::RunCompleted)
+    end
+
+    it "does not expose the producer side of the bus" do
+      expect(Stoplight.telemetry).not_to respond_to(:publish)
+      expect(Stoplight.telemetry).not_to respond_to(:subscribed?)
     end
   end
 


### PR DESCRIPTION
#754

Stoplight already delegates register/light to its default system, but observing a system's telemetry required reaching into `Wiring::System` internals - there was no equivalent default-system entry point for subscribing to events.

- Adds `Stoplight.telemetry` / `System#telemetry`, returning a `Domain::Telemetry::Consumer` - a subscribe/unsubscribe-only forwarder - rather than the underlying bus directly, since the bus also implements the producer side (publish, subscribed?) that only Emitter/Storage should ever call.
- Stoplight now formally extends `_System`, and register/light switch to (...) forwarding to match telemetry's style.