### PR TITLE
Emit RecoveryProbeCompleted on every yellow-state probe

### DIFF
--- a/lib/stoplight/domain/strategies/yellow_run_strategy.rb
+++ b/lib/stoplight/domain/strategies/yellow_run_strategy.rb
@@ -106,21 +106,21 @@ module Stoplight
         end
 
         def capture_started_at
-          @clock.monotonic_millis if @run_recorder.subscribed?
+          @clock.monotonic_millis
         end
 
         def duration_since(started_at)
-          @clock.monotonic_millis - started_at if started_at
+          @clock.monotonic_millis - started_at
         end
 
         def record_recovery_probe_success(duration_ms:, error: nil)
           @run_recorder.record_success(duration_ms:, error:)
-          request_tracker.record_success
+          request_tracker.record_success(duration_ms:)
         end
 
         def record_recovery_probe_failure(error, duration_ms:, fallback_used:)
           @run_recorder.record_failure(error, duration_ms:, fallback_used:)
-          request_tracker.record_failure(error)
+          request_tracker.record_failure(error, duration_ms:)
         end
 
         def enter_recovery(state_snapshot)

--- a/lib/stoplight/domain/tracker/recovery_probe.rb
+++ b/lib/stoplight/domain/tracker/recovery_probe.rb
@@ -13,17 +13,16 @@ module Stoplight
           @emitter = emitter
         end
 
-        # @param exception [Exception]
-        def record_failure(exception)
+        def record_failure(exception, duration_ms:)
           metrics_store.record_failure(exception)
 
-          recover
+          recover(duration_ms:, exception:)
         end
 
-        def record_success
+        def record_success(duration_ms:)
           metrics_store.record_success
 
-          recover
+          recover(duration_ms:, exception: nil)
         end
 
         private
@@ -35,8 +34,24 @@ module Stoplight
         attr_reader :state_store
         attr_reader :emitter
 
-        def recover
+        def recover(duration_ms:, exception:)
           recovery_metrics = metrics_store.metrics_snapshot
+
+          emitter.emit(Telemetry::RecoveryProbeCompleted) do
+            failure = exception ? Telemetry::Failure.new(exception:, tracked: true) : nil
+            Telemetry::RecoveryProbeCompleted.new(
+              outcome: failure ? :failure : :success,
+              duration_ms:,
+              failure:,
+              progress: Telemetry::Metrics.new(
+                successes: recovery_metrics.successes,
+                errors: recovery_metrics.errors,
+                consecutive_errors: recovery_metrics.consecutive_errors,
+                consecutive_successes: recovery_metrics.consecutive_successes
+              )
+            )
+          end
+
           recovery_result = traffic_recovery.determine_color(config, recovery_metrics)
 
           return if recovery_result == TrafficRecovery::YELLOW

--- a/sig/stoplight/domain/strategies/yellow_run_strategy.rbs
+++ b/sig/stoplight/domain/strategies/yellow_run_strategy.rbs
@@ -32,19 +32,19 @@ module Stoplight
         def with_recovery_lock: [T] (
             fallback: (^(StandardError?) -> T)?,
             state_snapshot: StateSnapshot,
-          ) { (duration_ms?) -> T } -> T
+          ) { (duration_ms) -> T } -> T
 
-        def capture_started_at: () -> Float?
-        def duration_since: (duration_ms?) -> duration_ms?
+        def capture_started_at: () -> Float
+        def duration_since: (duration_ms) -> duration_ms
 
         def record_recovery_probe_success: (
-            duration_ms: duration_ms?,
+            duration_ms: duration_ms,
             ?error: StandardError?
           ) -> void
 
         def record_recovery_probe_failure: (
             StandardError,
-            duration_ms: duration_ms?,
+            duration_ms: duration_ms,
             fallback_used: bool,
           ) -> void
 

--- a/sig/stoplight/domain/tracker/recovery_probe.rbs
+++ b/sig/stoplight/domain/tracker/recovery_probe.rbs
@@ -18,9 +18,12 @@ module Stoplight
           emitter: Telemetry::Emitter,
         ) -> void
 
-        def record_failure: (StandardError exception) -> void
-        def record_success: -> void
-        def recover: -> void
+        def record_failure: (StandardError exception, duration_ms: Float) -> void
+        def record_success: (duration_ms: Float) -> void
+
+        private
+
+        def recover: (duration_ms: Float, exception: StandardError?) -> void
         def transition: (from_color: color, to_color: color) -> bool
       end
     end

--- a/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
         let(:code) { -> { "Success" } }
 
         it "returns result" do
