### PR TITLE
[#743] Wire TrafficBreached telemetry event

### DIFF
--- a/lib/stoplight/domain/tracker/request.rb
+++ b/lib/stoplight/domain/tracker/request.rb
@@ -10,12 +10,13 @@ module Stoplight
       #
       # @api private
       class Request
-        def initialize(traffic_control:, notifiers:, config:, metrics_store:, state_store:)
+        def initialize(traffic_control:, notifiers:, config:, metrics_store:, state_store:, emitter:)
           @traffic_control = traffic_control
           @notifiers = notifiers
           @config = config
           @metrics_store = metrics_store
           @state_store = state_store
+          @emitter = emitter
         end
 
         def record_failure(exception)
@@ -33,6 +34,7 @@ module Stoplight
         attr_reader :config
         attr_reader :metrics_store
         attr_reader :state_store
+        attr_reader :emitter
 
         def transition_to_red(exception, metrics:)
           if traffic_control.stop_traffic?(config, metrics)
@@ -42,6 +44,20 @@ module Stoplight
               info = LightInfo.new(name: config.name)
               notifiers.each do |notifier|
                 notifier.notify(info, Color::GREEN, Color::RED, exception)
+              end
+              emitter.emit(Telemetry::TrafficBreached) do
+                Telemetry::TrafficBreached.new(
+                  from_color: Color::GREEN,
+                  to_color: Color::RED,
+                  policy: traffic_control.name,
+                  failure: Telemetry::Failure.new(exception:, tracked: true),
+                  metrics: Telemetry::Metrics.new(
+                    successes: metrics.successes,
+                    errors: metrics.errors,
+                    consecutive_errors: metrics.consecutive_errors,
+                    consecutive_successes: metrics.consecutive_successes
+                  )
+                )
               end
             end
           end

--- a/lib/stoplight/domain/traffic_control/consecutive_errors.rb
+++ b/lib/stoplight/domain/traffic_control/consecutive_errors.rb
@@ -43,6 +43,8 @@ module Stoplight
           metrics.consecutive_errors >= config.threshold
         end
 
+        def name = NAME.to_s
+
         def hash = self.class.hash
 
         def ==(other)

--- a/lib/stoplight/domain/traffic_control/error_rate.rb
+++ b/lib/stoplight/domain/traffic_control/error_rate.rb
@@ -50,6 +50,8 @@ module Stoplight
           requests >= min_requests && error_rate >= config.threshold
         end
 
+        def name = NAME.to_s
+
         def ==(other)
           other.is_a?(self.class) && min_requests == other.min_requests
         end

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -99,7 +99,7 @@ module Stoplight
       end
 
       def request_tracker
-        Domain::Tracker::Request.new(traffic_control:, notifiers:, config:, metrics_store:, state_store:)
+        Domain::Tracker::Request.new(traffic_control:, notifiers:, config:, metrics_store:, state_store:, emitter: @emitter)
       end
 
       def recovery_probe_tracker

--- a/sig/stoplight/domain/ports/traffic_control.rbs
+++ b/sig/stoplight/domain/ports/traffic_control.rbs
@@ -22,6 +22,10 @@ module Stoplight
     #       error_rate = metrics.failures.fdiv(total)
     #       error_rate >= 0.5 # Stop traffic when error rate reaches 50%
     #     end
+    #
+    #     def name
+    #       "error_rate_custom"
+    #     end
     #   end
     #
     interface _TrafficControl
@@ -32,6 +36,9 @@ module Stoplight
       # current state and metrics.
       # @return +true+ if traffic should be stopped otherwise false
       def stop_traffic?: (Config, Domain::MetricsSnapshot) -> bool
+
+      # Returns a string identifier for this policy (e.g. "consecutive_errors", "error_rate").
+      def name: () -> String
 
       # Object methods
       def ==: (untyped) -> bool

--- a/sig/stoplight/domain/tracker/request.rbs
+++ b/sig/stoplight/domain/tracker/request.rbs
@@ -7,6 +7,7 @@ module Stoplight
         attr_reader notifiers: Array[_StateTransitionNotifier]
         attr_reader metrics_store: _MetricsStore
         attr_reader state_store: _StateStore
+        attr_reader emitter: Telemetry::Emitter
 
         def initialize: (
           config: Config,
@@ -14,6 +15,7 @@ module Stoplight
           notifiers: Array[_StateTransitionNotifier],
           metrics_store: _MetricsStore,
           state_store: _StateStore,
+          emitter: Telemetry::Emitter,
         ) -> void
 
         def record_failure: (StandardError exception) -> void

--- a/spec/support/adapters/null_traffic_control.rb
+++ b/spec/support/adapters/null_traffic_control.rb
@@ -3,5 +3,6 @@
 class NullTrafficControl
   def check_compatibility = raise NotImplementedError
   def stop_traffic?(config, metrics) = raise NotImplementedError
+  def name = raise NotImplementedError
   def ==(other) = raise NotImplementedError
 end

--- a/spec/unit/stoplight/domain/tracker/request_spec.rb
+++ b/spec/unit/stoplight/domain/tracker/request_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Stoplight::Domain::Tracker::Request do
-  subject(:request_tracker) { described_class.new(state_store:, traffic_control:, notifiers:, config:, metrics_store:) }
+  subject(:request_tracker) { described_class.new(state_store:, traffic_control:, notifiers:, config:, metrics_store:, emitter:) }
 
   let(:metrics_store) { instance_double(NullMetricsStore) }
   let(:state_store) { instance_double(NullStateStore) }
@@ -10,6 +10,8 @@ RSpec.describe Stoplight::Domain::Tracker::Request do
   let(:notifier) { instance_double(NullNotifier) }
   let(:config) { instance_double(Stoplight::Domain::Config, name: name) }
   let(:name) { SecureRandom.uuid }
+  let(:emitter) { TestTelemetryEmitter.new }
+  let(:policy_name) { SecureRandom.uuid }
 
   specify "#record_success" do
     expect(metrics_store).to receive(:record_success)
@@ -30,15 +32,6 @@ RSpec.describe Stoplight::Domain::Tracker::Request do
         allow(traffic_control).to receive(:stop_traffic?).with(config, metrics).and_return(true)
       end
 
-      context "when successfully transitions to RED" do
-        it "sends notifications about transition" do
-          allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::RED).and_return(true)
-          expect(notifier).to receive(:notify).with(have_attributes(name:), Stoplight::Color::GREEN, Stoplight::Color::RED, exception)
-
-          request_tracker.record_failure(exception)
-        end
-      end
-
       context "when failed to transition to RED" do
         it "does not send notification about transition" do
           allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::RED).and_return(false)
