### PR TITLE
Last check shows both successes and failures

### DIFF
--- a/lib/stoplight/admin/actions/stats.rb
+++ b/lib/stoplight/admin/actions/stats.rb
@@ -22,10 +22,7 @@ module Stoplight
           recovery_metrics_snapshot = @storage.recovery_metrics_snapshot(config)
 
           LightView.new(
-            id: config.id,
             config:,
-            color: state_snapshot.color,
-            state: state_snapshot.locked_state,
             failures: [metrics.last_error].compact,
             failure_count: metrics.consecutive_errors,
             state_snapshot:,

--- a/lib/stoplight/admin/actions/stats.rb
+++ b/lib/stoplight/admin/actions/stats.rb
@@ -17,16 +17,11 @@ module Stoplight
         end
 
         private def build_light(config)
-          state_snapshot = @storage.state_snapshot(config)
-          metrics = @storage.metrics_snapshot(config)
-          recovery_metrics_snapshot = @storage.recovery_metrics_snapshot(config)
-
           LightView.new(
             config:,
-            failures: [metrics.last_error].compact,
-            failure_count: metrics.consecutive_errors,
-            state_snapshot:,
-            recovery_metrics_snapshot:
+            metrics_snapshot: @storage.metrics_snapshot(config),
+            state_snapshot: @storage.state_snapshot(config),
+            recovery_metrics_snapshot: @storage.recovery_metrics_snapshot(config)
           )
         end
       end

--- a/lib/stoplight/admin/light_view.rb
+++ b/lib/stoplight/admin/light_view.rb
@@ -11,29 +11,18 @@ module Stoplight
         Stoplight::Color::RED
       ].freeze
 
-      attr_reader :id
       attr_reader :latest_failure
-      attr_reader :color
-      attr_reader :name
-      attr_reader :state
       attr_reader :failures
       attr_reader :failure_count
 
       def initialize(
         config:,
-        id:,
-        color:,
-        state:,
         failures:,
         state_snapshot:,
         recovery_metrics_snapshot:,
         failure_count: nil
       )
-        @id = id
         @config = config
-        @name = config.name
-        @color = color
-        @state = state
         @failures = failures
         @failure_count = failure_count
         @latest_failure = @failures.first
@@ -45,16 +34,21 @@ module Stoplight
         !unlocked?
       end
 
+      def color = @state_snapshot.color
+      def id = @config.id
+      def name = @config.name
+      def state = @state_snapshot.locked_state
+
       def unlocked?
-        @state == Stoplight::State::UNLOCKED
+        @state_snapshot.locked_state == Stoplight::State::UNLOCKED
       end
 
       # @return [Hash]
       def as_json
         {
-          id: @id,
-          name: @name,
-          color: @color,
+          id: @config.id,
+          name: @config.name,
+          color: @state_snapshot.color,
           failures: @failures,
           locked: locked?
         }
@@ -62,7 +56,7 @@ module Stoplight
 
       # @return [Array]
       def default_sort_key
-        [-COLORS.index(@color).to_i, @name]
+        [-COLORS.index(@state_snapshot.color).to_i, @config.name]
       end
 
       def last_check = @latest_failure&.time # TODO: take into account positive checks as well
@@ -81,7 +75,7 @@ module Stoplight
 
       # @return [String]
       def description_title
-        case @color
+        case @state_snapshot.color
         when Stoplight::Color::RED
           if locked? && @failures.empty?
             "Locked Open"
@@ -103,7 +97,7 @@ module Stoplight
 
       # @return [String]
       def description_message
-        case @color
+        case @state_snapshot.color
         when Stoplight::Color::RED
           if (latest_failure = @latest_failure)
             "#{latest_failure.error_class}: #{latest_failure.error_message}"
@@ -131,7 +125,7 @@ module Stoplight
 
       # @return [String]
       def description_comment
-        case @color
+        case @state_snapshot.color
         when Stoplight::Color::RED
           if locked?
             "Override active - all requests blocked"

--- a/lib/stoplight/admin/light_view.rb
+++ b/lib/stoplight/admin/light_view.rb
@@ -11,23 +11,17 @@ module Stoplight
         Stoplight::Color::RED
       ].freeze
 
