### PR TITLE
Add a system switcher to the admin panel

### DIFF
--- a/lib/stoplight/admin.rb
+++ b/lib/stoplight/admin.rb
@@ -64,23 +64,24 @@ module Stoplight
     @systems = []
 
     def self.add_system(system)
-      validate_persistent_system!(system)
-      @systems << system
+      @systems << validate_persistent_system!(system)
+    end
+
+    def self.__stoplight__reset_systems!
+      @systems = []
     end
 
     def self.validate_persistent_system!(system)
-      return if system.persistent?
+      return system if system.persistent?
 
-      raise TypeError, "Stoplight Admin requires a persistent data store, but the current data store is not. " \
+      raise TypeError, "Stoplight Admin requires a persistent data store, but the current data store is not persistent. " \
         "Please configure a different data store in your Stoplight configuration."
     end
     private_class_method :validate_persistent_system!
 
     set :systems do
       if @systems.empty?
-        default_system = Stoplight.__stoplight__default_system
-        validate_persistent_system!(default_system)
-        [default_system]
+        [validate_persistent_system!(Stoplight.__stoplight__default_system)]
       else
         @systems
       end
@@ -105,11 +106,11 @@ module Stoplight
     get "/" do
       system = settings.systems.first
 
-      redirect to("/systems/#{system.config.id}/lights")
+      redirect system_url(system.config.id, "/lights")
     end
 
     get "/systems/:system_id/lights" do
-      lights, stats = dependencies(current_system).stats_action.call
+      lights, stats = dependencies.stats_action.call
 
       erb :index, locals: stats.merge(
         lights: lights,
@@ -118,47 +119,47 @@ module Stoplight
       )
     end
 
-    # Keep this endpoint for backward compatibility. Any monitoring system polling this
-    # endpoint will keep receiving the first system's (likely default one) lights
+    # Always reports the first configured system, regardless of which system is "current" -
+    # for external monitors that already poll this unscoped path.
     get "/stats" do
-      lights, stats = dependencies(settings.systems.first).stats_action.call
+      lights, stats = Dependencies.new(system: settings.systems.first).stats_action.call
 
       json({stats: stats, lights: lights.map(&:as_json)})
     end
 
     get "/systems/:system_id/lights.json" do
-      lights, stats = dependencies(current_system).stats_action.call
+      lights, stats = dependencies.stats_action.call
 
       json({stats: stats, lights: lights.map(&:as_json)})
     end
 
     patch "/systems/:system_id/lights/:light_id/unlock" do
       light_id = T.must(params[:light_id])
-      dependencies(current_system).unlock_action.call(light_id:)
+      dependencies.unlock_action.call(light_id:)
 
-      redirect to("/systems/#{current_system_id}/lights")
+      redirect system_url(current_system_id, "/lights")
     end
 
     patch "/systems/:system_id/lights/:light_id/lock" do
       light_id = T.must(params[:light_id])
       color = T.must(params[:color])
-      dependencies(current_system).lock_action.call(light_id:, color:)
+      dependencies.lock_action.call(light_id:, color:)
 
-      redirect to("/systems/#{current_system_id}/lights")
+      redirect system_url(current_system_id, "/lights")
     end
 
     patch "/systems/:system_id/lights/lock" do
       color = T.must(params[:color])
-      dependencies(current_system).lock_all_action.call(color:)
+      dependencies.lock_all_action.call(color:)
 
-      redirect to("/systems/#{current_system_id}/lights")
+      redirect system_url(current_system_id, "/lights")
     end
 
     delete "/systems/:system_id/lights/:light_id" do
       light_id = T.must(params[:light_id])
-      dependencies(current_system).remove_action.call(light_id:)
+      dependencies.remove_action.call(light_id:)
 
-      redirect to("/systems/#{current_system_id}/lights")
+      redirect system_url(current_system_id, "/lights")
     end
   end
 end

--- a/lib/stoplight/admin/helpers.rb
+++ b/lib/stoplight/admin/helpers.rb
@@ -9,8 +9,8 @@ module Stoplight
         Color::RED
       ].freeze
 
