### PR TITLE
Wire `LightRegistered` event

### DIFF
--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -41,7 +41,7 @@ module Stoplight
       end
 
       def build
-        Stoplight::Domain::Light.new(
+        light = Stoplight::Domain::Light.new(
           @name,
           state_store:,
           green_run_strategy:,
@@ -50,6 +50,12 @@ module Stoplight
           lock_control:,
           error_tracking_policy: @error_tracking_policy
         )
+
+        @emitter.emit(Domain::Telemetry::LightRegistered) do
+          Domain::Telemetry::LightRegistered.new(settings: telemetry_settings)
+        end
+
+        light
       end
 
       def state_store = storage_set.state_store
@@ -146,6 +152,22 @@ module Stoplight
 
       def run_recorder(color)
         Domain::Telemetry::RunRecorder.new(emitter: @emitter, color:)
+      end
+
+      def telemetry_settings
+        Domain::Telemetry::Settings.new(
+          cool_off_time: @config.cool_off_time,
+          threshold: @config.threshold,
+          recovery_threshold: @config.recovery_threshold,
+          window_size: @config.window_size,
+          tracked_errors: @config.tracked_errors.map { |matcher| Domain::MatcherValidator.call(matcher) },
+          skipped_errors: @config.skipped_errors.map { |matcher| Domain::MatcherValidator.call(matcher) },
+          traffic_control: @config.traffic_control.name,
+          traffic_recovery: @config.traffic_recovery.name,
+          # No strategy accepts constructor params yet; placeholder for forward compatibility.
+          traffic_control_params: {},
+          traffic_recovery_params: {}
+        )
       end
 
       def redis

--- a/sig/stoplight/wiring/light_factory.rbs
+++ b/sig/stoplight/wiring/light_factory.rbs
@@ -60,6 +60,7 @@ module Stoplight
       def yellow_run_strategy: -> Domain::Strategies::YellowRunStrategy
       def red_run_strategy: -> Domain::Strategies::RedRunStrategy
       def run_recorder: (Domain::color) -> Domain::Telemetry::RunRecorder
+      def telemetry_settings: -> Domain::Telemetry::Settings
       def redis: -> Infrastructure::redis
       def storage_scripting: -> Infrastructure::Redis::Storage::Scripting
       def failover_system: -> _System

--- a/spec/unit/stoplight/wiring/light_factory_spec.rb
+++ b/spec/unit/stoplight/wiring/light_factory_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Wiring::LightFactory do
+  subject(:factory) do
+    described_class.new(
+      system_id: Stoplight::Domain::Id.for("Test"),
+      system_name: "Test",
+      config:,
+      failover_system:,
+      telemetry: bus
+    )
+  end
+
+  let(:failover_system) do
+    Stoplight::Wiring::System.new(
+      config: Stoplight::Wiring::FailSafeConfig.with(name: SecureRandom.uuid),
+      failover_system: nil,
+      registry: instance_double(Stoplight::Infrastructure::Memory::Storage::Registry, register: nil)
+    )
+  end
+
+  let(:config) do
+    Stoplight::Wiring::LightConfigurationDsl.new(
+      name: "stripe",
+      tracked_errors: [ArgumentError],
+      skipped_errors: [TypeError],
+      traffic_control: :error_rate,
+      threshold: 0.5,
+      window_size: 60,
+      traffic_recovery: :consecutive_successes
+    ).configure!(Stoplight::Wiring::DefaultConfig)
+  end
+
+  let(:bus) { Stoplight::Domain::Telemetry::Bus.new(error_notifier: ->(error) { raise error }) }
+  let(:received) { [] }
+
+  before { bus.subscribe(Stoplight::Domain::Telemetry::LightRegistered) { |envelope| received << envelope } }
+
+  describe "#build" do
+    it "emits exactly one LightRegistered event" do
+      factory.build
+
+      expect(received.size).to eq(1)
+    end
+
+    it "maps the resolved config onto a Settings snapshot" do
+      factory.build
+
+      settings = received.first.payload.settings
+      expect(settings).to have_attributes(
+        cool_off_time: config.cool_off_time,
+        threshold: 0.5,
+        recovery_threshold: config.recovery_threshold,
+        window_size: 60,
+        tracked_errors: ["ArgumentError"],
+        skipped_errors: ["TypeError"],
+        traffic_control: "error_rate",
+        traffic_control_params: {},
+        traffic_recovery: "consecutive_successes",
+        traffic_recovery_params: {}
+      )
+    end
+
+    it "returns the fully constructed light" do
+      light = factory.build
+
+      expect(light).to be_a(Stoplight::Domain::Light)
+      expect(light.name).to eq("stripe")
+    end
+  end
+end

--- a/spec/unit/stoplight/wiring/system_spec.rb
+++ b/spec/unit/stoplight/wiring/system_spec.rb
@@ -195,6 +195,36 @@ RSpec.describe Stoplight::Wiring::System do
       expect(system.telemetry).not_to respond_to(:publish)
       expect(system.telemetry).not_to respond_to(:subscribed?)
     end
+
+    describe "LightRegistered" do
+      it "emits exactly one LightRegistered event when a light is registered for the first time" do
+        system.telemetry.subscribe(Stoplight::Telemetry::LightRegistered) { |envelope| received << envelope }
+
+        system.register("stripe")
+
+        expect(received.size).to eq(1)
+        expect(received.first.payload).to be_a(Stoplight::Telemetry::LightRegistered)
+      end
+
+      it "does not emit LightRegistered again when the same light is registered a second time" do
+        system.telemetry.subscribe(Stoplight::Telemetry::LightRegistered) { |envelope| received << envelope }
+
+        system.register("stripe")
+        system.register("stripe")
+
+        expect(received.size).to eq(1)
+      end
+
+      it "emits LightRegistered before any other telemetry event for the light" do
+        system.telemetry.subscribe { |envelope| received << envelope }
+
+        system.register("stripe")
+        system.light("stripe").run { "ok" }
+
+        expect(received[0].payload).to be_a(Stoplight::Telemetry::LightRegistered)
+        expect(received[1].payload).to be_a(Stoplight::Telemetry::RunCompleted)
+      end
+    end
   end
 
   describe "#light" do


### PR DESCRIPTION
Closes #752.

`LightRegistered` fires once per (process, system, light) — the moment a light's configuration first materializes — so a subscriber can build a live inventory of every configured light without waiting for it to run or fail. The event type, its RBS signature, and its slot in the bus `EVENT_CLASSES` set all existed already; this PR wires the emit call and adds spec coverage.

The emit lives in `LightFactory#build` rather than `System#register`: `LightFactory` already holds both the light's own emitter and its fully-resolved config, and `Domain::Light.new` is side-effect-free, so emitting right after construction and before returning satisfies the ordering guarantee that this event precedes every other event for that light. The `Settings` payload maps directly off the resolved config, reusing `Domain::MatcherValidator` for error-matcher names; `traffic_control_params`/`traffic_recovery_params` default to `{}` since no strategy takes constructor params yet.