-      attr_reader :latest_failure
-      attr_reader :failures
-      attr_reader :failure_count
-
       def initialize(
         config:,
-        failures:,
         state_snapshot:,
-        recovery_metrics_snapshot:,
-        failure_count: nil
+        metrics_snapshot:,
+        recovery_metrics_snapshot:
       )
         @config = config
-        @failures = failures
-        @failure_count = failure_count
-        @latest_failure = @failures.first
         @state_snapshot = state_snapshot
         @recovery_metrics_snapshot = recovery_metrics_snapshot
+        @metrics_snapshot = metrics_snapshot
+        @failures = [metrics_snapshot.last_error].compact
       end
 
       def locked?
@@ -38,6 +32,8 @@ module Stoplight
       def id = @config.id
       def name = @config.name
       def state = @state_snapshot.locked_state
+      def latest_failure = @metrics_snapshot.last_error
+      def failure_count = @metrics_snapshot.consecutive_errors
 
       def unlocked?
         @state_snapshot.locked_state == Stoplight::State::UNLOCKED
@@ -49,7 +45,7 @@ module Stoplight
           id: @config.id,
           name: @config.name,
           color: @state_snapshot.color,
-          failures: @failures,
+          failures: Array(@metrics_snapshot.last_error),
           locked: locked?
         }
       end
@@ -59,7 +55,7 @@ module Stoplight
         [-COLORS.index(@state_snapshot.color).to_i, @config.name]
       end
 
-      def last_check = @latest_failure&.time # TODO: take into account positive checks as well
+      def last_check = @metrics_snapshot.last_error&.time # TODO: take into account positive checks as well
 
       private def duration_in_words(seconds)
         minutes = seconds / 60
@@ -77,7 +73,7 @@ module Stoplight
       def description_title
         case @state_snapshot.color
         when Stoplight::Color::RED
-          if locked? && @failures.empty?
+          if locked? && @metrics_snapshot.last_error.nil?
             "Locked Open"
           else
             "Last Error"
@@ -99,7 +95,7 @@ module Stoplight
       def description_message
         case @state_snapshot.color
         when Stoplight::Color::RED
-          if (latest_failure = @latest_failure)
+          if (latest_failure = @metrics_snapshot.last_error)
             "#{latest_failure.error_class}: #{latest_failure.error_message}"
           elsif locked?
             "Circuit manually locked open"
@@ -107,7 +103,7 @@ module Stoplight
             "Not available"
           end
         when Stoplight::Color::YELLOW
-          if (latest_failure = @latest_failure)
+          if (latest_failure = @metrics_snapshot.last_error)
             "#{latest_failure.error_class}: #{latest_failure.error_message}"
           else
             "Not available"

--- a/lib/stoplight/admin/light_view.rb
+++ b/lib/stoplight/admin/light_view.rb
@@ -11,6 +11,8 @@ module Stoplight
         Stoplight::Color::RED
       ].freeze
 
