### PR TITLE
Wire RecoveryProbeCompleted event (#746)

### DIFF
--- a/lib/stoplight/domain/strategies/yellow_run_strategy.rb
+++ b/lib/stoplight/domain/strategies/yellow_run_strategy.rb
@@ -104,7 +104,7 @@ module Stoplight
         end
 
         def capture_started_at
-          @clock.monotonic_time if @run_recorder.subscribed?
+          @clock.monotonic_time if @run_recorder.subscribed? || request_tracker.subscribed?
         end
 
         def duration_since(started_at)
@@ -113,12 +113,12 @@ module Stoplight
 
         def record_recovery_probe_success(duration_ms:, error: nil)
           @run_recorder.record_success(duration_ms:, error:)
-          request_tracker.record_success
+          request_tracker.record_success(duration_ms:)
         end
 
         def record_recovery_probe_failure(error, duration_ms:, fallback_used:)
           @run_recorder.record_failure(error, duration_ms:, fallback_used:)
-          request_tracker.record_failure(error)
+          request_tracker.record_failure(error, duration_ms:)
         end
 
         def enter_recovery(state_snapshot)

--- a/lib/stoplight/domain/tracker/recovery_probe.rb
+++ b/lib/stoplight/domain/tracker/recovery_probe.rb
@@ -13,17 +13,20 @@ module Stoplight
           @emitter = emitter
         end
 
+        # True when any subscriber would receive a RecoveryProbeCompleted event.
+        def subscribed? = emitter.subscribed?(Telemetry::RecoveryProbeCompleted)
+
         # @param exception [Exception]
-        def record_failure(exception)
+        def record_failure(exception, duration_ms:)
           metrics_store.record_failure(exception)
 
-          recover
+          recover(outcome: :failure, duration_ms:, failure: Telemetry::Failure.new(exception:, tracked: true))
         end
 
-        def record_success
+        def record_success(duration_ms:)
           metrics_store.record_success
 
-          recover
+          recover(outcome: :success, duration_ms:, failure: nil)
         end
 
         private
@@ -35,8 +38,23 @@ module Stoplight
         attr_reader :state_store
         attr_reader :emitter
 
-        def recover
+        def recover(outcome:, duration_ms:, failure:)
           recovery_metrics = metrics_store.metrics_snapshot
+
+          # Fires on every probe, whatever the outcome - it's a per-probe measurement, not a
+          # state transition, so there's no dedup guard here.
+          emitter.emit(Telemetry::RecoveryProbeCompleted) do
+            Telemetry::RecoveryProbeCompleted.new(
+              outcome:, duration_ms:, failure:,
+              progress: Telemetry::Metrics.new(
+                successes: recovery_metrics.successes,
+                errors: recovery_metrics.errors,
+                consecutive_errors: recovery_metrics.consecutive_errors,
+                consecutive_successes: recovery_metrics.consecutive_successes
+              )
+            )
+          end
+
           recovery_result = traffic_recovery.determine_color(config, recovery_metrics)
 
           return if recovery_result == TrafficRecovery::YELLOW

--- a/sig/stoplight/domain/telemetry/recovery_probe_completed.rbs
+++ b/sig/stoplight/domain/telemetry/recovery_probe_completed.rbs
@@ -4,22 +4,23 @@ module Stoplight
       # Emitted for every recovery probe.
       class RecoveryProbeCompleted < Data
         attr_reader outcome: probe_outcome
-        # Latency of the recovering dependency.
-        attr_reader duration_ms: Float
+        # Latency of the recovering dependency. nil when nobody was subscribed at the start of the
+        # probe (same measurement race as RunCompleted#duration_ms).
+        attr_reader duration_ms: Float?
         attr_reader failure: Failure?
         # Recovery metrics after this probe.
         attr_reader progress: Metrics
 
         def self.new: (
             outcome: probe_outcome,
-            duration_ms: Float,
+            duration_ms: Float?,
             failure: Failure?,
             progress: Metrics
           ) -> instance
 
         def initialize: (
             outcome: probe_outcome,
-            duration_ms: Float,
+            duration_ms: Float?,
             failure: Failure?,
             progress: Metrics
           ) -> void

--- a/sig/stoplight/domain/tracker/recovery_probe.rbs
+++ b/sig/stoplight/domain/tracker/recovery_probe.rbs
@@ -18,9 +18,10 @@ module Stoplight
           emitter: Telemetry::Emitter,
         ) -> void
 
-        def record_failure: (StandardError exception) -> void
-        def record_success: -> void
-        def recover: -> void
+        def subscribed?: () -> bool
+        def record_failure: (StandardError exception, duration_ms: duration_ms?) -> void
+        def record_success: (duration_ms: duration_ms?) -> void
+        def recover: (outcome: Telemetry::probe_outcome, duration_ms: duration_ms?, failure: Telemetry::Failure?) -> void
         def transition: (from_color: color, to_color: color) -> bool
       end
     end

--- a/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
@@ -67,6 +67,27 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
             retry_after: nil
           )
         end
