### PR TITLE
chore: Make meaningful default exception message

### DIFF
--- a/features/stoplight/basic_functionality.feature
+++ b/features/stoplight/basic_functionality.feature
@@ -19,7 +19,7 @@ Feature: Stoplight Basic Functionality
     When 1 request is made
     Then the light fails with error:
       | Type        | Stoplight::Error::RedLight |
-      | Message     | basic-service |
+      | Message     | Stoplight "basic-service" is red - network traffic stopped until recovery. |
 
   Scenario: Light count all failures regardless of time
     Given the service starts failing with "connection-timeout"

--- a/features/stoplight/basic_functionality.feature
+++ b/features/stoplight/basic_functionality.feature
@@ -19,7 +19,7 @@ Feature: Stoplight Basic Functionality
     When 1 request is made
     Then the light fails with error:
       | Type        | Stoplight::Error::RedLight |
-      | Message     | Stoplight "basic-service" is red - network traffic stopped until recovery. |
+      | Message     | Stoplight "basic-service" is red - traffic stopped until recovery. |
 
   Scenario: Light count all failures regardless of time
     Given the service starts failing with "connection-timeout"

--- a/features/stoplight/state_control.feature
+++ b/features/stoplight/state_control.feature
@@ -26,7 +26,7 @@ Feature: Stoplight State Control
     And 1 request is made
     Then the light fails with error:
       | Type        | Stoplight::Error::RedLight |
-      | Message     | manual-control             |
+      | Message     | Stoplight "manual-control" is red - network traffic stopped until recovery. |
     And the light color is red
     And the light is in "locked_red" state
 

--- a/features/stoplight/state_control.feature
+++ b/features/stoplight/state_control.feature
@@ -26,7 +26,7 @@ Feature: Stoplight State Control
     And 1 request is made
     Then the light fails with error:
       | Type        | Stoplight::Error::RedLight |
-      | Message     | Stoplight "manual-control" is red - network traffic stopped until recovery. |
+      | Message     | Stoplight "manual-control" is red - traffic stopped until recovery. |
     And the light color is red
     And the light is in "locked_red" state
 

--- a/lib/stoplight/error.rb
+++ b/lib/stoplight/error.rb
@@ -18,7 +18,7 @@ module Stoplight
     end
 
     class RedLight < Base
-      EXCEPTION_MESSAGE = 'Stoplight "%{light_name}" is red - network traffic stopped until recovery.'
+      EXCEPTION_MESSAGE = 'Stoplight "%{light_name}" is red - traffic stopped until recovery.'
       private_constant :EXCEPTION_MESSAGE
 
       # @!attribute light_name

--- a/lib/stoplight/error.rb
+++ b/lib/stoplight/error.rb
@@ -18,6 +18,9 @@ module Stoplight
     end
 
     class RedLight < Base
+      EXCEPTION_MESSAGE = 'Stoplight "%{light_name}" is red - network traffic stopped until recovery.'
+      private_constant :EXCEPTION_MESSAGE
+
       # @!attribute light_name
       #   @return [String] The light's name
       attr_reader :light_name
@@ -45,7 +48,7 @@ module Stoplight
         @cool_off_time = cool_off_time
         @retry_after = retry_after
 
-        super(light_name)
+        super(format(EXCEPTION_MESSAGE, light_name: light_name))
       end
     end
   end

--- a/sig/stoplight/error.rbs
+++ b/sig/stoplight/error.rbs
@@ -16,6 +16,8 @@ module Stoplight
     end
 
     class RedLight < Base
+      EXCEPTION_MESSAGE: String
+
       attr_reader light_name: String
       attr_reader cool_off_time: Numeric
       attr_reader retry_after: Time?

--- a/spec/unit/stoplight/domain/run_strategies/red_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/red_run_strategy_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe Stoplight::Domain::Strategies::RedRunStrategy, :freeze do
     let(:fallback) { nil }
 
     it "records and raises the error" do