-      def dependencies(system)
-        Dependencies.new(system:)
+      def dependencies
+        Dependencies.new(system: current_system)
       end
 
       def system_url(system_id, path)
@@ -71,6 +71,10 @@ module Stoplight
 
       def current_system
         find_system(current_system_id)
+      end
+
+      def show_system_switcher?
+        settings.systems.size > 1
       end
     end
   end

--- a/lib/stoplight/admin/views/_card.erb
+++ b/lib/stoplight/admin/views/_card.erb
@@ -24,7 +24,7 @@
 
     <div class="flex-1 min-w-0 ms-4">
       <p class="text-sm font-medium text-gray-900 truncate dark:text-white">
-        <%= light.name %>
+        <%= CGI.escapeHTML(light.name) %>
       </p>
       <span class="flex items-center text-sm font-medium text-gray-500 dark:text-gray-400 truncate me-3">
         <span class="flex w-2.5 h-2.5 bg-<%= color %>-600 rounded-full me-1.5 shrink-0"></span>
@@ -104,9 +104,9 @@
   <div class="p-4 my-4 text-sm text-<%= color %>-800 rounded-lg bg-<%= color %>-50 dark:bg-gray-800 dark:text-<%= color %>-400">
     <div class="flex justify-between items-center">
       <div class="pr-4">
-        <p class="font-semibold"><%= light.description_title %></p>
-        <p class="font-medium"><%= light.description_message %></p>
-        <p><%= light.description_comment %></p>
+        <p class="font-semibold"><%= CGI.escapeHTML(light.description_title) %></p>
+        <p class="font-medium"><%= CGI.escapeHTML(light.description_message) %></p>
+        <p><%= CGI.escapeHTML(light.description_comment) %></p>
       </div>
       <% if light.latest_failure %>
         <div class="whitespace-nowrap text-center" style="margin-bottom: auto;">

--- a/lib/stoplight/admin/views/layout.erb
+++ b/lib/stoplight/admin/views/layout.erb
@@ -43,6 +43,28 @@
 
             <div class="hidden w-full md:block md:w-auto" id="navbar-default">
               <ul class="font-medium flex flex-col p-4 md:p-0 mt-4 border border-gray-100 rounded-lg bg-gray-50 md:flex-row md:space-x-8 rtl:space-x-reverse md:mt-0 md:border-0 md:bg-white dark:bg-gray-800 md:dark:bg-gray-900 dark:border-gray-700">
+                <% if show_system_switcher? %>
+                  <li class="relative me-2 mb-2">
+                    <button id="systemMenuButton" data-dropdown-toggle="systemMenu" type="button"
+                      class="flex items-center gap-2 py-2.5 px-4 text-sm font-medium text-gray-900 bg-white border border-gray-300 rounded-lg hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-gray-100 dark:bg-gray-800 dark:text-white dark:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700">
+                      <%= CGI.escapeHTML(current_system.name) %>
+                      <svg class="w-2.5 h-2.5 ms-1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6" fill="none">
+                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
+                      </svg>
+                    </button>
+                    <div id="systemMenu" class="z-10 hidden w-60 bg-white divide-y divide-gray-100 rounded-lg shadow-lg border border-gray-100 dark:bg-gray-700 dark:divide-gray-600 dark:border-gray-600">
+                      <ul class="py-2 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="systemMenuButton">
+                        <% settings.systems.each do |other_system| %>
+                          <li>
+                            <a href="<%= system_url(other_system.config.id, "/lights") %>" class="block px-4 py-2 <%= (other_system.config.id == current_system_id) ? "bg-blue-50 text-blue-700 dark:bg-gray-600 dark:text-white" : "hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white" %>">
+                              <%= CGI.escapeHTML(other_system.name) %>
+                            </a>
+                          </li>
+                        <% end %>
+                      </ul>
+                    </div>
+                  </li>
+                <% end %>
                 <% if count_red + count_yellow > 0 %>
                   <li>
                     <a <%= control_attributes(system_url(system_id, '/lights/lock?color=green'), verb: "patch") %> class="inline-flex items-center font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 border bg-white dark:bg-gray-800 <%= settings.read_only? ? "text-gray-400 border-gray-200 cursor-not-allowed dark:text-gray-500 dark:border-gray-700" : "text-gray-900 border-gray-300 focus:outline-none hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 dark:text-white dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:border-gray-600 dark:focus:ring-gray-700" %>">

