### PR TITLE
Display when recovery starts in yellow state

### DIFF
--- a/lib/stoplight/admin/actions/stats.rb
+++ b/lib/stoplight/admin/actions/stats.rb
@@ -28,6 +28,7 @@ module Stoplight
             state: state_snapshot.locked_state,
             failures: [metrics.last_error].compact,
             failure_count: metrics.consecutive_errors,
+            state_snapshot:,
             recovery_metrics_snapshot:
           )
         end

--- a/lib/stoplight/admin/light_view.rb
+++ b/lib/stoplight/admin/light_view.rb
@@ -19,7 +19,16 @@ module Stoplight
       attr_reader :failures
       attr_reader :failure_count
 
-      def initialize(config:, id:, color:, state:, failures:, recovery_metrics_snapshot:, failure_count: nil)
+      def initialize(
+        config:,
+        id:,
+        color:,
+        state:,
+        failures:,
+        state_snapshot:,
+        recovery_metrics_snapshot:,
+        failure_count: nil
+      )
         @id = id
         @config = config
         @name = config.name
@@ -28,6 +37,7 @@ module Stoplight
         @failures = failures
         @failure_count = failure_count
         @latest_failure = @failures.first
+        @state_snapshot = state_snapshot
         @recovery_metrics_snapshot = recovery_metrics_snapshot
       end
 
@@ -57,24 +67,16 @@ module Stoplight
 
       def last_check = @latest_failure&.time # TODO: take into account positive checks as well
 
-      # @return [String, nil]
-      # TODO: is this method still in use?
-      def last_check_in_words
-        last_error_time = @latest_failure&.time
-        return unless last_error_time
-
-        time_difference = (Time.now.utc - last_error_time).to_i
-        if time_difference < 1
-          "just now"
-        elsif time_difference < 60
-          "#{time_difference.to_i}s ago"
-        elsif time_difference < 3600
-          "#{(time_difference / 60).to_i}m ago"
-        elsif time_difference < 86400
-          "#{(time_difference / 3600).to_i}h ago"
-        else
-          "#{(time_difference / 86400).to_i}d ago"
-        end
+      private def duration_in_words(seconds)
+        minutes = seconds / 60
+        seconds %= 60
+        hours = minutes / 60
+        minutes %= 60
+        parts = [] #: Array[String]
+        parts << "#{hours} #{(hours == 1) ? "hour" : "hours"}" if hours > 0
+        parts << "#{minutes} #{(minutes == 1) ? "minute" : "minutes"}" if minutes > 0
+        parts << "#{seconds} #{(seconds == 1) ? "second" : "seconds"}" if seconds > 0
+        parts.join(", ")
       end
 
       # @return [String]
@@ -133,12 +135,23 @@ module Stoplight
         when Stoplight::Color::RED
           if locked?
             "Override active - all requests blocked"
+          elsif (recovery_at = @state_snapshot.recovery_scheduled_after)
+            recovery_in = [0, (recovery_at - Time.now.utc).to_i].max
+            if recovery_in > 0
+              "Will attempt recovery in #{duration_in_words(recovery_in)}"
+            else
+              "Recovery started: awaiting test traffic"
+            end
           else
-            "Will attempt recovery after cooling period"
+            "Recovery started: awaiting test traffic"
           end
         when Stoplight::Color::YELLOW
           recovery_metrics_snapshot = T.must(@recovery_metrics_snapshot)
-          "Allowing limited test traffic (#{recovery_metrics_snapshot.consecutive_successes} of #{@config.recovery_threshold} requests)"
+          if recovery_metrics_snapshot.consecutive_successes.zero?
+            "Recovery started: awaiting test traffic"
+          else
+            "Allowing limited test traffic (#{recovery_metrics_snapshot.consecutive_successes} of #{@config.recovery_threshold} requests)"
+          end
         when Stoplight::Color::GREEN
           if locked?
             "Override active - all requests processed"

--- a/sig/stoplight/admin/light_view.rbs
+++ b/sig/stoplight/admin/light_view.rbs
@@ -14,6 +14,7 @@ module Stoplight
       @failures: Array[Domain::Failure]
       @failure_count: Integer?
       @latest_failure: Domain::Failure?
+      @state_snapshot: Domain::StateSnapshot
       @recovery_metrics_snapshot: Domain::MetricsSnapshot?
       @config: Domain::Config
 
@@ -23,6 +24,7 @@ module Stoplight
           color: Domain::color,
           state: Domain::state,
           failures: Array[Domain::Failure],
+          state_snapshot: Domain::StateSnapshot,
           recovery_metrics_snapshot: Domain::MetricsSnapshot?,
           ?failure_count: Integer?
         ) -> void
@@ -32,7 +34,7 @@ module Stoplight
       def as_json: -> Hash[Symbol, _ToS]
       def default_sort_key: -> Array[Comparable]
       def last_check: -> Time?
-      def last_check_in_words: -> String?
+      private def duration_in_words: (Integer) -> String
       def description_title: -> String
       def description_message: -> String
       def description_comment: -> String

--- a/spec/unit/stoplight/admin/light_view_spec.rb
+++ b/spec/unit/stoplight/admin/light_view_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Stoplight::Admin::LightView do
       color:,
       state:,
       failures:,
+      state_snapshot:,
       recovery_metrics_snapshot:
     )
   end
@@ -20,6 +21,10 @@ RSpec.describe Stoplight::Admin::LightView do
   let(:state) { Stoplight::State::UNLOCKED }
   let(:recovery_metrics_snapshot) { nil }
   let(:config) { instance_double(Stoplight::Domain::Config, name:, recovery_threshold: 13) }
