### PR TITLE
Prune expired Memory metric buckets on writes

### DIFF
--- a/lib/stoplight/infrastructure/memory/storage/window_metrics.rb
+++ b/lib/stoplight/infrastructure/memory/storage/window_metrics.rb
@@ -78,8 +78,8 @@ module Stoplight
             @consecutive_successes = 0
             @last_error = nil
             @last_success_at = nil
-            @successes = SlidingWindow.new(clock: @clock)
-            @errors = SlidingWindow.new(clock: @clock)
+            @successes = SlidingWindow.new(clock: @clock, window_size: @window_size)
+            @errors = SlidingWindow.new(clock: @clock, window_size: @window_size)
           end
 
           def build_metrics_snapshot

--- a/lib/stoplight/infrastructure/memory/storage/window_metrics.rb
+++ b/lib/stoplight/infrastructure/memory/storage/window_metrics.rb
@@ -83,8 +83,8 @@ module Stoplight
           end
 
           def build_metrics_snapshot
-            errors = @errors.sum_in_window(@window_size)
-            successes = @successes.sum_in_window(@window_size)
+            errors = @errors.sum_in_window
+            successes = @successes.sum_in_window
 
             Domain::MetricsSnapshot.new(
               errors:,

--- a/lib/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rb
+++ b/lib/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rb
@@ -35,8 +35,8 @@ module Stoplight
               @running_sum += 1
             end
 
-            def sum_in_window(window_size)
-              slide_window!(monotonic_seconds - window_size)
+            def sum_in_window
+              slide_window!(monotonic_seconds - @window_size)
               @running_sum
             end
 

--- a/lib/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rb
+++ b/lib/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rb
@@ -18,17 +18,20 @@ module Stoplight
           # @note Not thread-safe; synchronization must be handled externally
           # @api private
           class SlidingWindow
-            def initialize(clock:)
+            def initialize(clock:, window_size:)
               # A hash mapping time buckets to their counts
               @buckets = Hash.new { |buckets, bucket| buckets[bucket] = 0 }
               # The running sum of all increments in the current window
               @running_sum = 0
               @clock = clock
+              @window_size = window_size
             end
 
             # Increment the count at the current monotonic second
             def increment
-              @buckets[current_bucket] += 1
+              timestamp = monotonic_seconds
+              slide_window!(timestamp - @window_size)
+              @buckets[timestamp.to_i] += 1
               @running_sum += 1
             end
 
@@ -55,10 +58,6 @@ module Stoplight
                   @buckets.shift
                 end
               end
-            end
-
-            def current_bucket
-              monotonic_seconds.to_i
             end
 
             # Monotonic, so a wall-clock step (NTP) cannot break FIFO eviction;

--- a/sig/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rbs
+++ b/sig/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rbs
@@ -7,16 +7,15 @@ module Stoplight
             @buckets: Hash[Integer, Integer]
             @running_sum: Integer
             @clock: Domain::_Clock
+            @window_size: Domain::duration_seconds
 
-            def initialize: (clock: Domain::_Clock) -> void
+            def initialize: (clock: Domain::_Clock, window_size: Domain::duration_seconds) -> void
 
             def increment: -> void
 
             def sum_in_window: (Domain::duration_seconds window_size) -> Integer
 
             private def slide_window!: (Float window_start) -> void
-
-            private def current_bucket: -> Integer
 
             private def monotonic_seconds: -> Float
 

--- a/sig/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rbs
+++ b/sig/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rbs
@@ -13,7 +13,7 @@ module Stoplight
 
             def increment: -> void
 
-            def sum_in_window: (Domain::duration_seconds window_size) -> Integer
+            def sum_in_window: -> Integer
 
             private def slide_window!: (Float window_start) -> void
 

--- a/spec/unit/stoplight/infrastructure/memory/storage/window_metrics/sliding_window_spec.rb
+++ b/spec/unit/stoplight/infrastructure/memory/storage/window_metrics/sliding_window_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Stoplight::Infrastructure::Memory::Storage::WindowMetrics::SlidingWindow do
-  subject(:counter) { described_class.new(clock:) }
+  subject(:counter) { described_class.new(clock:, window_size:) }
 
   let(:clock) { instance_double(NullClock) }
+  let(:window_size) { 60 }
 
   # Position the monotonic clock at an absolute second.
   def at(seconds)

--- a/spec/unit/stoplight/infrastructure/memory/storage/window_metrics/sliding_window_spec.rb
+++ b/spec/unit/stoplight/infrastructure/memory/storage/window_metrics/sliding_window_spec.rb
@@ -18,51 +18,52 @@ RSpec.describe Stoplight::Infrastructure::Memory::Storage::WindowMetrics::Slidin
       counter.increment
       counter.increment
 
-      expect(counter.sum_in_window(10)).to eq(3)
+      expect(counter.sum_in_window).to eq(3)
     end
 
     it "when empty returns zero sum" do
       at(100)
-      expect(counter.sum_in_window(0)).to eq(0)
-      expect(counter.sum_in_window(100)).to eq(0)
-      expect(counter.sum_in_window(10000)).to eq(0)
+      expect(counter.sum_in_window).to eq(0)
     end
 
-    it "increments the count for the different seconds" do
-      at(98)
-      counter.increment
-      counter.increment
-      at(99)
-      counter.increment
-      counter.increment
-      at(100)
-      counter.increment
+    context "when events span the configured window" do
+      let(:window_size) { 2 }
 
-      expect(counter.sum_in_window(2)).to eq(5)
-      expect(counter.sum_in_window(1)).to eq(3)
-      expect(counter.sum_in_window(0)).to eq(1)
+      it "counts events within the window" do
+        at(98)
+        counter.increment
+        counter.increment
+        at(99)
+        counter.increment
+        counter.increment
+        at(100)
+        counter.increment
+
+        expect(counter.sum_in_window).to eq(5)
+      end
     end
 
-    it "increments the count for the different sparsely distributed seconds" do
-      at(80)
-      counter.increment
-      at(90)
-      counter.increment
-      at(95)
-      counter.increment
-      at(100)
+    context "when events are sparsely distributed" do
+      let(:window_size) { 15 }
 
-      expect(counter.sum_in_window(60)).to eq(3)
-      expect(counter.sum_in_window(15)).to eq(2)
-      expect(counter.sum_in_window(5)).to eq(1)
-      expect(counter.sum_in_window(2)).to eq(0)
+      it "expires events outside the window" do
+        at(80)
+        counter.increment
+        at(90)
+        counter.increment
+        at(95)
+        counter.increment
+        at(100)
+
+        expect(counter.sum_in_window).to eq(2)
+      end
     end
   end
 
   describe "#sum_in_window" do
     it "returns zero when no increments in the window" do
       at(100)
-      expect(counter.sum_in_window(0)).to eq(0)
+      expect(counter.sum_in_window).to eq(0)
     end
   end
 end

--- a/spec/unit/stoplight/infrastructure/memory/storage/window_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/memory/storage/window_metrics_spec.rb
@@ -23,6 +23,26 @@ RSpec.describe Stoplight::Infrastructure::Memory::Storage::WindowMetrics do
 
       metrics.record_success
     end
+
+    context "without taking snapshots" do
+      let(:window_size) { 10 }
+
+      it "keeps success buckets bounded to the configured window" do
+        monotonic_time = 0.0
+        allow(clock).to receive(:current_time).and_return(Time.utc(2026, 8, 7))
+        allow(clock).to receive(:monotonic_time) { monotonic_time }
+
+        (0..100).each do |second|
+          monotonic_time = second * 1_000.0
+          metrics.record_success
+        end
+
+        successes = metrics.instance_variable_get(:@successes)
+        buckets = successes.instance_variable_get(:@buckets)
+        expect(buckets.size).to eq(window_size + 1)
+        expect(buckets.keys).to contain_exactly(*(90..100))
+      end
+    end
   end
 
   describe "#record_failure" do


### PR DESCRIPTION
## Summary

- prune expired in-memory metric buckets during each write
- keep the configured window inside `SlidingWindow` while preserving one monotonic-clock read per increment
- cover sustained successful traffic that never requests a metrics snapshot

Each bucket is still removed from the FIFO hash at most once, so writes remain amortized O(1) while memory stays bounded to the active window.

## Validation

- `bundle exec rspec` — 796 examples, 0 failures
- `bundle exec standardrb`
- `bundle exec steep check`
- `bundle exec rbs -I sig validate`
- Cucumber with Memory and Redis using both `Stoplight()` and `System#register`
- 1,000,001-write stress smoke — 11 buckets retained for a 10-second window

Closes #774