### PR TITLE
Age the Memory metrics window on the monotonic clock

### DIFF
--- a/docs/data_storages.md
+++ b/docs/data_storages.md
@@ -42,6 +42,11 @@ run are meaningful regardless of which backend they run against. If you change b
 in one backend, change it in all of them (and add/adjust the property or integration
 spec that pins the invariant).
 
+Known exception: the Memory backend ages its metrics window on the monotonic clock,
+so wall-clock steps (NTP) cannot corrupt it. Redis windows stay on wall time because
+monotonic readings are not comparable across hosts; under a wall-clock step the two
+backends can briefly disagree about window membership.
+
 ## Backward compatibility
 
 Don't change a backend's key layout without a deliberate deprecation - existing users

--- a/features/stoplight/support/env.rb
+++ b/features/stoplight/support/env.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 require "stoplight"
+require "timecop"
 require_relative "stoplight_world"
 require_relative "configure_light_world"
 require_relative "stoplight_assertion_helpers"
+
+# Window buckets age on the monotonic clock; travel/freeze must move it too.
+Timecop.mock_process_clock = true
 
 Before do
   Timecop.return

--- a/lib/stoplight/infrastructure/memory/storage/window_metrics.rb
+++ b/lib/stoplight/infrastructure/memory/storage/window_metrics.rb
@@ -83,9 +83,8 @@ module Stoplight
           end
 
           def build_metrics_snapshot