+
+        it "hands the measured duration to the recovery probe" do
+          allow(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
+          expect(clock).to receive(:monotonic_time).and_return(1.4, 2.2)
+          expect(request_tracker).to receive(:record_success).with(duration_ms: be_within(0.00001).of(0.8))
+
+          result
+        end
+
+        context "when only the recovery probe is subscribed" do
+          let(:run_recorder) { instance_double(Stoplight::Domain::Telemetry::RunRecorder, subscribed?: false, record_success: nil) }
+
+          it "still measures the probe duration" do
+            allow(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
+            allow(request_tracker).to receive(:subscribed?).and_return(true)
+            expect(clock).to receive(:monotonic_time).and_return(1.4, 2.2)
+            expect(request_tracker).to receive(:record_success).with(duration_ms: be_within(0.00001).of(0.8))
+
+            expect(result).to eq("Success")
+          end
+        end
       end
 
       context "when nobody is subscribed to telemetry" do
@@ -75,8 +96,12 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
         let(:code) { -> { "Success" } }
         let(:run_recorder) { instance_double(Stoplight::Domain::Telemetry::RunRecorder, subscribed?: false, record_success: nil) }
 
+        before do
+          allow(request_tracker).to receive(:subscribed?).and_return(false)
+        end
+
         it "does not measure duration" do
-          expect(request_tracker).to receive(:record_success)
+          expect(request_tracker).to receive(:record_success).with(duration_ms: nil)
           expect(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
           expect(clock).not_to receive(:monotonic_time)
 
@@ -101,14 +126,14 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
             let(:fallback) { nil }
 
             it "records failure, notify and raises the error" do
-              expect(request_tracker).to receive(:record_failure).with(error)
+              expect(request_tracker).to receive(:record_failure).with(error, duration_ms: kind_of(Float))
               expect(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
 
               expect { result }.to raise_error(error)
             end
 
             it "produces RunCompleted event" do
-              expect(request_tracker).to receive(:record_failure).with(error)
+              expect(request_tracker).to receive(:record_failure).with(error, duration_ms: kind_of(Float))
               allow(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
               expect(clock).to receive(:monotonic_time).and_return(1.4, 2.2)
 
@@ -134,7 +159,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
             end
 
             it "records failure, notify and returns the fallback" do
-              expect(request_tracker).to receive(:record_failure).with(error)
+              expect(request_tracker).to receive(:record_failure).with(error, duration_ms: kind_of(Float))
               expect(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
 
               expect(result).to eq("Fallback")
@@ -142,7 +167,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
             end
 
             it "produces RunCompleted event" do
-              expect(request_tracker).to receive(:record_failure).with(error)
+              expect(request_tracker).to receive(:record_failure).with(error, duration_ms: kind_of(Float))
               allow(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
               expect(clock).to receive(:monotonic_time).and_return(1.4, 2.2)
 

--- a/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
+++ b/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
   let(:name) { SecureRandom.uuid }
   let(:emitter) { TestTelemetryEmitter.new }
   let(:policy_name) { SecureRandom.uuid }
+  let(:probe_duration_ms) { 12.5 }
 
   shared_examples "when recover to" do |recover_to:, transition_from:, transition_to:|
     context "when recover to #{recover_to}" do
@@ -64,7 +65,10 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       transition_to: Stoplight::Color::RED
 
     context "when recover to unexpected to outcome" do
-      let(:metrics_after_probe) { instance_double(Stoplight::Domain::MetricsSnapshot) }
+      let(:metrics_after_probe) {
+        instance_double(Stoplight::Domain::MetricsSnapshot,
+          successes: 5, errors: 2, consecutive_errors: 0, consecutive_successes: 3)
+      }
       let(:recover_to) { "unexpected" }
 
       before do
@@ -77,7 +81,10 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
     end
 
     context "when recover to YELLOW (needs more probes)" do
-      let(:metrics_after_probe) { instance_double(Stoplight::Domain::MetricsSnapshot) }
+      let(:metrics_after_probe) {
+        instance_double(Stoplight::Domain::MetricsSnapshot,
+          successes: 5, errors: 2, consecutive_errors: 0, consecutive_successes: 3)
+      }
       let(:recover_to) { Stoplight::Domain::TrafficRecovery::YELLOW }
 
       before do
@@ -95,7 +102,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
   end
 
   describe "#record_success" do
-    subject(:record_probe) { recorder.record_success }
+    subject(:record_probe) { recorder.record_success(duration_ms: probe_duration_ms) }
 
     before do
       allow(metrics_store).to receive(:record_success)
@@ -106,7 +113,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
   end
 
   describe "#record_failure" do
-    subject(:record_probe) { recorder.record_failure(exception) }
+    subject(:record_probe) { recorder.record_failure(exception, duration_ms: probe_duration_ms) }
 
     let(:exception) { KeyError.new("bang") }
 
@@ -142,7 +149,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       end
 
       it "emits a RecoverySucceeded event with the transition details" do
-        expect { recorder.record_success }.to emit(Stoplight::Domain::Telemetry::RecoverySucceeded).with(
+        expect { recorder.record_success(duration_ms: probe_duration_ms) }.to emit(Stoplight::Domain::Telemetry::RecoverySucceeded).with(
           from_color: Stoplight::Color::YELLOW,
           to_color: Stoplight::Color::GREEN,
           policy: policy_name,
@@ -156,7 +163,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       end
 
       it "emits exactly one RecoverySucceeded event" do
-        recorder.record_success
+        recorder.record_success(duration_ms: probe_duration_ms)
 
         count = emitter.emitted.count { |event| event.instance_of?(Stoplight::Domain::Telemetry::RecoverySucceeded) }
         expect(count).to eq(1)
@@ -168,7 +175,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
         end
 
         it "does not emit a RecoverySucceeded event" do
-          expect { recorder.record_success }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
+          expect { recorder.record_success(duration_ms: probe_duration_ms) }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
         end
       end
     end
@@ -179,7 +186,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       end
 
       it "does not emit a RecoverySucceeded event" do
-        expect { recorder.record_success }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
+        expect { recorder.record_success(duration_ms: probe_duration_ms) }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
       end
     end
 
@@ -190,8 +197,63 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       end
 
       it "does not emit a RecoverySucceeded event" do
-        expect { recorder.record_success }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
+        expect { recorder.record_success(duration_ms: probe_duration_ms) }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
       end
+    end
+  end
+
+  describe "RecoveryProbeCompleted telemetry" do
+    let(:metrics_after_probe) {
+      instance_double(Stoplight::Domain::MetricsSnapshot,
+        successes: 5,
+        errors: 2,
+        consecutive_errors: 0,
+        consecutive_successes: 3)
+    }
+    let(:progress) {
+      Stoplight::Domain::Telemetry::Metrics.new(successes: 5, errors: 2, consecutive_errors: 0, consecutive_successes: 3)
+    }
+
+    before do
+      allow(metrics_store).to receive(:record_success)
+      allow(metrics_store).to receive(:record_failure)
+      allow(metrics_store).to receive(:metrics_snapshot).and_return(metrics_after_probe)
+      # stay yellow so the probe outcome is the only thing under test
+      allow(traffic_recovery).to receive(:determine_color).and_return(Stoplight::Domain::TrafficRecovery::YELLOW)
+    end
+
+    it "reports a successful probe with the post-probe metrics" do
+      expect { recorder.record_success(duration_ms: 12.5) }.to emit(Stoplight::Domain::Telemetry::RecoveryProbeCompleted).with(
+        outcome: :success,
+        duration_ms: 12.5,
+        failure: nil,
+        progress:
+      )
+    end
+
+    it "reports a failed probe carrying the tracked exception" do
+      exception = KeyError.new("bang")
+
+      expect { recorder.record_failure(exception, duration_ms: 3.0) }.to emit(Stoplight::Domain::Telemetry::RecoveryProbeCompleted).with(
+        outcome: :failure,
+        duration_ms: 3.0,
+        failure: have_attributes(exception:, tracked: true),
+        progress:
+      )
+    end
+
+    it "fires on every probe, even when the light stays yellow" do
+      recorder.record_success(duration_ms: 1.0)
+
+      count = emitter.emitted.count { |event| event.instance_of?(Stoplight::Domain::Telemetry::RecoveryProbeCompleted) }
+      expect(count).to eq(1)
+    end
+
+    it "passes duration_ms through untouched when measurement was skipped" do
+      expect { recorder.record_success(duration_ms: nil) }.to emit(Stoplight::Domain::Telemetry::RecoveryProbeCompleted).with(
+        outcome: :success,
+        duration_ms: nil
+      )
     end
   end
 end


### PR DESCRIPTION
Wires up `RecoveryProbeCompleted`, which was defined back in the telemetry work but never actually emitted, so subscribers can see every yellow probe's outcome without it getting mixed into the general `RunCompleted` error-rate stream.

It fires from `RecoveryProbe#recover`, right after the post-probe metrics snapshot and before the still-yellow early return, so it happens on every probe regardless of which color the probe resolves to. There's no dedup guard because it's a per-probe measurement, not a state transition. `record_success`/`record_failure` pass the outcome (`:success`/`:failure`), the tracked failure (nil on success), and the same snapshot used for the recovery decision as `progress`.

Duration is the one thing `RecoveryProbe` can't see on its own, so `YellowRunStrategy` measures it (it already has clock access from the `RunCompleted` work) and threads it down. I typed `duration_ms` as `Float?` to match `RunCompleted#duration_ms` — it's nil only when nobody was subscribed at probe start, same race. I also extended the clock-capture guard so it measures when the probe event is subscribed, not just `RunCompleted`; otherwise subscribing to only `RecoveryProbeCompleted` would always give you a nil duration.

Tests: added a `RecoveryProbeCompleted telemetry` group in `recovery_probe_spec.rb` covering success, tracked failure, that it fires even when the light stays yellow, and that a nil duration passes through. In `yellow_run_strategy_spec.rb` I added cases for the measured duration reaching the probe and for the probe-only-subscribed path, and updated the existing expectations for the new `duration_ms:` argument. RBS updated in lockstep.

`bundle exec rspec` is green (791 examples, 0 failures, with Redis up), `steep check` clean, `rbs -I sig validate` clean, `standardrb` clean.

Closes #746.