### PR TITLE
Display number of remaining test probes in yellow state

### DIFF
--- a/lib/stoplight/admin/actions/stats.rb
+++ b/lib/stoplight/admin/actions/stats.rb
@@ -19,14 +19,16 @@ module Stoplight
         private def build_light(config)
           state_snapshot = @storage.state_snapshot(config)
           metrics = @storage.metrics_snapshot(config)
+          recovery_metrics_snapshot = @storage.recovery_metrics_snapshot(config)
 
           LightView.new(
             id: config.id,
-            name: config.name,
+            config:,
             color: state_snapshot.color,
             state: state_snapshot.locked_state,
             failures: [metrics.last_error].compact,
-            failure_count: metrics.consecutive_errors
+            failure_count: metrics.consecutive_errors,
+            recovery_metrics_snapshot:
           )
         end
       end

--- a/lib/stoplight/admin/light_view.rb
+++ b/lib/stoplight/admin/light_view.rb
@@ -19,14 +19,16 @@ module Stoplight
       attr_reader :failures
       attr_reader :failure_count
 
-      def initialize(id:, name:, color:, state:, failures:, failure_count: nil)
+      def initialize(config:, id:, color:, state:, failures:, recovery_metrics_snapshot:, failure_count: nil)
         @id = id
-        @name = name
+        @config = config
+        @name = config.name
         @color = color
         @state = state
         @failures = failures
         @failure_count = failure_count
         @latest_failure = @failures.first
+        @recovery_metrics_snapshot = recovery_metrics_snapshot
       end
 
       def locked?
@@ -56,6 +58,7 @@ module Stoplight
       def last_check = @latest_failure&.time # TODO: take into account positive checks as well
 
       # @return [String, nil]
+      # TODO: is this method still in use?
       def last_check_in_words
         last_error_time = @latest_failure&.time
         return unless last_error_time
@@ -134,7 +137,8 @@ module Stoplight
             "Will attempt recovery after cooling period"
           end
         when Stoplight::Color::YELLOW
-          "Allowing limited test traffic (0 of 1 requests)"
+          recovery_metrics_snapshot = T.must(@recovery_metrics_snapshot)
+          "Allowing limited test traffic (#{recovery_metrics_snapshot.consecutive_successes} of #{@config.recovery_threshold} requests)"
         when Stoplight::Color::GREEN
           if locked?
             "Override active - all requests processed"

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -55,6 +55,7 @@ module Stoplight
       def state_store = storage_set.state_store
       def metrics_store = storage_set.metrics_store
       def lock_control = Domain::LockControl.new(state_store:, emitter: @emitter)
+      def recovery_metrics_store = storage_set.recovery_metrics_store
 
       private
 
@@ -67,7 +68,6 @@ module Stoplight
       attr_reader :system_name
 
       def recovery_lock_store = storage_set.recovery_lock_store
-      def recovery_metrics_store = storage_set.recovery_metrics_store
       def storage_scripting = Infrastructure::Redis::Storage::Scripting.new(redis:)
       def failover_system = T.must(@failover_system)
 

--- a/lib/stoplight/wiring/system/storage.rb
+++ b/lib/stoplight/wiring/system/storage.rb
@@ -13,6 +13,10 @@ module Stoplight
           @telemetry = telemetry
         end
 
+        def recovery_metrics_snapshot(config)
+          recovery_metrics_store(config).metrics_snapshot
+        end
+
         def state_snapshot(config)
           state_store(config).state_snapshot
         end
@@ -32,6 +36,10 @@ module Stoplight
 
         def unlock(config)
           lock_control(config).unlock
+        end
+
+        private def recovery_metrics_store(config)
+          light_factory(config).recovery_metrics_store
         end
 
         private def state_store(config)

--- a/sig/stoplight/admin/light_view.rbs
+++ b/sig/stoplight/admin/light_view.rbs
@@ -14,13 +14,16 @@ module Stoplight
       @failures: Array[Domain::Failure]
       @failure_count: Integer?
       @latest_failure: Domain::Failure?
+      @recovery_metrics_snapshot: Domain::MetricsSnapshot?
+      @config: Domain::Config
 
       def initialize: (
           id: String,
-          name: String,
+          config: Domain::Config,
           color: Domain::color,
           state: Domain::state,
           failures: Array[Domain::Failure],
+          recovery_metrics_snapshot: Domain::MetricsSnapshot?,
           ?failure_count: Integer?
         ) -> void
 

--- a/sig/stoplight/wiring/system/storage.rbs
+++ b/sig/stoplight/wiring/system/storage.rbs
@@ -16,6 +16,7 @@ module Stoplight
           ) -> void
 
         def state_snapshot: (Domain::Config) -> Domain::StateSnapshot
+        def recovery_metrics_snapshot: (Domain::Config) -> Domain::MetricsSnapshot
         def metrics_snapshot: (Domain::Config) -> Domain::MetricsSnapshot
         def delete: (Domain::Config) -> void
         def lock: (Domain::Config, Domain::color) -> void
