### PR TITLE
config.ru: actually configure Stoplight's default system, not just a Sinatra setting

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -9,7 +9,10 @@ require "stoplight/admin"
 
 redis = Redis.new
 
-Stoplight::Admin.set :data_store, Stoplight::DataStore::Redis.new(redis)
+Stoplight.configure do |config|
+  config.data_store = Stoplight::DataStore::Redis.new(redis)
+end
+
 Stoplight::Admin.set :environment, :production
 
 run Stoplight::Admin

--- a/spec/integration/admin_config_ru_spec.rb
+++ b/spec/integration/admin_config_ru_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rack/test"
+require "rack/builder"
+
+RSpec.describe "config.ru", :redis do
+  include Rack::Test::Methods
+
+  let(:app) { Rack::Builder.parse_file(File.expand_path("../../config.ru", __dir__)) }
+
+  around do |example|
+    original_redis_url = ENV["REDIS_URL"]
+    ENV["REDIS_URL"] = ENV.fetch("STOPLIGHT_REDIS_URL", "redis://127.0.0.1:6379/0")
+    example.run
+  ensure
+    ENV["REDIS_URL"] = original_redis_url
+  end
+
+  before { Stoplight.__stoplight__reset! }
+
+  it "surfaces a light a separate process already wrote to the same Redis" do
+    Stoplight.configure(trust_me_im_an_engineer: true) { |config| config.data_store = Stoplight::DataStore::Redis.new(redis) }
+    Stoplight.register("foo")
+    Stoplight.light("foo").run { "ok" }
+    Stoplight.__stoplight__reset!
+
+    get "/"
+
+    expect(last_response.body).not_to include("No lights found")
+  end
+end


### PR DESCRIPTION
The standalone admin panel (config.ru) shows "No lights found" no matter what's in Redis. Stoplight::Admin.set :data_store, ... only sets a setting on the Sinatra app itself - it never calls Stoplight.configure, so Stoplight.__stoplight__default_system (what the dashboard's Dependencies actually reads from) silently falls back to an in-memory store the first time anything touches it.

- Replace Stoplight::Admin.set :data_store, ... with Stoplight.configure { |c| c.data_store = ... }, so the same Redis-backed store actually backs the default system a separate worker process writes to.
- Added an integration spec that boots config.ru itself (via Rack::Builder.parse_file) and asserts a light written by another process is visible - fails against the prior code, passes against the fix.