+      attr_reader :failures
+
       def initialize(
         config:,
         state_snapshot:,
@@ -55,7 +57,13 @@ module Stoplight
         [-COLORS.index(@state_snapshot.color).to_i, @config.name]
       end
 
-      def last_check = @metrics_snapshot.last_error&.time # TODO: take into account positive checks as well
+      def last_check = [
+        @metrics_snapshot.last_error_at,
+        @metrics_snapshot.last_success_at,
+        @recovery_metrics_snapshot.last_error_at,
+        @recovery_metrics_snapshot.last_success_at,
+        @state_snapshot.breached_at
+      ].compact.max
 
       private def duration_in_words(seconds)
         minutes = seconds / 60
@@ -136,7 +144,7 @@ module Stoplight
             "Recovery started: awaiting test traffic"
           end
         when Stoplight::Color::YELLOW
-          recovery_metrics_snapshot = T.must(@recovery_metrics_snapshot)
+          recovery_metrics_snapshot = @recovery_metrics_snapshot
           if recovery_metrics_snapshot.consecutive_successes.zero?
             "Recovery started: awaiting test traffic"
           else

--- a/lib/stoplight/admin/views/_card.erb
+++ b/lib/stoplight/admin/views/_card.erb
@@ -125,12 +125,10 @@
       <span class="font-medium">Failures:</span> <%= light.failure_count %>
     </div>
 
-    <% light.last_check.then do |last_check| %>
-      <% if last_check %>
-        <div>
-          <span class="font-medium">Last Check:</span><%= time_ago_in_words(last_check) %>
-        </div>
-      <% end %>
+    <% if light.last_check %>
+      <div>
+        <span class="font-medium">Last Check:</span><%= time_ago_in_words(light.last_check) %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/sig/stoplight/admin/light_view.rbs
+++ b/sig/stoplight/admin/light_view.rbs
@@ -3,26 +3,24 @@ module Stoplight
     class LightView
       COLORS: Array[Domain::color]
 
+      @state_snapshot: Domain::StateSnapshot
+      @metrics_snapshot: Domain::MetricsSnapshot
+      @recovery_metrics_snapshot: Domain::MetricsSnapshot?
+      @config: Domain::Config
+      @failures: Array[Domain::Failure]
+
+      def initialize: (
+          config: Domain::Config,
+          state_snapshot: Domain::StateSnapshot,
+          recovery_metrics_snapshot: Domain::MetricsSnapshot?,
+          metrics_snapshot: Domain::MetricsSnapshot,
+        ) -> void
+
       def id: -> String
       def color: -> Domain::color
       def name: -> String
       def state: -> Domain::state
-
-      @failures: Array[Domain::Failure]
-      @failure_count: Integer?
-      @latest_failure: Domain::Failure?
-      @state_snapshot: Domain::StateSnapshot
-      @recovery_metrics_snapshot: Domain::MetricsSnapshot?
-      @config: Domain::Config
-
-      def initialize: (
-          config: Domain::Config,
-          failures: Array[Domain::Failure],
-          state_snapshot: Domain::StateSnapshot,
-          recovery_metrics_snapshot: Domain::MetricsSnapshot?,
-          ?failure_count: Integer?
-        ) -> void
-
+      def failure_count: -> Integer
       def locked?: -> bool
       def unlocked?: -> bool
       def as_json: -> Hash[Symbol, _ToS]
@@ -32,6 +30,7 @@ module Stoplight
       def description_title: -> String
       def description_message: -> String
       def description_comment: -> String
+      def latest_failure: -> Domain::Failure?
     end
   end
 end

--- a/sig/stoplight/admin/light_view.rbs
+++ b/sig/stoplight/admin/light_view.rbs
@@ -3,14 +3,11 @@ module Stoplight
     class LightView
       COLORS: Array[Domain::color]
 
-      attr_reader id: String
-      attr_reader color: Domain::color
-      attr_reader name: String
+      def id: -> String
+      def color: -> Domain::color
+      def name: -> String
+      def state: -> Domain::state
 
-      @id: String
-      @name: String
-      @color: Domain::color
-      @state: Domain::state
       @failures: Array[Domain::Failure]
       @failure_count: Integer?
       @latest_failure: Domain::Failure?
@@ -19,10 +16,7 @@ module Stoplight
       @config: Domain::Config
 
       def initialize: (
-          id: String,
           config: Domain::Config,
-          color: Domain::color,
-          state: Domain::state,
           failures: Array[Domain::Failure],
           state_snapshot: Domain::StateSnapshot,
           recovery_metrics_snapshot: Domain::MetricsSnapshot?,

--- a/sig/stoplight/admin/light_view.rbs
+++ b/sig/stoplight/admin/light_view.rbs
@@ -3,16 +3,18 @@ module Stoplight
     class LightView
       COLORS: Array[Domain::color]
 
+      attr_reader failures: Array[Domain::Failure]
+
       @state_snapshot: Domain::StateSnapshot
       @metrics_snapshot: Domain::MetricsSnapshot
-      @recovery_metrics_snapshot: Domain::MetricsSnapshot?
+      @recovery_metrics_snapshot: Domain::MetricsSnapshot
       @config: Domain::Config
       @failures: Array[Domain::Failure]
 
       def initialize: (
           config: Domain::Config,
           state_snapshot: Domain::StateSnapshot,
-          recovery_metrics_snapshot: Domain::MetricsSnapshot?,
+          recovery_metrics_snapshot: Domain::MetricsSnapshot,
           metrics_snapshot: Domain::MetricsSnapshot,
         ) -> void
 

--- a/spec/unit/stoplight/admin/light_view_spec.rb
+++ b/spec/unit/stoplight/admin/light_view_spec.rb
@@ -3,10 +3,7 @@
 RSpec.describe Stoplight::Admin::LightView do
   subject(:light) do
     described_class.new(
-      id:,
       config:,
-      color:,
-      state:,
       failures:,
       state_snapshot:,
       recovery_metrics_snapshot:
@@ -20,9 +17,9 @@ RSpec.describe Stoplight::Admin::LightView do
   let(:name) { "light-specs" }
   let(:state) { Stoplight::State::UNLOCKED }
   let(:recovery_metrics_snapshot) { nil }
-  let(:config) { instance_double(Stoplight::Domain::Config, name:, recovery_threshold: 13) }
+  let(:config) { instance_double(Stoplight::Domain::Config, id:, name:, recovery_threshold: 13) }
   let(:state_snapshot) do
-    instance_double(Stoplight::Domain::StateSnapshot, recovery_scheduled_after:)
+    instance_double(Stoplight::Domain::StateSnapshot, recovery_scheduled_after:, color:, locked_state: state)
   end
   let(:recovery_scheduled_after) { nil }
 

--- a/spec/unit/stoplight/admin/light_view_spec.rb
+++ b/spec/unit/stoplight/admin/light_view_spec.rb
@@ -4,18 +4,21 @@ RSpec.describe Stoplight::Admin::LightView do
   subject(:light) do
     described_class.new(
       config:,
-      failures:,
       state_snapshot:,
+      metrics_snapshot:,
       recovery_metrics_snapshot:
     )
   end
   let(:id) { SecureRandom.uuid }
-  let(:failures) { [latest_failure] }
   let(:latest_failure) { Stoplight::Domain::Failure.from_error(latest_exception, time: Time.now) }
   let(:latest_exception) { StandardError.new("bang!") }
   let(:color) { "green" }
   let(:name) { "light-specs" }
   let(:state) { Stoplight::State::UNLOCKED }
+  let(:metrics_snapshot) do
+    instance_double(Stoplight::Domain::MetricsSnapshot,
+      last_error: latest_failure)
+  end
   let(:recovery_metrics_snapshot) { nil }
   let(:config) { instance_double(Stoplight::Domain::Config, id:, name:, recovery_threshold: 13) }
   let(:state_snapshot) do
@@ -34,7 +37,6 @@ RSpec.describe Stoplight::Admin::LightView do
 
       context "when locked red with an errors" do
         let(:state) { Stoplight::State::LOCKED_RED }
-        let(:failures) { [latest_failure] }
 
         it { expect(description_title).to eq("Last Error") }
         it { expect(description_message).to eq("StandardError: bang!") }
@@ -43,7 +45,7 @@ RSpec.describe Stoplight::Admin::LightView do
 
       context "when locked red without errors" do
         let(:state) { Stoplight::State::LOCKED_RED }
-        let(:failures) { [] }
+        let(:latest_failure) { nil }
 
         it { expect(description_title).to eq("Locked Open") }
         it { expect(description_message).to eq("Circuit manually locked open") }
@@ -52,7 +54,6 @@ RSpec.describe Stoplight::Admin::LightView do
 
       context "when unlocked" do
         let(:state) { Stoplight::State::UNLOCKED }
-        let(:failures) { [latest_failure] }
 
         it { expect(description_title).to eq("Last Error") }
         it { expect(description_message).to eq("StandardError: bang!") }
@@ -62,7 +63,7 @@ RSpec.describe Stoplight::Admin::LightView do
 
       context "when unlocked without an error" do
         let(:state) { Stoplight::State::UNLOCKED }
-        let(:failures) { [] }
+        let(:latest_failure) { nil }
 
         it { expect(description_title).to eq("Last Error") }
         it { expect(description_message).to eq("Not available") }
@@ -105,7 +106,7 @@ RSpec.describe Stoplight::Admin::LightView do
       end
 
       context "without an error" do
-        let(:failures) { [] }
+        let(:latest_failure) { nil }
 
         it { expect(description_title).to eq("Testing Recovery") }
         it { expect(description_message).to eq("Not available") }
@@ -149,7 +150,7 @@ RSpec.describe Stoplight::Admin::LightView do
         name:,
         color:,
         locked: false,
-        failures: failures
+        failures: [latest_failure]
       })
     end
   end

--- a/spec/unit/stoplight/admin/lights_stats_spec.rb
+++ b/spec/unit/stoplight/admin/lights_stats_spec.rb
@@ -18,19 +18,19 @@ RSpec.describe Stoplight::Admin::LightsStats do
         [
           Stoplight::Admin::LightView.new(
             config: instance_double(Stoplight::Domain::Config, name: "green", id: "a"),
-            failures: [],
+            metrics_snapshot: instance_double(Stoplight::Domain::MetricsSnapshot, last_error: nil),
             state_snapshot: instance_double(Stoplight::Domain::StateSnapshot, color: "green", locked_state: "unlocked"),
             recovery_metrics_snapshot: nil
           ),
           Stoplight::Admin::LightView.new(
             config: instance_double(Stoplight::Domain::Config, name: "yellow", id: "b"),
-            failures: [],
+            metrics_snapshot: instance_double(Stoplight::Domain::MetricsSnapshot, last_error: nil),
             state_snapshot: instance_double(Stoplight::Domain::StateSnapshot, color: "yellow", locked_state: "unlocked"),
             recovery_metrics_snapshot: instance_double(Stoplight::Domain::MetricsSnapshot, requests: 4)
           ),
           Stoplight::Admin::LightView.new(
             config: instance_double(Stoplight::Domain::Config, name: "red", id: "c"),
-            failures: [],
+            metrics_snapshot: instance_double(Stoplight::Domain::MetricsSnapshot, last_error: nil),
             state_snapshot: instance_double(Stoplight::Domain::StateSnapshot, color: "red", locked_state: "locked"),
             recovery_metrics_snapshot: nil
           )

--- a/spec/unit/stoplight/admin/lights_stats_spec.rb
+++ b/spec/unit/stoplight/admin/lights_stats_spec.rb
@@ -17,30 +17,21 @@ RSpec.describe Stoplight::Admin::LightsStats do
       let(:lights) do
         [
           Stoplight::Admin::LightView.new(
-            id: "a",
-            config: instance_double(Stoplight::Domain::Config, name: "green"),
-            color: "green",
-            state: "unlocked",
+            config: instance_double(Stoplight::Domain::Config, name: "green", id: "a"),
             failures: [],
-            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot),
+            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot, color: "green", locked_state: "unlocked"),
             recovery_metrics_snapshot: nil
           ),
           Stoplight::Admin::LightView.new(
-            id: "b",
-            config: instance_double(Stoplight::Domain::Config, name: "yellow"),
-            color: "yellow",
-            state: "unlocked",
+            config: instance_double(Stoplight::Domain::Config, name: "yellow", id: "b"),
             failures: [],
-            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot),
+            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot, color: "yellow", locked_state: "unlocked"),
             recovery_metrics_snapshot: instance_double(Stoplight::Domain::MetricsSnapshot, requests: 4)
           ),
           Stoplight::Admin::LightView.new(
-            id: "c",
-            config: instance_double(Stoplight::Domain::Config, name: "red"),
-            color: "red",
-            state: "locked",
+            config: instance_double(Stoplight::Domain::Config, name: "red", id: "c"),
             failures: [],
-            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot),
+            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot, color: "red", locked_state: "locked"),
             recovery_metrics_snapshot: nil
           )
         ]


### PR DESCRIPTION
Fixes #883 

Before fix footer row of a light card only showed last check time when there are errors:

<img width="2060" height="686" alt="image" src="https://github.com/user-attachments/assets/16ee9083-8f83-4190-9c12-1e1c23bf08d4" />

After the fix, it's displayed always, say you can see when the light was used the last time.

<img width="512" height="244" alt="Screenshot 2026-08-26 at 00 28 50" src="https://github.com/user-attachments/assets/64560e37-4da7-4a8b-aadc-4b6823c844be" />

works for yellow too:

<img width="491" height="242" alt="Screenshot 2026-08-26 at 09 51 46" src="https://github.com/user-attachments/assets/cffbb127-9d83-4e54-871f-bc7e514b82d6" />