+  let(:state_snapshot) do
+    instance_double(Stoplight::Domain::StateSnapshot, recovery_scheduled_after:)
+  end
+  let(:recovery_scheduled_after) { nil }
 
   describe "#description_title and #description_message" do
     subject(:description_title) { light.description_title }
@@ -28,6 +33,7 @@ RSpec.describe Stoplight::Admin::LightView do
 
     context "when the light is red" do
       let(:color) { Stoplight::Color::RED }
+      let(:recovery_scheduled_after) { 3.minute.from_now }
 
       context "when locked red with an errors" do
         let(:state) { Stoplight::State::LOCKED_RED }
@@ -53,7 +59,8 @@ RSpec.describe Stoplight::Admin::LightView do
 
         it { expect(description_title).to eq("Last Error") }
         it { expect(description_message).to eq("StandardError: bang!") }
-        it { expect(description_comment).to eq("Will attempt recovery after cooling period") }
+
+        it { expect(description_comment).to match(/Will attempt recovery in 2 minutes, \d+ seconds/) }
       end
 
       context "when unlocked without an error" do
@@ -62,17 +69,43 @@ RSpec.describe Stoplight::Admin::LightView do
 
         it { expect(description_title).to eq("Last Error") }
         it { expect(description_message).to eq("Not available") }
-        it { expect(description_comment).to eq("Will attempt recovery after cooling period") }
+        it { expect(description_comment).to match(/Will attempt recovery in 2 minutes, \d+ seconds/) }
+      end
+
+      context "when unlocked and recovery is overdue" do
+        let(:state) { Stoplight::State::UNLOCKED }
+        let(:recovery_scheduled_after) { 1.second.ago }
+
+        it { expect(description_comment).to eq("Recovery started: awaiting test traffic") }
+      end
+
+      context "when unlocked and recovery_scheduled_after is nil" do
+        let(:state) { Stoplight::State::UNLOCKED }
+        let(:recovery_scheduled_after) { nil }
+
+        it { expect(description_comment).to eq("Recovery started: awaiting test traffic") }
       end
     end
 
     context "when the light is yellow" do
       let(:color) { Stoplight::Color::YELLOW }
-      let(:recovery_metrics_snapshot) { instance_double(Stoplight::Domain::MetricsSnapshot, consecutive_successes: 7) }
+      let(:recovery_metrics_snapshot) { instance_double(Stoplight::Domain::MetricsSnapshot, consecutive_successes:) }
+      let(:consecutive_successes) { 7 }
 
       it { expect(description_title).to eq("Testing Recovery") }
       it { expect(description_message).to eq("StandardError: bang!") }
-      it { expect(description_comment).to eq("Allowing limited test traffic (7 of 13 requests)") }
+
+      context "without probes" do
+        let(:consecutive_successes) { 0 }
+
+        it { expect(description_comment).to eq("Recovery started: awaiting test traffic") }
+      end
+
+      context "with probes" do
+        let(:consecutive_successes) { 7 }
+
+        it { expect(description_comment).to eq("Allowing limited test traffic (7 of 13 requests)") }
+      end
 
       context "without an error" do
         let(:failures) { [] }
@@ -101,34 +134,6 @@ RSpec.describe Stoplight::Admin::LightView do
         it { expect(description_message).to eq("No recent errors") }
         it { expect(description_comment).to eq("Operating normally") }
       end
-    end
-  end
-
-  describe "#last_check_in_words" do
-    subject { light.last_check_in_words }
-
-    context "when the last check was more than a second ago" do
-      let(:latest_failure) { Stoplight::Domain::Failure.from_error(StandardError.new, time: Time.now) }
-
-      it { is_expected.to eq("just now") }
-    end
-
-    context "when the last check was less than a minute ago" do
-      let(:latest_failure) { Stoplight::Domain::Failure.from_error(StandardError.new, time: Time.now - 10) }
-
-      it { is_expected.to match(/\d+s ago/) }
-    end
-
-    context "when the last check was less than a hour ago" do
-      let(:latest_failure) { Stoplight::Domain::Failure.from_error(StandardError.new, time: Time.now - 300) }
-
-      it { is_expected.to match(/\d+m ago/) }
-    end
-
-    context "when the last check was less than a day ago" do
-      let(:latest_failure) { Stoplight::Domain::Failure.from_error(StandardError.new, time: Time.now - 7200) }
-
-      it { is_expected.to match(/\d+h ago/) }
     end
   end
 

--- a/spec/unit/stoplight/admin/lights_stats_spec.rb
+++ b/spec/unit/stoplight/admin/lights_stats_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Stoplight::Admin::LightsStats do
             color: "green",
             state: "unlocked",
             failures: [],
+            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot),
             recovery_metrics_snapshot: nil
           ),
           Stoplight::Admin::LightView.new(
@@ -30,6 +31,7 @@ RSpec.describe Stoplight::Admin::LightsStats do
             color: "yellow",
             state: "unlocked",
             failures: [],
+            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot),
             recovery_metrics_snapshot: instance_double(Stoplight::Domain::MetricsSnapshot, requests: 4)
           ),
           Stoplight::Admin::LightView.new(
@@ -38,6 +40,7 @@ RSpec.describe Stoplight::Admin::LightsStats do
             color: "red",
             state: "locked",
             failures: [],
+            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot),
             recovery_metrics_snapshot: nil
           )
         ]


### PR DESCRIPTION
Fixes #885

Before: "Will attempt recovery after cooling period" 

After: 
<img width="1032" height="592" alt="Screenshot 2026-08-23 at 23 14 33" src="https://github.com/user-attachments/assets/c10f86d3-0c4a-4080-8ba2-54164be3fd54" />