--- a/sig/stoplight/admin.rbs
+++ b/sig/stoplight/admin.rbs
@@ -8,9 +8,7 @@ module Stoplight
 
     self.@systems: Array[Wiring::System]
     def self.add_system: (Wiring::System) -> void
-
-    private
-
-    def self.validate_persistent_system!: (Wiring::System) -> void
+    def self.__stoplight__reset_systems!: -> void
+    def self.validate_persistent_system!: (Wiring::System) -> Wiring::System
   end
 end

--- a/sig/stoplight/admin/helpers.rbs
+++ b/sig/stoplight/admin/helpers.rbs
@@ -3,14 +3,15 @@ module Stoplight
     module Helpers : Sinatra::Base
       COLORS: Array[Domain::color]
 
-      def dependencies: (Wiring::System)-> Dependencies
-      def system_url: (String system_id, String path) -> untyped
+      def dependencies: -> Dependencies
+      def system_url: (String system_id, String path) -> String
       def asset_path: (String) -> String
       def time_ago_in_words: (Time) -> String
       def control_attributes: (String href, ?confirm: String?, ?verb: String?) -> String
       def find_system: (String) -> Wiring::System
       def current_system_id: -> String
       def current_system: -> Wiring::System
+      def show_system_switcher?: -> bool
     end
   end
 end

--- a/spec/integration/admin_config_ru_spec.rb
+++ b/spec/integration/admin_config_ru_spec.rb
@@ -56,8 +56,9 @@ RSpec.describe "config.ru", :redis do
     Stoplight.register("foo")
     Stoplight.light("foo").run { "ok" }
     Stoplight.__stoplight__reset!
+    system_id = Stoplight.__stoplight__default_system.config.id
 
-    get "/"
+    get "/systems/#{system_id}/lights"
 
     expect(last_response.body).not_to include("No lights found")
   end

--- a/spec/unit/stoplight/admin/helpers_spec.rb
+++ b/spec/unit/stoplight/admin/helpers_spec.rb
@@ -19,8 +19,28 @@ RSpec.describe Stoplight::Admin::Helpers, :redis do
   end
 
   describe "#dependencies" do
-    it "returns Dependencies" do
-      expect(helper.dependencies(system)).to be_an_instance_of(Stoplight::Admin::Dependencies)
+    before { allow(helper).to receive(:current_system).and_return(system) }
+
+    it "returns Dependencies for the current system" do
+      expect(Stoplight::Admin::Dependencies).to receive(:new).with(system:).and_call_original
+
+      expect(helper.dependencies).to be_an_instance_of(Stoplight::Admin::Dependencies)
+    end
+  end
+
+  describe "#show_system_switcher?" do
+    context "with one system configured" do
+      it "returns false" do
+        expect(helper.show_system_switcher?).to be false
+      end
+    end
+
+    context "with more than one system configured" do
+      let(:systems) { [system, system] }
+
+      it "returns true" do
+        expect(helper.show_system_switcher?).to be true
+      end
     end
   end
 end

--- a/spec/unit/stoplight/admin_spec.rb
+++ b/spec/unit/stoplight/admin_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
   end
 
   after do
-    Stoplight::Admin.instance_variable_set(:@systems, [])
+    Stoplight::Admin.__stoplight__reset_systems!
   end
 
   describe ".add_system" do
@@ -30,9 +30,19 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
     end
   end
 
+  describe ".__stoplight__reset_systems!" do
+    it "clears every explicitly added system" do
+      expect(Stoplight::Admin.settings.systems).to eq([system])
+
+      Stoplight::Admin.__stoplight__reset_systems!
+
+      expect(Stoplight::Admin.settings.systems).to eq([Stoplight.__stoplight__default_system])
+    end
+  end
+
   describe ".systems" do
     context "when no system has been explicitly added" do
-      before { Stoplight::Admin.instance_variable_set(:@systems, []) }
+      before { Stoplight::Admin.__stoplight__reset_systems! }
 
       it "raises if the default system is not persistent" do
         allow(Stoplight).to receive(:__stoplight__default_system)