-      expect { result }.to raise_error(Stoplight::Error::RedLight, name) { |error|
+      expect { result }.to raise_error(Stoplight::Error::RedLight) { |error|
+        expect(error.light_name).to eq(name)
         expect(error.cool_off_time).to eq(cool_off_time)
         expect(error.retry_after).to eq(state_snapshot.recovery_scheduled_after)
       }

--- a/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
@@ -281,7 +281,8 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
 
         it "raises RedLight without yielding" do
           expect do |code|
-            expect { strategy.execute(fallback, state_snapshot:, error_tracking_policy:, &code) }.to raise_error(Stoplight::Error::RedLight, name) { |error|
+            expect { strategy.execute(fallback, state_snapshot:, error_tracking_policy:, &code) }.to raise_error(Stoplight::Error::RedLight) { |error|
+              expect(error.light_name).to eq(name)
               expect(error.cool_off_time).to eq(cool_off_time)
               expect(error.retry_after).to eq(state_snapshot.recovery_scheduled_after)
             }
@@ -302,7 +303,9 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
           expect do
             expect do
               strategy.execute(fallback, state_snapshot:, error_tracking_policy:) {}
-            end.to raise_error(Stoplight::Error::RedLight, name)
+            end.to raise_error(Stoplight::Error::RedLight) { |error|
+              expect(error.light_name).to eq(name)
+            }
           end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
             outcome: :blocked,
             color: "yellow",

--- a/spec/unit/stoplight/error_spec.rb
+++ b/spec/unit/stoplight/error_spec.rb
@@ -33,5 +33,18 @@ RSpec.describe Stoplight::Error do
     it "is a subclass of StandardError" do
       expect(described_class::RedLight).to be < described_class::Base
     end
+
+    it "record correct exception message with a light name" do
+      error = described_class::RedLight.new("example-zero", cool_off_time: 60, retry_after: nil)
+
+      expect(error.message).to eq('Stoplight "example-zero" is red - network traffic stopped until recovery.')
+    end
+
+    it "exposes the error metadata" do
+      retry_after = Time.now + 60
+      error = described_class::RedLight.new("example-zero", cool_off_time: 60, retry_after:)
+
+      expect(error).to have_attributes(light_name: "example-zero", cool_off_time: 60, retry_after:)
+    end
   end
 end

--- a/spec/unit/stoplight/error_spec.rb
+++ b/spec/unit/stoplight/error_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe Stoplight::Error do
   end
 
   describe "::RedLight" do
+    let(:light_name) { "holy_light" }
+    let(:cool_off_time) { 60 }
+    let(:retry_after) { Time.now + 60 }
+
     it "is a class" do
       expect(described_class::RedLight).to be_a(Class)
     end
@@ -35,16 +39,15 @@ RSpec.describe Stoplight::Error do
     end
 
     it "record correct exception message with a light name" do
-      error = described_class::RedLight.new("example-zero", cool_off_time: 60, retry_after: nil)
+      error = described_class::RedLight.new(light_name, cool_off_time:, retry_after:)
 
-      expect(error.message).to eq('Stoplight "example-zero" is red - network traffic stopped until recovery.')
+      expect(error.message).to eq("Stoplight \"#{light_name}\" is red - network traffic stopped until recovery.")
     end
 
     it "exposes the error metadata" do
-      retry_after = Time.now + 60
-      error = described_class::RedLight.new("example-zero", cool_off_time: 60, retry_after:)
+      error = described_class::RedLight.new(light_name, cool_off_time:, retry_after:)
 
-      expect(error).to have_attributes(light_name: "example-zero", cool_off_time: 60, retry_after:)
+      expect(error).to have_attributes(light_name:, cool_off_time:, retry_after:)
     end
   end
 end

--- a/spec/unit/stoplight/error_spec.rb
+++ b/spec/unit/stoplight/error_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Stoplight::Error do
     it "record correct exception message with a light name" do
       error = described_class::RedLight.new(light_name, cool_off_time:, retry_after:)
 
-      expect(error.message).to eq("Stoplight \"#{light_name}\" is red - network traffic stopped until recovery.")
+      expect(error.message).to eq("Stoplight \"#{light_name}\" is red - traffic stopped until recovery.")
     end
 
     it "exposes the error metadata" do


### PR DESCRIPTION
# Description

This PR aims to make meaningful deafult exception message for the Stoplight RedLight Exception.
At the moment, we return light name in the exception message, which might confuse people who rescue exception and send them to Sentry in a way like this:
```ruby
def call
# ...
rescue Stoplight::Error::RedLight => e
  IssueReporter.warn("Failure", message: e.message)
end
```
Given that Stoplight provides sensible defaults, I believe that we should provide a more meaningful default error message.

I suggest using something like `Stoplight "%{light_name}" is red - network traffic stopped until recovery.`.