@@ -24,6 +25,7 @@ module Stoplight
         private
 
         def state_store: (Domain::Config) -> Domain::_StateStore
+        def recovery_metrics_store: (Domain::Config) -> Domain::_MetricsStore
         def metrics_store: (Domain::Config) -> Domain::_MetricsStore
         def lock_control: (Domain::Config) -> Domain::LockControl
         def light_factory: (Domain::Config) -> LightFactory

--- a/spec/unit/stoplight/admin/actions/stats_spec.rb
+++ b/spec/unit/stoplight/admin/actions/stats_spec.rb
@@ -36,10 +36,12 @@ RSpec.describe Stoplight::Admin::Actions::Stats do
     let(:metrics_snapshot) do
       instance_double(Stoplight::Domain::MetricsSnapshot, last_error: nil, consecutive_errors: 0)
     end
+    let(:recovery_metrics_snapshot) { instance_double(Stoplight::Domain::MetricsSnapshot) }
 
     before do
       allow(storage).to receive(:state_snapshot).with(config).and_return(state_snapshot)
       allow(storage).to receive(:metrics_snapshot).with(config).and_return(metrics_snapshot)
+      allow(storage).to receive(:recovery_metrics_snapshot).with(config).and_return(recovery_metrics_snapshot)
     end
 
     it "builds a light view from the config and its storage snapshots" do

--- a/spec/unit/stoplight/admin/light_view_spec.rb
+++ b/spec/unit/stoplight/admin/light_view_spec.rb
@@ -4,10 +4,11 @@ RSpec.describe Stoplight::Admin::LightView do
   subject(:light) do
     described_class.new(
       id:,
-      name:,
+      config:,
       color:,
       state:,
-      failures:
+      failures:,
+      recovery_metrics_snapshot:
     )
   end
   let(:id) { SecureRandom.uuid }
@@ -17,6 +18,8 @@ RSpec.describe Stoplight::Admin::LightView do
   let(:color) { "green" }
   let(:name) { "light-specs" }
   let(:state) { Stoplight::State::UNLOCKED }
+  let(:recovery_metrics_snapshot) { nil }
+  let(:config) { instance_double(Stoplight::Domain::Config, name:, recovery_threshold: 13) }
 
   describe "#description_title and #description_message" do
     subject(:description_title) { light.description_title }
@@ -65,17 +68,18 @@ RSpec.describe Stoplight::Admin::LightView do
 
     context "when the light is yellow" do
       let(:color) { Stoplight::Color::YELLOW }
+      let(:recovery_metrics_snapshot) { instance_double(Stoplight::Domain::MetricsSnapshot, consecutive_successes: 7) }
 
       it { expect(description_title).to eq("Testing Recovery") }
       it { expect(description_message).to eq("StandardError: bang!") }
-      it { expect(description_comment).to eq("Allowing limited test traffic (0 of 1 requests)") }
+      it { expect(description_comment).to eq("Allowing limited test traffic (7 of 13 requests)") }
 
       context "without an error" do
         let(:failures) { [] }
 
         it { expect(description_title).to eq("Testing Recovery") }
         it { expect(description_message).to eq("Not available") }
-        it { expect(description_comment).to eq("Allowing limited test traffic (0 of 1 requests)") }
+        it { expect(description_comment).to eq("Allowing limited test traffic (7 of 13 requests)") }
       end
     end
 

--- a/spec/unit/stoplight/admin/lights_stats_spec.rb
+++ b/spec/unit/stoplight/admin/lights_stats_spec.rb
@@ -18,24 +18,27 @@ RSpec.describe Stoplight::Admin::LightsStats do
         [
           Stoplight::Admin::LightView.new(
             id: "a",
-            name: "green",
+            config: instance_double(Stoplight::Domain::Config, name: "green"),
             color: "green",
             state: "unlocked",
-            failures: []
+            failures: [],
+            recovery_metrics_snapshot: nil
           ),
           Stoplight::Admin::LightView.new(
             id: "b",
-            name: "yellow",
+            config: instance_double(Stoplight::Domain::Config, name: "yellow"),
             color: "yellow",
             state: "unlocked",
-            failures: []
+            failures: [],
+            recovery_metrics_snapshot: instance_double(Stoplight::Domain::MetricsSnapshot, requests: 4)
           ),
           Stoplight::Admin::LightView.new(
             id: "c",
-            name: "red",
+            config: instance_double(Stoplight::Domain::Config, name: "red"),
             color: "red",
             state: "locked",
-            failures: []
+            failures: [],
+            recovery_metrics_snapshot: nil
           )
         ]
       end


### PR DESCRIPTION
Fixes #884

### Before

Admin showed: `Allowing limited test traffic (0 of 1 requests)` regardless the light configuration

### After 

Admin respects lights configuration and shows an actual number of requests made:

<img width="506" height="250" alt="Screenshot 2026-08-23 at 00 30 10" src="https://github.com/user-attachments/assets/64ef05b6-8dbf-44aa-a7bc-68ba89110c69" />