@@ -106,6 +116,21 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
 
       expect(last_response.status).to eq(302)
       expect(last_response.headers["location"]).to include("#{last_request.env["HTTP_HOST"]}/systems/#{system_id}/lights")
+    end
+
+    context "with more than one system configured" do
+      let(:other_data_store) { Stoplight::DataStore::Redis.new(redis) }
+      let(:other_system) { Stoplight.register_system(SecureRandom.uuid, data_store: other_data_store) }
+
+      before { Stoplight::Admin.add_system(other_system) }
+
+      it "redirects to the first-registered system's lights, not the last" do
+        get "/"
+
+        expect(last_response.status).to eq(302)
+        expect(last_response.headers["location"]).to include("/systems/#{system_id}/lights")
+        expect(last_response.headers["location"]).not_to include("/systems/#{other_system.config.id}/lights")
+      end
     end
   end
 
@@ -201,6 +226,20 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
         end
       end
 
+      context "when the light's name contains HTML" do
+        let(:light_name) { %(<script>alert("xss")</script>) }
+
+        before { light.run(&light_condition) }
+
+        it "escapes the light's name" do
+          get "/systems/#{system_id}/lights"
+
+          expect(last_response).to be_ok
+          expect(last_response.body).not_to include(light_name)
+          expect(last_response.body).to include(CGI.escapeHTML(light_name))
+        end
+      end
+
       context "when light has multiple consecutive failures" do
         let(:light) { system.register(SecureRandom.uuid) }
 
@@ -217,6 +256,82 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
 
           expect(last_response.body).to include(">Failures:</span> 3")
         end