-            window_start = (@clock.current_time - @window_size)
-            errors = @errors.sum_in_window(window_start)
-            successes = @successes.sum_in_window(window_start)
+            errors = @errors.sum_in_window(@window_size)
+            successes = @successes.sum_in_window(@window_size)
 
             Domain::MetricsSnapshot.new(
               errors:,

--- a/lib/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rb
+++ b/lib/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rb
@@ -26,14 +26,14 @@ module Stoplight
               @clock = clock
             end
 
-            # Increment the count at a given timestamp
+            # Increment the count at the current monotonic second
             def increment
               @buckets[current_bucket] += 1
               @running_sum += 1
             end
 
-            def sum_in_window(window_start)
-              slide_window!(window_start)
+            def sum_in_window(window_size)
+              slide_window!(monotonic_seconds - window_size)
               @running_sum
             end
 
@@ -58,11 +58,13 @@ module Stoplight
             end
 
             def current_bucket
-              bucket_for_time(@clock.current_time)
+              monotonic_seconds.to_i
             end
 
-            def bucket_for_time(time)
-              time.to_i
+            # Monotonic, so a wall-clock step (NTP) cannot break FIFO eviction;
+            # the clock port returns float milliseconds.
+            def monotonic_seconds
+              @clock.monotonic_time / 1000.0
             end
           end
         end

--- a/sig/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rbs
+++ b/sig/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rbs
@@ -12,13 +12,13 @@ module Stoplight
 
             def increment: -> void
 
-            def sum_in_window: (Time window_start) -> Integer
+            def sum_in_window: (Domain::duration_seconds window_size) -> Integer
 
-            private def slide_window!: (Time window_start) -> void
+            private def slide_window!: (Float window_start) -> void
 
             private def current_bucket: -> Integer
 
-            private def bucket_for_time: (Time time) -> Integer
+            private def monotonic_seconds: -> Float
 
             def inspect: -> String
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,8 @@ require_relative "support/route_helpers"
 require_relative "support/matchers/emit"
 
 Timecop.safe_mode = true
+# Window buckets age on the monotonic clock; travel/freeze must move it too.
+Timecop.mock_process_clock = true
 
 require File.expand_path("dummy/config/environment", __dir__)
 require "ammeter/init"

--- a/spec/unit/stoplight/infrastructure/data_store/window_metrics_snapshot.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/window_metrics_snapshot.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples "a window metrics snapshot" do
         let(:window_size) { 5000 }
 
         before do
-          Timecop.freeze(Time.now - window_size - 10) do
+          Timecop.freeze(-window_size - 10) do
             record_success
           end
         end
@@ -27,7 +27,7 @@ RSpec.shared_examples "a window metrics snapshot" do
         let(:window_size) { 5000 }
 
         before do
-          Timecop.freeze(Time.now - window_size - 10) do
+          Timecop.freeze(-window_size - 10) do
             record_failure(error)
           end
         end

--- a/spec/unit/stoplight/infrastructure/memory/storage/window_metrics/sliding_window_spec.rb
+++ b/spec/unit/stoplight/infrastructure/memory/storage/window_metrics/sliding_window_spec.rb
@@ -1,69 +1,67 @@
 # frozen_string_literal: true
 
 RSpec.describe Stoplight::Infrastructure::Memory::Storage::WindowMetrics::SlidingWindow do
-  let(:counter) { described_class.new(clock:) }
-  let(:clock) { Stoplight::Infrastructure::SystemClock.new }
+  subject(:counter) { described_class.new(clock:) }
 
-  around do |example|
-    Timecop.freeze do
-      example.run
-    end
+  let(:clock) { instance_double(NullClock) }
+
+  # Position the monotonic clock at an absolute second.
+  def at(seconds)
+    allow(clock).to receive(:monotonic_time).and_return(seconds * 1000.0)
   end
 
   describe "#increment" do
     it "increments the count for the given time" do
+      at(100)
       counter.increment
       counter.increment
       counter.increment
 
-      expect(counter.sum_in_window(Time.now - 10)).to eq(3)
+      expect(counter.sum_in_window(10)).to eq(3)
     end
 
     it "when empty returns zero sum" do
-      expect(counter.sum_in_window(Time.now)).to eq(0)
-      expect(counter.sum_in_window(Time.now - 100)).to eq(0)
-      expect(counter.sum_in_window(Time.now - 10000)).to eq(0)
+      at(100)
+      expect(counter.sum_in_window(0)).to eq(0)
+      expect(counter.sum_in_window(100)).to eq(0)
+      expect(counter.sum_in_window(10000)).to eq(0)
     end
 
     it "increments the count for the different seconds" do
-      Timecop.freeze(Time.now - 2) do
-        counter.increment
-        counter.increment
-      end
-      Timecop.freeze(Time.now - 1) do
-        counter.increment
-        counter.increment
-      end
-      Timecop.freeze(Time.now) do
-        counter.increment
-      end
+      at(98)
+      counter.increment
+      counter.increment
+      at(99)
+      counter.increment
+      counter.increment
+      at(100)
+      counter.increment
 
-      expect(counter.sum_in_window(Time.now - 2)).to eq(5)
-      expect(counter.sum_in_window(Time.now - 1)).to eq(3)
-      expect(counter.sum_in_window(Time.now)).to eq(1)
+      expect(counter.sum_in_window(2)).to eq(5)
+      expect(counter.sum_in_window(1)).to eq(3)
+      expect(counter.sum_in_window(0)).to eq(1)
     end
 
     it "increments the count for the different sparsely distributed seconds" do
-      Timecop.freeze(Time.now - 20) do
-        counter.increment
-      end
-      Timecop.freeze(Time.now - 10) do
-        counter.increment
-      end
-      Timecop.freeze(Time.now - 5) do
-        counter.increment
-      end
+      at(80)
+      counter.increment
+      at(90)
+      counter.increment
+      at(95)
+      counter.increment
+      at(100)
 
-      expect(counter.sum_in_window(Time.now - 60)).to eq(3)
-      expect(counter.sum_in_window(Time.now - 15)).to eq(2)
-      expect(counter.sum_in_window(Time.now - 5)).to eq(1)
-      expect(counter.sum_in_window(Time.now - 2)).to eq(0)
+      expect(counter.sum_in_window(60)).to eq(3)
+      expect(counter.sum_in_window(15)).to eq(2)
+      expect(counter.sum_in_window(5)).to eq(1)
+      expect(counter.sum_in_window(2)).to eq(0)
     end
   end
 
   describe "#sum_in_window" do
     it "returns zero when no increments in the window" do
-      expect(counter.sum_in_window(Time.now)).to eq(0)
+      at(100)
+      expect(counter.sum_in_window(0)).to eq(0)
     end
   end
 end

--- a/spec/unit/stoplight/infrastructure/memory/storage/window_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/memory/storage/window_metrics_spec.rb
@@ -13,4 +13,50 @@ RSpec.describe Stoplight::Infrastructure::Memory::Storage::WindowMetrics do
     def record_failure(error) = metrics.record_failure(error)
     def record_success = metrics.record_success
   end
+
+  describe "#record_success" do
+    let(:clock) { instance_double(NullClock) }
+
+    it "reads each clock once" do
+      expect(clock).to receive(:current_time).once.and_return(Time.utc(2026, 8, 7))
+      expect(clock).to receive(:monotonic_time).once.and_return(1_000.0)
+
+      metrics.record_success
+    end
+  end
+
+  describe "#record_failure" do
+    let(:clock) { instance_double(NullClock) }
+    let(:current_time) { Time.utc(2026, 8, 7) }
+
+    it "reads the wall clock once and uses it for the failure" do
+      expect(clock).to receive(:current_time).once.and_return(current_time)
+      allow(clock).to receive(:monotonic_time).and_return(1_000.0)
+
+      snapshot = metrics.record_failure(StandardError.new)
+
+      expect(snapshot.last_error).to have_attributes(occurred_at: current_time)
+    end
+  end
+
+  describe "#metrics_snapshot" do
+    context "when the wall clock steps backwards between recordings" do
+      let(:clock) { instance_double(NullClock) }
+      let(:window_size) { 60 }
+
+      it "expires events by elapsed time, not wall time" do
+        t0 = Time.utc(2026, 8, 7, 12, 0, 0)
+        mono = 1_000.0
+        allow(clock).to receive(:monotonic_time) { mono }
+        allow(clock).to receive(:current_time).and_return(t0, t0 - 300)
+
+        metrics.record_failure(StandardError.new)
+        mono = 31_000.0
+        metrics.record_failure(StandardError.new)
+        mono = 62_000.0
+
+        expect(metrics.metrics_snapshot.errors).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/unit/stoplight/infrastructure/system_clock_spec.rb
+++ b/spec/unit/stoplight/infrastructure/system_clock_spec.rb
@@ -18,10 +18,6 @@ RSpec.describe Stoplight::Infrastructure::SystemClock do
   describe "#monotonic_time" do
     subject(:monotonic_time) { clock.monotonic_time }
 
-    around do |example|
-      Timecop.freeze { example.run }
-    end
-
     it "returns monotonic time in milliseconds" do
       expect(monotonic_time).to be_within(10).of(Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond))
     end


