### PR TITLE
Fix state snapshot yellow color computation logic

### DIFF
--- a/lib/stoplight/domain/state_snapshot.rb
+++ b/lib/stoplight/domain/state_snapshot.rb
@@ -29,7 +29,7 @@ module Stoplight
           Color::GREEN
         elsif locked_state == State::LOCKED_RED
           Color::RED
-        elsif (recovery_scheduled_after && recovery_scheduled_after! < time) || recovery_started_at
+        elsif (recovery_scheduled_after && recovery_scheduled_after! < time) || recovery_started?
           Color::YELLOW
         elsif breached_at
           Color::RED

--- a/lib/stoplight/domain/state_snapshot.rb
+++ b/lib/stoplight/domain/state_snapshot.rb
@@ -44,11 +44,7 @@ module Stoplight
       # This method indicates whether the recovery has already started explicitly
       #
       def recovery_started?
-        if recovery_started_at.nil?
-          false
-        else
-          recovery_started_at! <= time
-        end
+        !!recovery_started_at
       end
 
       def recovery_started_at!

--- a/spec/unit/stoplight/domain/state_snapshot_spec.rb
+++ b/spec/unit/stoplight/domain/state_snapshot_spec.rb
@@ -46,17 +46,17 @@ RSpec.describe Stoplight::Domain::StateSnapshot do
       it { is_expected.to be(Stoplight::Color::YELLOW) }
     end
 
-    context "when threshold is breached and recovery is in the future" do
-      let(:breached_at) { time - 3 }
-      let(:recovery_started_at) { time + 3 }
-
-      it { is_expected.to be(Stoplight::Color::RED) }
-    end
 
     context "when threshold breached" do
       let(:breached_at) { time - 3 }
 
       it { is_expected.to be(Stoplight::Color::RED) }
+
+      context "when recovery is in the future" do
+        let(:recovery_started_at) { time + 3 }
+
+        it { is_expected.to be(Stoplight::Color::RED) }
+      end
     end
   end
 end

--- a/spec/unit/stoplight/domain/state_snapshot_spec.rb
+++ b/spec/unit/stoplight/domain/state_snapshot_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe Stoplight::Domain::StateSnapshot do
       it { is_expected.to be(Stoplight::Color::YELLOW) }
     end
 
+    context "when recovery is in the future due to clock skew" do
+      let(:recovery_started_at) { time + 3 }
+
+      it { is_expected.to be(Stoplight::Color::YELLOW) }
+    end
+
     context "when threshold breached" do
       let(:breached_at) { time - 3 }
 

--- a/spec/unit/stoplight/domain/state_snapshot_spec.rb
+++ b/spec/unit/stoplight/domain/state_snapshot_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe Stoplight::Domain::StateSnapshot do
       it { is_expected.to be(Stoplight::Color::YELLOW) }
     end
 
+    context "when threshold is breached and recovery is in the future" do
+      let(:breached_at) { time - 3 }
+      let(:recovery_started_at) { time + 3 }
+
+      it { is_expected.to be(Stoplight::Color::RED) }
+    end
+
     context "when threshold breached" do
       let(:breached_at) { time - 3 }
 

--- a/spec/unit/stoplight/domain/state_snapshot_spec.rb
+++ b/spec/unit/stoplight/domain/state_snapshot_spec.rb
@@ -46,17 +46,10 @@ RSpec.describe Stoplight::Domain::StateSnapshot do
       it { is_expected.to be(Stoplight::Color::YELLOW) }
     end
 
-
     context "when threshold breached" do
       let(:breached_at) { time - 3 }
 
       it { is_expected.to be(Stoplight::Color::RED) }
-
-      context "when recovery is in the future" do
-        let(:recovery_started_at) { time + 3 }
-
-        it { is_expected.to be(Stoplight::Color::RED) }
-      end
     end
   end
 end


### PR DESCRIPTION
Fix discrepancy in logic found in the way color calculates yellow. Previously it checks whether or not  `recovery_started_at` is truthy or not. But there is another function `recovery_started?` that has additional logic of checking whether or not `recovery_started_at` is in the future or not. Therefore, the color computation also uses this function to avoid drift further down the line.

Fixes #782 