-          expect(request_tracker).to receive(:record_success)
+          expect(request_tracker).to receive(:record_success).with(duration_ms: anything)
           expect(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
 
           expect(result).to eq("Success")
@@ -70,16 +70,15 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
         end
       end
 
-      context "when nobody is subscribed to telemetry" do
+      context "when nobody is subscribed to RunCompleted" do
         subject(:result) { strategy.execute(nil, state_snapshot: nil, error_tracking_policy:, &code) }
 
         let(:code) { -> { "Success" } }
         let(:run_recorder) { instance_double(Stoplight::Domain::Telemetry::RunRecorder, subscribed?: false, record_success: nil) }
 
-        it "does not measure duration" do
-          expect(request_tracker).to receive(:record_success)
+        it "still captures duration for probe telemetry" do
+          expect(request_tracker).to receive(:record_success).with(duration_ms: be_a(Float))
           expect(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
-          expect(clock).not_to receive(:monotonic_millis)
 
           expect(result).to eq("Success")
         end
@@ -102,14 +101,14 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
             let(:fallback) { nil }
 
             it "records failure, notify and raises the error" do
-              expect(request_tracker).to receive(:record_failure).with(error)
+              expect(request_tracker).to receive(:record_failure).with(error, duration_ms: anything)
               expect(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
 
               expect { result }.to raise_error(error)
             end
 
             it "produces RunCompleted event" do
-              expect(request_tracker).to receive(:record_failure).with(error)
+              expect(request_tracker).to receive(:record_failure).with(error, duration_ms: anything)
               allow(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
               expect(clock).to receive(:monotonic_millis).and_return(1.4, 2.2)
 
@@ -135,7 +134,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
             end
 
             it "records failure, notify and returns the fallback" do
-              expect(request_tracker).to receive(:record_failure).with(error)
+              expect(request_tracker).to receive(:record_failure).with(error, duration_ms: anything)
               expect(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
 
               expect(result).to eq("Fallback")
@@ -143,7 +142,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
             end
 
             it "produces RunCompleted event" do
-              expect(request_tracker).to receive(:record_failure).with(error)
+              expect(request_tracker).to receive(:record_failure).with(error, duration_ms: anything)
               allow(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
               expect(clock).to receive(:monotonic_millis).and_return(1.4, 2.2)
 
@@ -164,7 +163,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
           let(:track_error) { false }
 
           it "records success and raises the error" do
-            expect(request_tracker).to receive(:record_success)
+            expect(request_tracker).to receive(:record_success).with(duration_ms: anything)
             expect(recovery_lock_store).to receive(:release_lock).with(recovery_lock_token)
             expect(clock).to receive(:monotonic_millis).and_return(1.4, 2.2)
 

--- a/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
+++ b/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
@@ -64,7 +64,10 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       transition_to: Stoplight::Color::RED
 
     context "when recover to unexpected to outcome" do
-      let(:metrics_after_probe) { instance_double(Stoplight::Domain::MetricsSnapshot) }
+      let(:metrics_after_probe) {
+        instance_double(Stoplight::Domain::MetricsSnapshot,
+          successes: 0, errors: 0, consecutive_errors: 0, consecutive_successes: 0)
+      }
       let(:recover_to) { "unexpected" }
 
       before do
@@ -77,7 +80,10 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
     end
 
     context "when recover to YELLOW (needs more probes)" do
-      let(:metrics_after_probe) { instance_double(Stoplight::Domain::MetricsSnapshot) }
+      let(:metrics_after_probe) {
+        instance_double(Stoplight::Domain::MetricsSnapshot,
+          successes: 0, errors: 0, consecutive_errors: 0, consecutive_successes: 0)
+      }
       let(:recover_to) { Stoplight::Domain::TrafficRecovery::YELLOW }
 
       before do
@@ -95,7 +101,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
   end
 
   describe "#record_success" do
-    subject(:record_probe) { recorder.record_success }
+    subject(:record_probe) { recorder.record_success(duration_ms: 5.0) }
 
     before do
       allow(metrics_store).to receive(:record_success)
@@ -106,7 +112,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
   end
 
   describe "#record_failure" do
-    subject(:record_probe) { recorder.record_failure(exception) }
+    subject(:record_probe) { recorder.record_failure(exception, duration_ms: 3.0) }
 
     let(:exception) { KeyError.new("bang") }
 
@@ -142,7 +148,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       end
 
       it "emits a RecoverySucceeded event with the transition details" do
-        expect { recorder.record_success }.to emit(Stoplight::Domain::Telemetry::RecoverySucceeded).with(
+        expect { recorder.record_success(duration_ms: 5.0) }.to emit(Stoplight::Domain::Telemetry::RecoverySucceeded).with(
           from_color: Stoplight::Color::YELLOW,
           to_color: Stoplight::Color::GREEN,
           policy: policy_name,
@@ -156,7 +162,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       end
 
       it "emits exactly one RecoverySucceeded event" do
-        recorder.record_success
+        recorder.record_success(duration_ms: 5.0)
 
         count = emitter.emitted.count { |event| event.instance_of?(Stoplight::Domain::Telemetry::RecoverySucceeded) }
         expect(count).to eq(1)
@@ -168,7 +174,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
         end
 
         it "does not emit a RecoverySucceeded event" do
-          expect { recorder.record_success }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
+          expect { recorder.record_success(duration_ms: 5.0) }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
         end
       end
     end
@@ -179,7 +185,7 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       end
 
       it "does not emit a RecoverySucceeded event" do
-        expect { recorder.record_success }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
+        expect { recorder.record_success(duration_ms: 5.0) }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
       end
     end
 
@@ -190,7 +196,105 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       end
 
       it "does not emit a RecoverySucceeded event" do
-        expect { recorder.record_success }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
+        expect { recorder.record_success(duration_ms: 5.0) }.not_to emit(Stoplight::Domain::Telemetry::RecoverySucceeded)
+      end
+    end
+  end
+
+  describe "RecoveryProbeCompleted telemetry" do
+    let(:metrics_after_probe) {
+      instance_double(Stoplight::Domain::MetricsSnapshot,
+        successes: 5,
+        errors: 2,
+        consecutive_errors: 0,
+        consecutive_successes: 3)
+    }
+    let(:expected_progress) {
+      Stoplight::Domain::Telemetry::Metrics.new(
+        successes: metrics_after_probe.successes,
+        errors: metrics_after_probe.errors,
+        consecutive_errors: metrics_after_probe.consecutive_errors,
+        consecutive_successes: metrics_after_probe.consecutive_successes
+      )
+    }
+
+    before do
+      allow(metrics_store).to receive(:metrics_snapshot).and_return(metrics_after_probe)
+      allow(metrics_store).to receive(:clear)
+      allow(notifier).to receive(:notify)
+      allow(traffic_recovery).to receive(:determine_color).and_return(Stoplight::Domain::TrafficRecovery::YELLOW)
+    end
+
+    context "when a probe succeeds" do
+      before { allow(metrics_store).to receive(:record_success) }
+
+      it "emits RecoveryProbeCompleted with outcome :success" do
+        expect { recorder.record_success(duration_ms: 5.0) }
+          .to emit(Stoplight::Domain::Telemetry::RecoveryProbeCompleted).with(
+            outcome: :success,
+            duration_ms: 5.0,
+            failure: nil,
+            progress: expected_progress
+          )
+      end
+
+      it "emits exactly one RecoveryProbeCompleted event per probe" do
+        recorder.record_success(duration_ms: 5.0)
+
+        count = emitter.emitted.count { |e| e.instance_of?(Stoplight::Domain::Telemetry::RecoveryProbeCompleted) }
+        expect(count).to eq(1)
+      end
+    end
+
+    context "when a probe fails" do
+      let(:exception) { KeyError.new("bang") }
+
+      before { allow(metrics_store).to receive(:record_failure).with(exception) }
+
+      it "emits RecoveryProbeCompleted with outcome :failure" do
+        expect { recorder.record_failure(exception, duration_ms: 3.0) }
+          .to emit(Stoplight::Domain::Telemetry::RecoveryProbeCompleted).with(
+            outcome: :failure,
+            duration_ms: 3.0,
+            failure: have_attributes(exception: exception, tracked: true),
+            progress: expected_progress
+          )
+      end
+
+      it "emits exactly one RecoveryProbeCompleted event per probe" do
+        recorder.record_failure(exception, duration_ms: 3.0)
+
+        count = emitter.emitted.count { |e| e.instance_of?(Stoplight::Domain::Telemetry::RecoveryProbeCompleted) }
+        expect(count).to eq(1)
+      end
+    end
+
+    context "when the probe transitions to green" do
+      before do
+        allow(metrics_store).to receive(:record_success)
+        allow(traffic_recovery).to receive(:determine_color).and_return(Stoplight::Domain::TrafficRecovery::GREEN)
+        allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::GREEN).and_return(true)
+        allow(traffic_recovery).to receive(:name).and_return(policy_name)
+      end
+
+      it "still emits RecoveryProbeCompleted" do
+        expect { recorder.record_success(duration_ms: 5.0) }
+          .to emit(Stoplight::Domain::Telemetry::RecoveryProbeCompleted)
+      end
+    end
+
+    context "when the probe transitions to red" do
+      let(:exception) { KeyError.new("bang") }
+
+      before do
+        allow(metrics_store).to receive(:record_failure).with(exception)
+        allow(traffic_recovery).to receive(:determine_color).and_return(Stoplight::Domain::TrafficRecovery::RED)
+        allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::RED).and_return(true)
+      end
+
+      it "still emits RecoveryProbeCompleted" do
+        expect { recorder.record_failure(exception, duration_ms: 3.0) }
+          .to emit(Stoplight::Domain::Telemetry::RecoveryProbeCompleted)
       end
     end
   end


### PR DESCRIPTION
Closes #746 

Wires the `Telemetry::RecoveryProbeCompleted` event so subscribers can observe probe outcome, latency, and recovery progress.