### PR TITLE
Add read-only mode to the Admin panel

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -15,4 +15,6 @@ end
 
 Stoplight::Admin.set :environment, :production
 
+Stoplight::Admin.set :read_only, ENV.fetch("STOPLIGHT_ADMIN_READ_ONLY", "false") == "true"
+
 run Stoplight::Admin

--- a/lib/stoplight/admin.rb
+++ b/lib/stoplight/admin.rb
@@ -17,6 +17,20 @@ rescue LoadError
 end
 
 module Stoplight
+  # A Sinatra dashboard listing every light, its color, and its recent failures, with
+  # controls to lock a light green or red, unlock it, or remove it.
+  #
+  # Setting +read_only+ deploys it as an observation-only dashboard: every light stays
+  # visible, and every control that would change one is refused with 403 rather than merely
+  # hidden, so calling the endpoints directly does not get around it. The standalone Docker
+  # image reads the same option from +STOPLIGHT_ADMIN_READ_ONLY+, for the exact string +true+.
+  #
+  # This is not access control - it has no notion of users, and anyone who reaches the panel
+  # still reads every light name and failure message. Keep it behind authentication either way.
+  #
+  # @example Observing without being able to change anything
+  #   Stoplight::Admin.set :read_only, true
+  #   mount Stoplight::Admin => "/stoplights"
   class Admin < Sinatra::Base
     COLORS = [
       GREEN = Stoplight::Color::GREEN,
@@ -36,11 +50,20 @@ module Stoplight
     helpers Helpers
 
     set :protection, except: %i[json_csrf]
+    set :read_only, false
     set :data_store, proc { Stoplight.__stoplight__default_configuration.data_store }
     set :views, File.join(__dir__, "admin", "views")
     set :nonce, proc { |request| }
     set :public_folder, ASSETS_PATH
     set :static_cache_control, [:public, max_age: ONE_YEAR_IN_SECONDS, immutable: true]
+
+    # Gates on the request method rather than on a list of paths, so a write route added
+    # later is refused without anyone having to remember this filter exists.
+    before do
+      if settings.read_only? && !request.get? && !request.head?
+        halt 403, "Stoplight Admin is running in read-only mode."
+      end
+    end
 
     get "/" do
       lights, stats = dependencies.stats_action.call

--- a/lib/stoplight/admin/helpers.rb
+++ b/lib/stoplight/admin/helpers.rb
@@ -22,6 +22,28 @@ module Stoplight
         url("/#{name}?v=#{ASSET_DIGESTS.fetch(name)}")
       end
 
+      # A read-only control keeps its place but loses its href, so there is nothing to follow
+      # and nothing to copy out of the page. aria-disabled carries that state to assistive
+      # technology, which the styling alone does not reach.
+      #
+      # @example The same control, writable and read-only
+      #   control_attributes(url("/red?names=foo"))
+      #   # => href="http://localhost/red?names=foo" data-turbo-method="post"
+      #
+      #   # once `set :read_only, true`
+      #   # => aria-disabled="true" title="Disabled in read-only mode"
+      #
+      # @param confirm [String, nil] message to confirm before following the link
+      def control_attributes(href, confirm: nil)
+        return %(aria-disabled="true" title="Disabled in read-only mode") if settings.read_only?
+
+        [
+          %(href="#{CGI.escapeHTML(href)}"),
+          %(data-turbo-method="post"),
+          (%(data-turbo-confirm="#{CGI.escapeHTML(confirm)}") if confirm)
+        ].compact.join(" ")
+      end
+
       def time_ago_in_words(time)
         time_difference = Time.now.utc - time
         if time_difference < 1

--- a/lib/stoplight/admin/views/_card.erb
+++ b/lib/stoplight/admin/views/_card.erb
@@ -50,11 +50,13 @@
       </svg>
     </button>
 
+    <% action_classes = "flex items-center py-2 px-4 text-sm " + (settings.read_only? ? "text-gray-400 dark:text-gray-500 cursor-not-allowed" : "hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white") %>
+
     <!-- Dropdown menu -->
     <div id="dropdownDotsHorizontal-<%= light.id %>" class="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow-sm w-44 dark:bg-gray-700 dark:divide-gray-600">
       <ul class="py-2 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownMenuIconHorizontalButton">
         <li>
-          <a href="<%= url("/unlock?names=#{light_name}") %>" data-turbo-method="post" class="flex items-center py-2 px-4 text-sm hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">
+          <a <%= control_attributes(url("/unlock?names=#{light_name}")) %> class="<%= action_classes %>">
             <svg class="flex w-4 h-4 me-1.5 shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <circle cx="12" cy="16" r="1"/>
               <rect width="18" height="12" x="3" y="10" rx="2"/>
@@ -64,7 +66,7 @@
           </a>
         </li>
         <li>
-          <a href="<%= url("/red?names=#{light_name}") %>" data-turbo-method="post" class="flex items-center py-2 px-4 text-sm hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">
+          <a <%= control_attributes(url("/red?names=#{light_name}")) %> class="<%= action_classes %>">
             <svg class="flex w-4 h-4 me-1.5 text-red-600 shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <circle cx="12" cy="16" r="1"/>
               <rect x="3" y="10" width="18" height="12" rx="2"/>
@@ -74,7 +76,7 @@
           </a>
         </li>
         <li>
-          <a href="<%= url("/green?names=#{light_name}") %>" data-turbo-method="post" class="flex items-center py-2 px-4 text-sm hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">
+          <a <%= control_attributes(url("/green?names=#{light_name}")) %> class="<%= action_classes %>">
             <svg class="flex w-4 h-4 me-1.5 text-green-600 shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <circle cx="12" cy="16" r="1"/>
               <rect x="3" y="10" width="18" height="12" rx="2"/>
@@ -84,7 +86,7 @@
           </a>
         </li>
         <li>
-          <a href="<%= url("/remove?names=#{light_name}") %>" data-turbo-method="post" data-turbo-confirm="Are you sure you want to remove this light?" class="flex items-center py-2 px-4 text-sm hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">
+          <a <%= control_attributes(url("/remove?names=#{light_name}"), confirm: "Are you sure you want to remove this light?") %> class="<%= action_classes %>">
             <svg class="flex w-4 h-4 me-1.5 text-red-600 shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <polyline points="3 6 5 6 21 6"/>
               <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>

--- a/lib/stoplight/admin/views/layout.erb
+++ b/lib/stoplight/admin/views/layout.erb
@@ -23,10 +23,16 @@
       <div class="grow">
         <nav class="bg-white border-gray-200 dark:bg-gray-900">
           <div class="flex flex-wrap items-center justify-between p-4">
-            <a href="<%= url('/') %>" class="flex items-center space-x-3 rtl:space-x-reverse">
-              🚦
-              <span class="self-center text-2xl font-semibold whitespace-nowrap dark:text-white">Stoplight Admin</span>
-            </a>
+            <div class="flex items-center space-x-3 rtl:space-x-reverse">
+              <a href="<%= url('/') %>" class="flex items-center space-x-3 rtl:space-x-reverse">
+                🚦
+                <span class="self-center text-2xl font-semibold whitespace-nowrap dark:text-white">Stoplight Admin</span>
+              </a>
+
+              <% if settings.read_only? %>
+                <span class="bg-gray-100 text-gray-600 text-xs font-medium px-2.5 py-0.5 rounded-sm dark:bg-gray-700 dark:text-gray-300" title="This panel cannot change light states">Read-only</span>
+              <% end %>
+            </div>
 
             <button data-collapse-toggle="navbar-default" type="button" class="inline-flex items-center p-2 w-10 h-10 justify-center text-sm text-gray-500 rounded-lg md:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600" aria-controls="navbar-default" aria-expanded="false">
               <span class="sr-only">Open main menu</span>
@@ -39,7 +45,7 @@
               <ul class="font-medium flex flex-col p-4 md:p-0 mt-4 border border-gray-100 rounded-lg bg-gray-50 md:flex-row md:space-x-8 rtl:space-x-reverse md:mt-0 md:border-0 md:bg-white dark:bg-gray-800 md:dark:bg-gray-900 dark:border-gray-700">
                 <% if count_red + count_yellow > 0 %>
                   <li>
-                    <a href="<%= url('/green_all') %>" data-turbo-method="post" class="inline-flex items-center text-gray-900 bg-white border border-gray-300 focus:outline-none hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-gray-800 dark:text-white dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:border-gray-600 dark:focus:ring-gray-700">
+                    <a <%= control_attributes(url('/green_all')) %> class="inline-flex items-center font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 border bg-white dark:bg-gray-800 <%= settings.read_only? ? "text-gray-400 border-gray-200 cursor-not-allowed dark:text-gray-500 dark:border-gray-700" : "text-gray-900 border-gray-300 focus:outline-none hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 dark:text-white dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:border-gray-600 dark:focus:ring-gray-700" %>">
                       <svg class="flex w-4 h-4 me-1.5 text-green-600 shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="16" r="1"/>
                         <rect x="3" y="10" width="18" height="12" rx="2"/>

--- a/spec/integration/admin_config_ru_spec.rb
+++ b/spec/integration/admin_config_ru_spec.rb
@@ -16,7 +16,34 @@ RSpec.describe "config.ru", :redis do
     ENV["REDIS_URL"] = original_redis_url
   end
 
+  around do |example|
+    original_read_only = Stoplight::Admin.settings.read_only
+    original_environment = Stoplight::Admin.settings.environment
+    original_env = ENV["STOPLIGHT_ADMIN_READ_ONLY"]
+    example.run
+  ensure
+    Stoplight::Admin.set :read_only, original_read_only
+    Stoplight::Admin.set :environment, original_environment
+    ENV["STOPLIGHT_ADMIN_READ_ONLY"] = original_env
+  end
+
   before { Stoplight.__stoplight__reset! }
+
+  it "runs the panel read-only when STOPLIGHT_ADMIN_READ_ONLY is true" do
+    ENV["STOPLIGHT_ADMIN_READ_ONLY"] = "true"
+
+    post "/green", names: "foo"
+
+    expect(last_response.status).to eq(403)
+  end
+
+  it "leaves the panel writable when STOPLIGHT_ADMIN_READ_ONLY holds any other value" do
+    ENV["STOPLIGHT_ADMIN_READ_ONLY"] = "1"
+
+    post "/green", names: "foo"
+
+    expect(last_response.status).to eq(302)
+  end
 
   it "surfaces a light a separate process already wrote to the same Redis" do
     Stoplight.configure(trust_me_im_an_engineer: true) { |config| config.data_store = Stoplight::DataStore::Redis.new(redis) }

--- a/spec/unit/stoplight/admin_spec.rb
+++ b/spec/unit/stoplight/admin_spec.rb
@@ -55,6 +55,40 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
         expect(last_response.body).to_not include("No lights found")
         expect(last_response.body).not_to include("Ensure that your Stoplight data store is properly configured and that your Stoplight blocks have been run.")
       end
+
+      it "links the light actions" do
+        get "/"
+
+        expect(last_response).to be_ok
+
+        expect(last_response.body).to include(%(href="http://#{last_request.env["HTTP_HOST"]}/unlock?names=foo" data-turbo-method="post"))
+        expect(last_response.body).to include(%(href="http://#{last_request.env["HTTP_HOST"]}/red?names=foo" data-turbo-method="post"))
+        expect(last_response.body).to include(%(href="http://#{last_request.env["HTTP_HOST"]}/green?names=foo" data-turbo-method="post"))
+
+        expect(last_response.body).to_not include("Read-only")
+      end
+
+      it "asks for confirmation before removing a light, and only before removing" do
+        get "/"
+
+        expect(last_response).to be_ok
+
+        expect(last_response.body).to include(
+          %(href="http://#{last_request.env["HTTP_HOST"]}/remove?names=foo" data-turbo-method="post" data-turbo-confirm="Are you sure you want to remove this light?")
+        )
+        expect(last_response.body.scan("data-turbo-confirm").count).to eq(1)
+      end
+    end
+
+    context "with a light that is not green" do
+      before { light.lock(Stoplight::Color::RED) }
+
+      it "links Lock All Green" do
+        get "/"
+
+        expect(last_response).to be_ok
+        expect(last_response.body).to include(%(href="http://#{last_request.env["HTTP_HOST"]}/green_all" data-turbo-method="post"))
+      end
     end
 
     context "when light has multiple consecutive failures" do
@@ -216,6 +250,139 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
       get "/stats"
       expect(last_response).to be_ok
       expect(response_body.fetch("lights").map { |h| h.fetch("name") }).to contain_exactly("bar")
+    end
+  end
+
+  context "when the admin panel is read-only" do
+    around do |example|
+      previous_setting = Stoplight::Admin.settings.read_only
+      Stoplight::Admin.set :read_only, true
+      example.run
+    ensure
+      Stoplight::Admin.set :read_only, previous_setting
+    end
+
+    describe "GET /" do
+      before { light.run(&light_condition) }
+
+      it "tells the operator the panel is read-only" do
+        get "/"
+
+        expect(last_response).to be_ok
+        expect(last_response.body).to include("Read-only")
+      end
+
+      it "renders the light actions without links" do
+        get "/"
+
+        expect(last_response).to be_ok
+        expect(last_response.body).to include("Unlock", "Lock Red", "Lock Green", "Remove")
+
+        expect(last_response.body).to_not include("/unlock?names=foo")
+        expect(last_response.body).to_not include("/red?names=foo")
+        expect(last_response.body).to_not include("/green?names=foo")
+        expect(last_response.body).to_not include("/remove?names=foo")
+      end
+
+      context "when some lights are not green" do
+        before { light.lock(Stoplight::Color::RED) }
+
+        it "renders Lock All Green without a link" do
+          get "/"
+
+          expect(last_response).to be_ok
+          expect(last_response.body).to include("Lock All Green")
+          expect(last_response.body).to_not include("/green_all")
+        end
+      end
+    end
+
+    describe "GET /stats" do
+      before { light.run(&light_condition) }
+
+      it "serves the stats" do
+        get "/stats"
+
+        expect(last_response).to be_ok
+        expect(response_body.fetch("lights").map { |h| h.fetch("name") }).to contain_exactly("foo")
+      end
+    end
+
+    it "serves HEAD requests" do
+      head "/"
+
+      expect(last_response).to be_ok
+    end
+
+    it "refuses a verb it has no route for, rather than only the ones it does" do
+      delete "/green"
+
+      expect(last_response.status).to eq(403)
+    end
+
+    describe "POST /unlock" do
+      before do
+        light.run(&light_condition)
+        light.lock(Stoplight::Color::GREEN)
+      end
+
+      it "refuses to unlock the light" do
+        post "/unlock", names: "foo"
+
+        expect(last_response.status).to eq(403)
+        expect(last_response.body).to include("read-only mode")
+        expect(light.state).to eq("locked_green")
+      end
+    end
+
+    describe "POST /green" do
+      before { light.run(&light_condition) }
+
+      it "refuses to lock the light" do
+        post "/green", names: "foo"
+
+        expect(last_response.status).to eq(403)
+        expect(light.state).to eq("unlocked")
+      end
+    end
+
+    describe "POST /red" do
+      before { light.run(&light_condition) }
+
+      it "refuses to lock the light" do
+        post "/red", names: "foo"
+
+        expect(last_response.status).to eq(403)
+        expect(light.state).to eq("unlocked")
+      end
+    end
+
+    describe "POST /green_all" do
+      before { light.lock(Stoplight::Color::RED) }
+
+      it "refuses to lock the lights" do
+        post "/green_all"
+
+        expect(last_response.status).to eq(403)
+        expect(light.state).to eq("locked_red")
+      end
+    end
+
+    describe "POST /remove" do
+      before do
+        light.run { raise "whoops" }
+      rescue
+        nil
+      end
+
+      it "refuses to remove the light" do
+        post "/remove", names: "foo"
+
+        expect(last_response.status).to eq(403)
+
+        get "/stats"
+        expect(response_body.fetch("lights").map { |h| h.fetch("name") }).to contain_exactly("foo")
+      end
     end
   end
 end


### PR DESCRIPTION
A read-only panel keeps every light visible while refusing to change any of them. The lock, unlock, and remove controls stay in place but lose their href, so there is nothing to click or copy out of the page.

<img width="1540" height="810" alt="Screenshot 2026-07-30 at 00 05 48" src="https://github.com/user-attachments/assets/9ddd8209-f3e3-48cf-9bd7-3abce875c3ec" />
