### PR TITLE
Reduce space consumed by windowed metrics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stoplight (5.8.2)
+    stoplight (5.8.3)
       concurrent-ruby
       zeitwerk
 

--- a/lib/stoplight/infrastructure/redis/data_store.rb
+++ b/lib/stoplight/infrastructure/redis/data_store.rb
@@ -242,7 +242,7 @@ module Stoplight
 
           scripting.call(
             :record_failure,
-            args: [current_ts, SecureRandom.hex(12), serialize_failure(failure), metrics_ttl, metadata_ttl],
+            args: [current_ts, SecureRandom.hex(12), serialize_failure(failure), metrics_ttl(config), metadata_ttl],
             keys: [
               metadata_key(config),
               config.window_size && errors_key(config, time: current_ts)
@@ -255,7 +255,7 @@ module Stoplight
 
           scripting.call(
             :record_success,
-            args: [current_ts, request_id, metrics_ttl, metadata_ttl],
+            args: [current_ts, request_id, metrics_ttl(config), metadata_ttl],
             keys: [
               metadata_key(config),
               config.window_size && successes_key(config, time: current_ts)
@@ -481,8 +481,8 @@ module Stoplight
         METRICS_TTL = 86400 # 1 day
         private_constant :METRICS_TTL
 
-        private def metrics_ttl
-          METRICS_TTL
+        private def metrics_ttl(config)
+          config.window_size || METRICS_TTL
         end
 
         METADATA_TTL = 86400 * 7 # 7 days

--- a/lib/stoplight/version.rb
+++ b/lib/stoplight/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stoplight
-  VERSION = Gem::Version.new("5.8.2")
+  VERSION = Gem::Version.new("5.8.3")
 end

--- a/sig/_private/stoplight/infrastructure/redis/data_store.rbs
+++ b/sig/_private/stoplight/infrastructure/redis/data_store.rbs
@@ -57,7 +57,7 @@ module Stoplight
         private def errors_key: (Domain::Config config, time: Time) -> String
         private def recovery_metrics_key: (Domain::Config config) -> String
         private def metadata_key: (Domain::Config config) -> String
-        private def metrics_ttl: -> Integer
+        private def metrics_ttl: (Domain::Config) -> Integer
         private def metadata_ttl: -> Integer
         private def detect_clock_skew: -> void
         private def should_sample?: (Float) -> bool

--- a/spec/unit/stoplight/infrastructure/redis/data_store_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/data_store_spec.rb
@@ -194,6 +194,70 @@ RSpec.describe Stoplight::Infrastructure::Redis::DataStore, :redis do
       def state_snapshot = data_store.get_state_snapshot(config)
       def clear = data_store.delete_light(config)
     end
+
+    describe "#record_failure" do
+      context "without window_size" do
+        let(:window_size) { nil }
+
+        it "uses default value as metrics_ttl when calling scripting" do
+          expect(scripting).to receive(:call).with(
+            :record_failure,
+            hash_including(
+              args: array_including(86_400)
+            )
+          ).and_call_original
+
+          data_store.record_failure(config, StandardError.new)
+        end
+      end
+
+      context "with window_size" do
+        let(:window_size) { 333 }
+
+        it "uses window_size as metrics_ttl when calling scripting" do
+          expect(scripting).to receive(:call).with(
+            :record_failure,
+            hash_including(
+              args: array_including(window_size)
+            )
+          ).and_call_original
+
+          data_store.record_failure(config, StandardError.new)
+        end
+      end
+    end
+
+    describe "#record_success" do
+      context "without window_size" do
+        let(:window_size) { nil }
+
+        it "uses default value as metrics_ttl when calling scripting" do
+          expect(scripting).to receive(:call).with(
+            :record_success,
+            hash_including(
+              args: array_including(86_400)
+            )
+          ).and_call_original
+
+          data_store.record_success(config)
+        end
+      end
+
+      context "with window_size" do
+        let(:window_size) { 333 }
+
+        it "uses window_size as metrics_ttl when calling scripting" do
+          expect(scripting).to receive(:call).with(
+            :record_success,
+            hash_including(
+              args: array_including(window_size)
+            )
+          ).and_call_original
+
+          data_store.record_success(config)
+        end
+      end
+    end
   end
 
   it_behaves_like Stoplight::Infrastructure::Redis::DataStore do


### PR DESCRIPTION
Fixes #872 

### Summary 

Fix PR reduce Redis memory consumption for error rate strategy.

### Background 

Under the hood we use 1 hour bucketed ZSETs to store metrics. For example:

- `metrics.{light_name}.success:1786176000`
- `metrics.{light_name}.success:1786179600`
- `metrics.{light_name}.success:1786183200`

Each bucket stores a full list of requests performed during this 1 hour window. This allows performing very precise calculations as cardinality of every bucket could be calculated with `O(log(N))` time complexity, yet accessing a few Redis keys per call (typically 1-2).

This comes with the memory cost - we store every request attempt as a 12-char string and memory could accumulate really fast on a busy light. 

### Solution 

Before that fix windowed metrics' memory consumption scaled lineraly with number of request regardless the used window. This fix expire stored metrics when window itself expire making space consumption proportional to window_size.

**Note**: the problem is already fixed in the develop branch, but since develop accumulated breaking changes, this PR targets main directly.