### PR TITLE
Drop unsupported versions of dependencies 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           - 'redis:8.0'
           - 'valkey/valkey:7.2-alpine'
           - 'valkey/valkey:8.1-alpine'
-        ruby: [ '3.2', '3.3', '3.4', '4.0' ]
+        ruby: ['3.3', '3.4', '4.0' ]
     services:
       data-store:
         image: ${{ matrix.data-store-image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,9 @@ jobs:
     strategy:
       matrix:
         data-store-image:
-          - 'redis:6.2'
-          - 'redis:7.2'
           - 'redis:7.4'
-          - 'redis:8.0'
+          - 'redis:8.4'
+          - 'redis:8.6'
           - 'valkey/valkey:7.2-alpine'
           - 'valkey/valkey:8.1-alpine'
         ruby: ['3.3', '3.4', '4.0' ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
           - 'redis:8.6'
           - 'valkey/valkey:7.2-alpine'
           - 'valkey/valkey:8.1-alpine'
+          - 'valkey/valkey:9.1-alpine'
         ruby: ['3.3', '3.4', '4.0' ]
     services:
       data-store:

--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ We only actively support the latest major version of Stoplight.
 
 **Data Stores**: Current supported versions from upstream (versions that receive security updates):
 
-* Redis: 8.0.x, 7.4.x, 7.2.x, 6.2.x (following [Redis's support policy])
+* Redis: 8.6.x, 8.4.x, 7.4.x (following [Redis's support policy])
 * Valkey: 8.0.x, 7.2.x (following [Valkey's support policy])
 * We test against the latest version of each major release
 

--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ We only actively support the latest major version of Stoplight.
 
 **Ruby**: Major versions that receive security updates (see [Ruby Maintenance Branches]):
 
-* Currently: Ruby 3.2.x, 3.3.x and 3.4.x
+* Currently: Ruby 3.3.x, 3.4.x and 4.0.x
 * We test against these versions in CI
 
 **Data Stores**: Current supported versions from upstream (versions that receive security updates):
@@ -635,7 +635,7 @@ For dependencies:
 * Ruby: When Ruby core team ends security support, we drop it in our next major release
 * Data Stores: When Redis/Valkey ends maintenance, we drop it in our next major release
 
-Example: "Ruby 3.2 reaches end-of-life in March 2026, so Stoplight 6.0 will require Ruby 3.3+"
+Example: "Ruby 3.3 reaches end-of-life in March 2027, so Stoplight 7.0 will require Ruby 3.4+"
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ We only actively support the latest major version of Stoplight.
 **Data Stores**: Current supported versions from upstream (versions that receive security updates):
 
 * Redis: 8.6.x, 8.4.x, 7.4.x (following [Redis's support policy])
-* Valkey: 8.0.x, 7.2.x (following [Valkey's support policy])
+* Valkey: 9.1.x, 9.0.x, 8.1.x, 8.0.x, 7.2.x (following [Valkey's support policy])
 * We test against the latest version of each major release
 
 For dependencies:


### PR DESCRIPTION
Changes:
- Drop Ruby 3.2 support (EOL: April 1 2026)
- Drop Redis 7.2 (EOL February 28, 2026), 6.4 (EOL August 31, 2025), and 6.2 (EOL February 28, 2025) support'
- Extend Valkey support with 9.x series