+      end
+
+      context "when the latest failure's message contains HTML" do
+        let(:light) { system.register(SecureRandom.uuid) }
+        let(:failure_message) { %(<script>alert("xss")</script>) }
+
+        before { 3.times { light.run(->(_) {}) { raise failure_message } } }
+
+        it "escapes the failure message in the light's description" do
+          get "/systems/#{system_id}/lights"
+
+          expect(last_response).to be_ok
+          expect(last_response.body).not_to include(failure_message)
+          expect(last_response.body).to include(CGI.escapeHTML(failure_message))
+        end
+      end
+    end
+  end
+
+  describe "system switcher" do
+    context "with a single system configured" do
+      it "does not render the switcher" do
+        get "/systems/#{system_id}/lights"
+
+        expect(last_response).to be_ok
+        expect(last_response.body).not_to include("systemMenuButton")
+      end
+    end
+
+    context "with more than one system configured" do
+      let(:other_data_store) { Stoplight::DataStore::Redis.new(redis) }
+      let(:other_system) { Stoplight.register_system(SecureRandom.uuid, data_store: other_data_store) }
+      before { Stoplight::Admin.add_system(other_system) }
+
+      it "renders a switcher button and menu listing every configured system" do
+        get "/systems/#{system_id}/lights"
+
+        expect(last_response).to be_ok
+        expect(last_response.body).to include("systemMenuButton")
+        expect(last_response.body).to include(system.name)
+        expect(last_response.body).to include(other_system.name)
+      end
+
+      it "links each menu row to that system's dashboard" do
+        get "/systems/#{system_id}/lights"
+
+        host = last_request.env["HTTP_HOST"]
+        expect(last_response.body).to include(%(href="http://#{host}/systems/#{other_system.config.id}/lights"))
+      end
+
+      it "highlights the current system's row in the menu" do
+        get "/systems/#{system_id}/lights"
+
+        host = last_request.env["HTTP_HOST"]
+        expect(last_response.body).to include(
+          %(href="http://#{host}/systems/#{system_id}/lights" class="block px-4 py-2 bg-blue-50 text-blue-700)
+        )
+        expect(last_response.body).to include(
+          %(href="http://#{host}/systems/#{other_system.config.id}/lights" class="block px-4 py-2 hover:bg-gray-100)
+        )
+      end
+    end
+
+    context "when a system's name contains HTML" do
+      let(:other_data_store) { Stoplight::DataStore::Redis.new(redis) }
+      let(:other_system_name) { %(<script>alert("xss")</script>) }
+      let(:other_system) { Stoplight.register_system(other_system_name, data_store: other_data_store) }
+
+      before { Stoplight::Admin.add_system(other_system) }
+
+      it "escapes the other system's name in the switcher menu" do
+        get "/systems/#{system_id}/lights"
+
+        expect(last_response).to be_ok
+        expect(last_response.body).not_to include(other_system_name)
+        expect(last_response.body).to include(CGI.escapeHTML(other_system_name))
       end
     end
   end
@@ -267,9 +382,34 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
         )
       end
     end
+
+    context "with more than one system configured" do
+      let(:other_data_store) { Stoplight::DataStore::Redis.new(redis) }
+      let(:other_system) { Stoplight.register_system(SecureRandom.uuid, data_store: other_data_store) }
+      let(:other_light) { other_system.register(SecureRandom.uuid) }
+
+      before do
+        Stoplight::Admin.add_system(other_system)
+        other_light.run { "ok" }
+      end
+
+      it "returns only the first-registered system's lights, not the last" do
+        get "/stats"
+
+        expect(last_response).to be_ok
+        other_light_id = Stoplight::Domain::Id.for(other_light.name)
+        expect(response_body["lights"].map { |light| light["id"] }).not_to include(other_light_id)
+      end
+    end
   end
 
   describe "GET /systems/{system_id}/lights.json" do
+    it "returns not found for an unknown system_id" do
+      get "/systems/deadbeaf/lights.json"
+
+      expect(last_response).to be_not_found
+    end
+
     context "with no lights" do
       it "returns expected response" do
         get "/systems/#{system_id}/lights.json"
@@ -336,6 +476,12 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
 
       expect(last_response.status).to eq(404)
     end
+
+    it "returns not found for an unknown system_id" do
+      patch "/systems/deadbeaf/lights/#{light_id}/unlock"
+
+      expect(last_response).to be_not_found
+    end
   end
 
   describe "PATCH /systems/{system_id}/lights/{light_id}/lock" do
@@ -361,6 +507,12 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
       patch "/systems/#{system_id}/lights/#{SecureRandom.uuid}/lock", color: "green"
 
       expect(last_response.status).to eq(404)
+    end
+
+    it "returns not found for an unknown system_id" do
+      patch "/systems/deadbeaf/lights/#{light_id}/lock", color: "green"
+
+      expect(last_response).to be_not_found
     end
   end
 
@@ -399,6 +551,12 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
       expect(last_response.status).to eq(400)
       expect(light.state).to eq("locked_red")
     end
+
+    it "returns not found for an unknown system_id" do
+      patch "/systems/deadbeaf/lights/lock", color: "green"
+
+      expect(last_response).to be_not_found
+    end
   end
 
   describe "DELETE /systems/{system_id}/lights/{light_id}" do
@@ -419,6 +577,12 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
       get "/systems/#{system_id}/lights.json"
       expect(last_response).to be_ok
       expect(response_body.fetch("lights").map { |h| h.fetch("name") }).to contain_exactly("bar")
+    end
+
+    it "returns not found for an unknown system_id" do
+      delete "/systems/deadbeaf/lights/#{light_id}"
+
+      expect(last_response).to be_not_found
     end
   end
 


### PR DESCRIPTION
## Summary

#868 added system-scoped routes to the admin panel (`/systems/:system_id/lights` and friends), but there was no way to move between systems from the UI - you had to already know a system's id and edit the URL by hand. This adds a switcher dropdown.

<img width="1169" height="1052" alt="Screenshot 2026-08-06 at 17 28 34" src="https://github.com/user-attachments/assets/93a2138c-4791-43ce-b8cd-0f869b801635" />
<img width="1169" height="1052" alt="Screenshot 2026-08-06 at 17 28 36" src="https://github.com/user-attachments/assets/1734b2dc-e235-42fe-8d8d-d03afec2b40f" />
<img width="1169" height="1052" alt="Screenshot 2026-08-06 at 17 28 40" src="https://github.com/user-attachments/assets/1be2ff25-7398-4500-9ec8-fbf52873c0f4" />

When you have only one system - the drop down is not even displayed 