### PR DESCRIPTION
Closes #779

`SlidingWindow` now owns the clock domain: buckets key on monotonic seconds and `sum_in_window(window_size)` takes a duration, so callers cannot feed wall timestamps into the window. `WindowMetrics#build_metrics_snapshot` loses its wall read; `record_success` and `record_failure` are unchanged from develop.

Reason : Wall clock can corrupt FIFO eviction: a backward NTP step inserts an older-keyed bucket behind newer ones where `slide_window!` never reaches it, so it outlives the window. Monotonic keys make the nondecreasing invariant hold by construction.

Re: the original goal, each record op reads the wall clock exactly once, now pinned by specs. The internal monotonic reads are allocation-free and cheap (144ns vs 345ns for `Time.now.utc`).

Benchs:

| op | time | allocs/op |
|---|---|---|
| record_success | 1.2µs -> 1.1µs | 2 -> 1 |
| record_failure | 4.5–4.8µs -> 4.3µs | 15.1 -> 12.1 |
| metrics_snapshot | 2.7µs -> 2.5µs | 10 -> 8 |
| Light#run success path | parity | 5.0 -> 4.0 |

Tests:

A regression spec pins that events expire by elapsed time when the wall clock steps backwards. The suites set `Timecop.mock_process_clock = true` so travel and freeze move the monotonic lane; the "outside the running window" shared examples use timecop's relative form (`Timecop.freeze(-window_size - 10)`) because freezing to a `Time` target deliberately leaves the monotonic clock unshifted. 

`system_clock_spec`'s monotonic example no longer freezes: with the process clock mocked, a frozen assertion compares the mock to itself. `sliding_window_spec` drives the injected clock to absolute seconds instead of nesting Timecop blocks.