@@ -53,6 +46,71 @@ RSpec.describe Stoplight::Domain::Tracker::Request do
       expect(traffic_control).to receive(:stop_traffic?).with(config, metrics).and_return(false)
 
       request_tracker.record_failure(exception)
+    end
+  end
+
+  describe "TrafficBreached telemetry" do
+    let(:exception) { KeyError.new("something went wrong") }
+    let(:metrics) do
+      instance_double(Stoplight::Domain::MetricsSnapshot,
+        successes: 10,
+        errors: 3,
+        consecutive_errors: 3,
+        consecutive_successes: 0)
+    end
+
+    before do
+      allow(metrics_store).to receive(:record_failure).with(exception).and_return(metrics)
+      allow(traffic_control).to receive(:stop_traffic?).with(config, metrics).and_return(true)
+      allow(traffic_control).to receive(:name).and_return(policy_name)
+      allow(notifier).to receive(:notify)
+    end
+
+    context "when the transition to RED succeeds" do
+      before do
+        allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::RED).and_return(true)
+      end
+
+      it "sends a notification about the color transition" do
+        expect(notifier).to receive(:notify).with(have_attributes(name:), Stoplight::Color::GREEN, Stoplight::Color::RED, exception)
+
+        request_tracker.record_failure(exception)
+      end
+
+      it "emits a TrafficBreached event with the transition details" do
+        expect { request_tracker.record_failure(exception) }.to emit(Stoplight::Domain::Telemetry::TrafficBreached).with(
+          from_color: Stoplight::Color::GREEN,
+          to_color: Stoplight::Color::RED,
+          policy: policy_name,
+          failure: Stoplight::Domain::Telemetry::Failure.new(exception:, tracked: true),
+          metrics: Stoplight::Domain::Telemetry::Metrics.new(
+            successes: metrics.successes,
+            errors: metrics.errors,
+            consecutive_errors: metrics.consecutive_errors,
+            consecutive_successes: metrics.consecutive_successes
+          )
+        )
+      end
+    end
+
+    context "when the transition to RED fails (light already red)" do
+      before do
+        allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::RED).and_return(false)
+      end
+
+      it "does not emit a TrafficBreached event" do
+        expect { request_tracker.record_failure(exception) }.not_to emit(Stoplight::Domain::Telemetry::TrafficBreached)
+      end
+    end
+
+    context "when traffic control does not stop the traffic" do
+      before do
+        allow(traffic_control).to receive(:stop_traffic?).with(config, metrics).and_return(false)
+      end
+
+      it "does not emit a TrafficBreached event" do
+        expect { request_tracker.record_failure(exception) }.not_to emit(Stoplight::Domain::Telemetry::TrafficBreached)
+      end
     end
   end
 end

--- a/spec/unit/stoplight/domain/traffic_control/consecutive_errors_spec.rb
+++ b/spec/unit/stoplight/domain/traffic_control/consecutive_errors_spec.rb
@@ -118,6 +118,12 @@ RSpec.describe Stoplight::Domain::TrafficControl::ConsecutiveErrors do
     end
   end
 
+  describe "#name" do
+    it "returns the policy name as a string" do
+      expect(described_class.new.name).to eq("consecutive_errors")
+    end
+  end
+
   describe "#eql?" do
     it "returns true for equal instances" do
       strategy_a = described_class.new

--- a/spec/unit/stoplight/domain/traffic_control/error_rate_spec.rb
+++ b/spec/unit/stoplight/domain/traffic_control/error_rate_spec.rb
@@ -170,6 +170,12 @@ RSpec.describe Stoplight::Domain::TrafficControl::ErrorRate do
     end
   end
 
+  describe "#name" do
+    it "returns the policy name as a string" do
+      expect(described_class.new.name).to eq("error_rate")
+    end
+  end
+
   describe "#eql?" do
     it "returns true for same class and same min_requests" do
       strategy_a = described_class.new


### PR DESCRIPTION
#743

`TrafficBreached` fires when traffic control trips a light from green to red — the circuit just opened. `RunCompleted` was the only wired event before this; `TrafficBreached` was defined but never emitted.

- Emits inside the `state_store.transition_to_color(Color::RED)` guard in `Tracker::Request#transition_to_red`, so the event fires exactly once per GREEN→RED flip (same dedup invariant the existing notifier call relies on)
- Injects `emitter:` into `Tracker::Request` via constructor — same pattern `RecoveryProbe` already uses
- Adds `TrafficControl#name` to both built-in policies and the `_TrafficControl` port; named `name` to match `TrafficRecovery#name` on the parallel interface rather than introducing a second term for the same concept. This is a breaking change for custom strategies duck-typing `_TrafficControl` — adding `def name = "your_policy"` is the migration