### PR TITLE
Remove min_requests from ErrorRate public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,18 +353,9 @@ light = Stoplight(
 
 Monitors error rate over a 5-minute sliding window. The stoplight turns red when error rate exceeds 50%.
 
-```ruby
-light = Stoplight(
-  "Payment API", 
-  traffic_control: {
-    error_rate: { min_requests: 20 },
-  }, 
-  window_size: 300, 
-  threshold: 0.5,
-)
-```
-
-Only evaluates error rate after at least 20 requests within the window. Default `min_requests` is 10.
+Error rate evaluation starts only after 100 requests within the window — enough samples
+for a statistically reliable estimate. If your service handles fewer than 100 requests
+per window, the breaker will never trip on error rate; use `traffic_control: :consecutive_errors` instead.
 
 
 #### When to use:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,8 @@
 ## Stoplight 6.0  - WIP
 A list of breaking changes in the future version, to be described in more details:
+- `ErrorRate#new` no longer accepts `min_requests:`. The minimum sample guard is now a
+  fixed internal constant (100). Passing the keyword raises `ArgumentError`. Remove any
+  `min_requests:` arguments and any `{error_rate: {min_requests: N}}` DSL configuration.
 - Removed Light#with() method 
 - Removed Light's `#with_data_store`, `#with_cool_off_time`, `#with_threshold`, `#with_window_size`, `#with_notifiers`, 
   `#with_error_notifier`, `#with_tracked_errors`, `#with_skipped_errors`

--- a/features/stoplight/global_configuration/traffic_control.feature
+++ b/features/stoplight/global_configuration/traffic_control.feature
@@ -20,10 +20,10 @@ Feature: Stoplight configuration - Traffic Control
       | Threshold       | 0.5        |
       | Window Size     | 60         |
     When a light exists
-    And 10 requests are made
+    And 50 requests are made
     Then the light color is green
     When the service starts failing with "timeout"
-    And 9 requests are made
+    And 49 requests are made
     Then the light color is green
     When 1 request is made
     Then the light color is red

--- a/features/stoplight/traffic_control/error_rate.feature
+++ b/features/stoplight/traffic_control/error_rate.feature
@@ -12,9 +12,9 @@ Feature: Error Rate Traffic Control Strategy
         | Recovery Threshold | 2          |
 
   Scenario: Light transitions to red after threshold failures
-    Given 6 request are made
+    Given 60 requests are made
     And the service starts failing with "connection-timeout"
-    When 4 requests are made
+    When 40 requests are made
     Then the light color is red
     And notification about transition from green to red is sent
 
@@ -62,9 +62,9 @@ Feature: Error Rate Traffic Control Strategy
 
   Scenario: Light does not transition to to red after successful call
     Given the service starts failing with "connection-timeout"
-    When 9 requests are made
+    When 91 requests are made
     And the service recovers and starts functioning normally
-    And 1 request is made
+    And 8 requests are made
     And the service starts failing with "connection-timeout" again
     When 1 request is made
     Then the light color is red

--- a/lib/stoplight/domain/traffic_control/error_rate.rb
+++ b/lib/stoplight/domain/traffic_control/error_rate.rb
@@ -10,19 +10,15 @@ module Stoplight
       #   config = Stoplight::Domain::Config.new(threshold: 0.6, window_size: 300, traffic_control:)
       #
       # Will switch to red if 60% error rate reached within the 5-minute (300 seconds) sliding window.
-      # By default this traffic control strategy starts evaluating only after 10 requests have been made. You can
-      # adjust this by passing a different value for `min_requests` when initializing the strategy.
-      #
-      #   traffic_control = Stoplight::Domain::TrafficControl::ErrorRate.new(min_requests: 100)
       #
       # @api private
       class ErrorRate
         NAME = :error_rate
 
-        # @param min_requests Minimum number of requests before traffic control is applied.
-        #   until this number of requests is reached, the error rate will not be considered.
-        def initialize(min_requests: 10)
-          @min_requests = min_requests
+        MIN_REQUESTS = 100
+        private_constant :MIN_REQUESTS
+
+        def initialize
         end
 
         def check_compatibility(config)
@@ -32,10 +28,6 @@ module Stoplight
             CompatibilityResult.incompatible("`threshold` should be a number")
           elsif config.threshold < 0 || config.threshold > 1
             CompatibilityResult.incompatible("`threshold` should be between 0 and 1")
-          elsif !min_requests.is_a?(Integer)
-            CompatibilityResult.incompatible("`min_requests` should be an integer")
-          elsif min_requests <= 0
-            CompatibilityResult.incompatible("`min_requests` should be bigger than 0")
           else
             CompatibilityResult.compatible
           end
@@ -47,24 +39,20 @@ module Stoplight
 
           raise ArgumentError, "accepts only windowed metrics" if error_rate.nil? || requests.nil?
 
-          requests >= min_requests && error_rate >= config.threshold
+          requests >= MIN_REQUESTS && error_rate >= config.threshold
         end
 
         def name = NAME.to_s
 
         def ==(other)
-          other.is_a?(self.class) && min_requests == other.min_requests
+          other.is_a?(self.class)
         end
 
         def eql?(other)
           self == other
         end
 
-        def hash = [self.class, @min_requests].hash
-
-        protected
-
-        attr_reader :min_requests
+        def hash = self.class.hash
       end
     end
   end

--- a/lib/stoplight/wiring/light_configuration_dsl/traffic_control_dsl.rb
+++ b/lib/stoplight/wiring/light_configuration_dsl/traffic_control_dsl.rb
@@ -11,8 +11,6 @@ module Stoplight
           Domain::TrafficControl::ConsecutiveErrors.new
         in Domain::TrafficControl::ErrorRate::NAME
           Domain::TrafficControl::ErrorRate.new
-        in {error_rate: error_rate_settings}
-          Domain::TrafficControl::ErrorRate.new(**error_rate_settings)
         else
           raise Stoplight::Error::ConfigurationError, <<~ERROR
             unsupported traffic_control strategy provided (`#{value}`). Supported options:

--- a/sig/stoplight/domain/telemetry/settings.rbs
+++ b/sig/stoplight/domain/telemetry/settings.rbs
@@ -11,7 +11,6 @@ module Stoplight
         # Constant names of the error matchers (matchers are named constants responding to #===).
         attr_reader tracked_errors: Array[String]
         attr_reader skipped_errors: Array[String]
-        # Policy tags plus their parameters (e.g. error_rate min_requests).
         attr_reader traffic_control: String
         attr_reader traffic_control_params: Hash[String, untyped]
         attr_reader traffic_recovery: String

--- a/sig/stoplight/domain/traffic_control/error_rate.rbs
+++ b/sig/stoplight/domain/traffic_control/error_rate.rbs
@@ -5,10 +5,9 @@ module Stoplight
         include _TrafficControl
 
         NAME: :error_rate
+        MIN_REQUESTS: Integer
 
-        attr_reader min_requests: Integer
-
-        def initialize: (?min_requests: Integer) -> void
+        def initialize: () -> void
       end
     end
   end

--- a/sig/stoplight/wiring/types.rbs
+++ b/sig/stoplight/wiring/types.rbs
@@ -1,6 +1,6 @@
 module Stoplight
   module Wiring
-    type traffic_control = :consecutive_errors | :error_rate | {error_rate: {min_requests: Integer}}
+    type traffic_control = :consecutive_errors | :error_rate
     type traffic_recovery = :consecutive_successes
   end
 end

--- a/spec/integration/light_spec.rb
+++ b/spec/integration/light_spec.rb
@@ -141,10 +141,10 @@ RSpec.describe "Light" do
       specify "with error rate" do
         light = Stoplight(SecureRandom.uuid, traffic_control: :error_rate, threshold: 0.5, window_size: 60)
 
-        5.times { light.run(fallback) {} }
+        50.times { light.run(fallback) {} }
         expect(light.color).to eq(Stoplight::Color::GREEN)
 
-        5.times { light.run(fallback, &failing_code) }
+        51.times { light.run(fallback, &failing_code) }
         expect(light.color).to eq(Stoplight::Color::RED)
       end
 

--- a/spec/properties/light_configuration_dsl_spec.rb
+++ b/spec/properties/light_configuration_dsl_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Stoplight::Wiring::LightConfigurationDsl do
           traffic_control: choose(
             :consecutive_errors,
             :error_rate,
-            {error_rate: {min_requests: integer.abs}},
             Stoplight::Types.undefined
           ),
           traffic_recovery: choose(

--- a/spec/unit/stoplight/domain/traffic_control/error_rate_spec.rb
+++ b/spec/unit/stoplight/domain/traffic_control/error_rate_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Stoplight::Domain::TrafficControl::ErrorRate do
-  subject(:traffic_control) { described_class.new(min_requests:) }
-
-  let(:min_requests) { 10 }
+  subject(:traffic_control) { described_class.new }
 
   describe "#check_compatibility" do
     subject(:availability) { traffic_control.check_compatibility(config) }
@@ -13,8 +11,6 @@ RSpec.describe Stoplight::Domain::TrafficControl::ErrorRate do
     let(:window_size) { 600 }
 
     context "when stoplight tracks running window" do
-      let(:window_size) { 600 }
-
       it { is_expected.to be_compatible }
     end
 
@@ -79,30 +75,6 @@ RSpec.describe Stoplight::Domain::TrafficControl::ErrorRate do
         expect(availability.error_messages).to eq("`threshold` should be a number")
       end
     end
-
-    context "when min_requests is less then 1" do
-      let(:min_requests) { 0 }
-      it { is_expected.to be_incompatible }
-      it "returns an error message" do
-        expect(availability.error_messages).to eq("`min_requests` should be bigger than 0")
-      end
-    end
-
-    context "when min_requests is negative" do
-      let(:min_requests) { -5 }
-      it { is_expected.to be_incompatible }
-      it "returns an error message" do
-        expect(availability.error_messages).to eq("`min_requests` should be bigger than 0")
-      end
-    end
-
-    context "when min_requests is not an integer" do
-      let(:min_requests) { 10.5 }
-      it { is_expected.to be_incompatible }
-      it "returns an error message" do
-        expect(availability.error_messages).to eq("`min_requests` should be an integer")
-      end
-    end
   end
 
   describe "#stop_traffic?" do
@@ -110,8 +82,8 @@ RSpec.describe Stoplight::Domain::TrafficControl::ErrorRate do
 
     let(:config) { instance_double(Stoplight::Domain::Config, threshold:) }
     let(:metadata) { instance_double(Stoplight::Domain::MetricsSnapshot, error_rate:, requests:) }
-
     let(:threshold) { 0.6 }
+    let(:min_requests) { 100 }
 
     context "when min requests satisfied" do
       let(:requests) { min_requests + 1 }
@@ -177,25 +149,12 @@ RSpec.describe Stoplight::Domain::TrafficControl::ErrorRate do
   end
 
   describe "#eql?" do
-    it "returns true for same class and same min_requests" do
-      strategy_a = described_class.new
-      strategy_b = described_class.new
-
-      expect(strategy_a.eql?(strategy_b)).to be(true)
+    it "returns true for two instances" do
+      expect(described_class.new.eql?(described_class.new)).to be(true)
     end
 
-    it "returns false when same class and different min_requests" do
-      strategy_a = described_class.new(min_requests: 10)
-      strategy_b = described_class.new(min_requests: 11)
-
-      expect(strategy_a.eql?(strategy_b)).to be(false)
-    end
-
-    it "returns false when different class and same min_requests" do
-      strategy_a = described_class.new(min_requests: 10)
-      strategy_b = Stoplight::Domain::TrafficControl::ConsecutiveErrors.new
-
-      expect(strategy_a.eql?(strategy_b)).to be(false)
+    it "returns false for a different class" do
+      expect(described_class.new.eql?(Stoplight::Domain::TrafficControl::ConsecutiveErrors.new)).to be(false)
     end
   end
 end

--- a/spec/unit/stoplight/wiring/light_configuration_dsl/traffic_control_dsl_spec.rb
+++ b/spec/unit/stoplight/wiring/light_configuration_dsl/traffic_control_dsl_spec.rb
@@ -27,14 +27,6 @@ RSpec.describe Stoplight::Wiring::LightConfigurationDsl::TrafficControlDsl do
     end
   end
 
-  context "when :error_rate with options" do
-    let(:traffic_control) { {error_rate: {min_requests: 11}} }
-
-    it "returns an instance of Stoplight::Domain::TrafficControl::ErrorRate with min_requests" do
-      is_expected.to eq(Stoplight::Domain::TrafficControl::ErrorRate.new(min_requests: 11))
-    end
-  end
-
   context "when unsupported option" do
     let(:traffic_control) { :latency }
 


### PR DESCRIPTION
Error Rate strategy no longer accepts a min_requests: keyword argument. The minimum sample size is now fixed at 100 requests (MIN_REQUESTS = 100).

## why

The error rate is only useful as a circuit-breaker signal when it is based on enough requests.

With a very small number of requests, a single failure can change the error rate dramatically. For example, with 10 requests, one failure changes the measured error rate by 10 percentage points. This can cause the circuit breaker to react to normal random variation rather than a genuine problem.

Requiring at least 100 requests makes the measurement more stable: each individual request changes the measured error rate by only 1 percentage point.

100 is therefore used as a fixed minimum rather than allowing callers to configure arbitrarily small values.

As a rule of thumb, statistical analysis of proportions also shows that around 100 observations gives a worst-case 95% margin of error of roughly ±10 percentage points. This is not a guarantee of accuracy, but it illustrates why very small samples provide much less reliable measurements.
