### PR TITLE
Redis Window Metrics: smaller event keys

### DIFF
--- a/lib/stoplight/infrastructure/redis/storage/window_metrics.rb
+++ b/lib/stoplight/infrastructure/redis/storage/window_metrics.rb
@@ -47,7 +47,7 @@ module Stoplight
 
             @scripting.call(
               "window_metrics/record_success",
-              args: [timestamp, SecureRandom.hex(12), zset_ttl, metrics_ttl, window_start_ts],
+              args: [timestamp, zset_ttl, metrics_ttl, window_start_ts],
               keys: [@metrics_key, @success_key]
             )
           end
@@ -59,7 +59,7 @@ module Stoplight
             successes, errors, last_success_at, last_error_json, consecutive_errors, consecutive_successes =
               @scripting.call(
                 "window_metrics/record_failure",
-                args: [timestamp, SecureRandom.hex(12), serialize_exception(exception, timestamp:),
+                args: [timestamp, serialize_exception(exception, timestamp:),
                   zset_ttl, metrics_ttl, window_start_ts],
                 keys: [@metrics_key, @failure_key, @success_key]
               )

--- a/lib/stoplight/infrastructure/redis/storage/window_metrics/record_failure.lua
+++ b/lib/stoplight/infrastructure/redis/storage/window_metrics/record_failure.lua
@@ -1,15 +1,18 @@
 local failure_ts_str = ARGV[1]
 local failure_ts = tonumber(ARGV[1])
-local failure_id = ARGV[2]
-local failure_json = ARGV[3]
-local zset_ttl = tonumber(ARGV[4])
-local metadata_ttl = tonumber(ARGV[5])
+local failure_json = ARGV[2]
+local zset_ttl = tonumber(ARGV[3])
+local metadata_ttl = tonumber(ARGV[4])
 -- window_start_ts passed as string from Ruby to avoid Lua float→string precision loss in ZCOUNT
-local window_start_ts_str = ARGV[6]
+local window_start_ts_str = ARGV[5]
 
 local metrics_key = KEYS[1]
 local failures_key = KEYS[2]
 local successes_key = KEYS[3]
+
+-- Unique member per event; two at the same timestamp would collapse in ZADD and
+-- undercount in ZCOUNT. Shared with record_success, no separate key needed.
+local failure_id = redis.call('HINCRBY', metrics_key, 'seq', 1)
 
 -- Record failure and prune expired entries
 redis.call('ZADD', failures_key, failure_ts, failure_id)

--- a/lib/stoplight/infrastructure/redis/storage/window_metrics/record_success.lua
+++ b/lib/stoplight/infrastructure/redis/storage/window_metrics/record_success.lua
@@ -1,12 +1,15 @@
 local request_ts = tonumber(ARGV[1])
-local request_id = ARGV[2]
-local zset_ttl = tonumber(ARGV[3])
-local metadata_ttl = tonumber(ARGV[4])
+local zset_ttl = tonumber(ARGV[2])
+local metadata_ttl = tonumber(ARGV[3])
 -- window_start_ts passed as string from Ruby to avoid Lua float→string precision loss
-local window_start_ts_str = ARGV[5]
+local window_start_ts_str = ARGV[4]
 
 local metrics_key = KEYS[1]
 local successes_key = KEYS[2]
+
+-- Unique member per event; two at the same timestamp would collapse in ZADD and
+-- undercount in ZCOUNT. Shared with record_failure, no separate key needed.
+local request_id = redis.call('HINCRBY', metrics_key, 'seq', 1)
 
 -- Record success and prune expired entries
 redis.call('ZADD', successes_key, request_ts, request_id)

--- a/spec/unit/stoplight/infrastructure/redis/storage/window_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/window_metrics_spec.rb
@@ -23,5 +23,23 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::WindowMetrics, :redis 
 
       metrics.record_failure(StandardError.new)
     end
+
+    it "counts every failure individually even at the same timestamp" do
+      allow(clock).to receive(:current_time).and_return(Time.now)
+
+      3.times { metrics.record_failure(StandardError.new) }
+
+      expect(metrics.metrics_snapshot.errors).to eq(3)
+    end
+  end
+
+  describe "#record_success" do
+    it "counts every success individually even at the same timestamp" do
+      allow(clock).to receive(:current_time).and_return(Time.now)
+
+      3.times { metrics.record_success }
+
+      expect(metrics.metrics_snapshot.successes).to eq(3)
+    end
   end
 end


### PR DESCRIPTION
Further reduces amount of data stored as ZSET members for window metrics. Benchmark results in. At 15,000 members (50 req/s, 300s window):

| approach | KB | bytes/member |
|--------|--------|--------|
| hex-24 (SecureRandom) | 1,730 KB | 118 |
| int-seq (HINCRBY) | 1,494 KB | 102 |
| savings | ~236 KB/ZSET  | ~16 | 

Performance benchmark results: difference falls withing noise