### PR TITLE
Batch Dependabot updates into monthly grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,30 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 14
+    groups:
+      bundler:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
+    cooldown:
+      default-days: 14
+    groups:
+      github-actions:
+        patterns: ["*"]
 
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
+    cooldown:
+      default-days: 14
+    groups:
+      docker:
+        patterns: ["*"]


### PR DESCRIPTION
Dependabot was opening several PRs a day, which meant reviewing minor and patch
bumps one at a time.

- **Grouped** each ecosystem's minor and patch updates into a single PR (`groups`).
- **Monthly** schedule instead of daily for github-actions and docker, weekly for bundler.
- **14-day cooldown** so a freshly published release isn't proposed until it has settled.

Major bundler updates are deliberately left out of the group: a gem major usually
needs code changes, and grouping it would block the rest of the batch behind it.
Actions and Docker group everything, since those majors are typically just a tag bump.

Upper bound is now three PRs a month (one per ecosystem) plus any bundler majors.

Note: grouping only affects future Dependabot runs. The currently open PRs need to be
closed so they get re-opened as one grouped PR.