### PR TITLE
Route legacy notifiers through the telemetry bus instead of domain code

### DIFF
--- a/lib/stoplight/domain/strategies/yellow_run_strategy.rb
+++ b/lib/stoplight/domain/strategies/yellow_run_strategy.rb
@@ -13,17 +13,15 @@ module Stoplight
       class YellowRunStrategy
         def initialize(
           name:,
-          notifiers:,
           request_tracker:,
           state_store:,
           metrics_store:,
           recovery_lock_store:,
-          config:, # FIXME: needed for backward compatibility, remove when notifier accepts light config
+          config:,
           clock:,
           run_recorder:,
           emitter:
         )
-          @notifiers = notifiers
           @request_tracker = request_tracker
           @state_store = state_store
           @metrics_store = metrics_store
@@ -75,7 +73,6 @@ module Stoplight
 
         private
 
-        attr_reader :notifiers
         attr_reader :request_tracker
         attr_reader :state_store
         attr_reader :metrics_store
@@ -134,10 +131,6 @@ module Stoplight
               to_color: Color::YELLOW,
               breached_at: T.must(state_snapshot.breached_at)
             )
-          end
-          light_info = LightInfo.new(name: @name)
-          notifiers.each do |notifier|
-            notifier.notify(light_info, Color::RED, Color::YELLOW, nil)
           end
         end
       end

--- a/lib/stoplight/domain/tracker/recovery_probe.rb
+++ b/lib/stoplight/domain/tracker/recovery_probe.rb
@@ -4,9 +4,8 @@ module Stoplight
   module Domain
     module Tracker
       class RecoveryProbe
-        def initialize(traffic_recovery:, notifiers:, config:, metrics_store:, state_store:, emitter:)
+        def initialize(traffic_recovery:, config:, metrics_store:, state_store:, emitter:)
           @traffic_recovery = traffic_recovery
-          @notifiers = notifiers
           @config = config
           @metrics_store = metrics_store
           @state_store = state_store
@@ -28,7 +27,6 @@ module Stoplight
         private
 
         attr_reader :traffic_recovery
-        attr_reader :notifiers
         attr_reader :config
         attr_reader :metrics_store
         attr_reader :state_store
@@ -59,7 +57,7 @@ module Stoplight
           case recovery_result
           when TrafficRecovery::GREEN
             to_color = Color::GREEN
-            if transition(from_color: Color::YELLOW, to_color:)
+            if transition(to_color:)
               emitter.emit(Telemetry::RecoverySucceeded) do
                 Telemetry::RecoverySucceeded.new(from_color: Color::YELLOW, to_color:,
                   policy: traffic_recovery.name,
@@ -73,7 +71,7 @@ module Stoplight
             end
           when TrafficRecovery::RED
             to_color = Color::RED
-            if transition(from_color: Color::YELLOW, to_color:)
+            if transition(to_color:)
               emitter.emit(Telemetry::RecoveryFailed) do
                 Telemetry::RecoveryFailed.new(
                   from_color: Color::YELLOW,
@@ -94,13 +92,9 @@ module Stoplight
           end
         end
 
-        def transition(from_color:, to_color:)
+        def transition(to_color:)
           return false unless state_store.transition_to_color(to_color)
           metrics_store.clear
-          info = LightInfo.new(name: config.name)
-          notifiers.each do |notifier|
-            notifier.notify(info, from_color, to_color, nil)
-          end
           true
         end
       end

--- a/lib/stoplight/domain/tracker/request.rb
+++ b/lib/stoplight/domain/tracker/request.rb
@@ -10,9 +10,8 @@ module Stoplight
       #
       # @api private
       class Request
-        def initialize(traffic_control:, notifiers:, config:, metrics_store:, state_store:, emitter:)
+        def initialize(traffic_control:, config:, metrics_store:, state_store:, emitter:)
           @traffic_control = traffic_control
-          @notifiers = notifiers
           @config = config
           @metrics_store = metrics_store
           @state_store = state_store
@@ -30,7 +29,6 @@ module Stoplight
         private
 
         attr_reader :traffic_control
-        attr_reader :notifiers
         attr_reader :config
         attr_reader :metrics_store
         attr_reader :state_store
@@ -41,10 +39,6 @@ module Stoplight
             # Returns true only if not yet in red therefore preventing
             # duplicate notifications
             if state_store.transition_to_color(Color::RED)
-              info = LightInfo.new(name: config.name)
-              notifiers.each do |notifier|
-                notifier.notify(info, Color::GREEN, Color::RED, exception)
-              end
               emitter.emit(Telemetry::TrafficBreached) do
                 Telemetry::TrafficBreached.new(
                   from_color: Color::GREEN,

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -37,6 +37,7 @@ module Stoplight
           clock: @clock,
           error_notifier: @error_notifier
         )
+        @telemetry = telemetry
         @wrapped_notifiers = nil
       end
 
@@ -54,6 +55,8 @@ module Stoplight
         @emitter.emit(Domain::Telemetry::LightRegistered) do
           Domain::Telemetry::LightRegistered.new(settings: telemetry_settings)
         end
+
+        NotifierBridge.new(light_name: @name, notifiers:).subscribe(@telemetry) unless notifiers.empty?
 
         light
       end
@@ -105,13 +108,12 @@ module Stoplight
       end
 
       def request_tracker
-        Domain::Tracker::Request.new(traffic_control:, notifiers:, config:, metrics_store:, state_store:, emitter: @emitter)
+        Domain::Tracker::Request.new(traffic_control:, config:, metrics_store:, state_store:, emitter: @emitter)
       end
 
       def recovery_probe_tracker
         Domain::Tracker::RecoveryProbe.new(
           traffic_recovery:,
-          notifiers:,
           config:,
           metrics_store: recovery_metrics_store,
           state_store:,
@@ -130,7 +132,6 @@ module Stoplight
       def yellow_run_strategy
         Domain::Strategies::YellowRunStrategy.new(
           name: @name,
-          notifiers:,
           request_tracker: recovery_probe_tracker,
           state_store:,
           metrics_store:,

--- a/lib/stoplight/wiring/light_factory.rb
+++ b/lib/stoplight/wiring/light_factory.rb
@@ -21,7 +21,6 @@ module Stoplight
         @error_notifier = Infrastructure::FailSafe::ErrorNotifier.new(
           error_notifier: config.error_notifier
         )
-        @notifiers = config.notifiers
         @traffic_recovery = config.traffic_recovery
         @traffic_control = config.traffic_control
 
@@ -37,8 +36,6 @@ module Stoplight
           clock: @clock,
           error_notifier: @error_notifier
         )
-        @telemetry = telemetry
-        @wrapped_notifiers = nil
       end
 
       def build
@@ -55,8 +52,6 @@ module Stoplight
         @emitter.emit(Domain::Telemetry::LightRegistered) do
           Domain::Telemetry::LightRegistered.new(settings: telemetry_settings)
         end
-
-        NotifierBridge.new(light_name: @name, notifiers:).subscribe(@telemetry) unless notifiers.empty?
 
         light
       end
@@ -94,17 +89,6 @@ module Stoplight
 
       def storage_set
         @storage_set ||= StorageSetBuilder.new(backend: build_backend, windowed: !config.window_size.nil?).build
-      end
-
-      # @return [<Stoplight::Notifier::Base>]
-      def notifiers
-        @wrapped_notifiers ||= Array(@notifiers).map do |notifier|
-          Infrastructure::Notifier::FailSafe.new(
-            notifier:,
-            error_notifier:,
-            circuit_breaker: create_circuit_breaker("notifier:#{notifier.class.name}")
-          )
-        end
       end
 
       def request_tracker

--- a/lib/stoplight/wiring/notifier_bridge.rb
+++ b/lib/stoplight/wiring/notifier_bridge.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Wiring
+    # Subscribes the legacy, user-facing +Notifier+ collaborators to the telemetry bus, so
+    # +Domain::Light+'s collaborators never call notifiers directly.
+    #
+    # @api private
+    class NotifierBridge
+      def initialize(light_name:, notifiers:)
+        @light_name = light_name
+        @notifiers = notifiers
+      end
+
+      def subscribe(bus)
+        bus.subscribe(Domain::Telemetry::TrafficBreached) { |envelope| notify(envelope, error: envelope.payload.failure&.exception) }
+        bus.subscribe(Domain::Telemetry::RecoveryStarted) { |envelope| notify(envelope, error: nil) }
+        bus.subscribe(Domain::Telemetry::RecoverySucceeded) { |envelope| notify(envelope, error: nil) }
+        bus.subscribe(Domain::Telemetry::RecoveryFailed) { |envelope| notify(envelope, error: envelope.payload.failure&.exception) }
+      end
+
+      private
+
+      def notify(envelope, error:)
+        return unless envelope.light_name == @light_name
+
+        info = Domain::LightInfo.new(name: @light_name)
+        payload = envelope.payload
+
+        @notifiers.each do |notifier|
+          notifier.notify(info, payload.from_color, payload.to_color, error)
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/wiring/notifier_bridge.rb
+++ b/lib/stoplight/wiring/notifier_bridge.rb
@@ -7,8 +7,7 @@ module Stoplight
     #
     # @api private
     class NotifierBridge
-      def initialize(light_name:, notifiers:)
-        @light_name = light_name
+      def initialize(notifiers:)
         @notifiers = notifiers
       end
 
@@ -22,9 +21,7 @@ module Stoplight
       private
 
       def notify(envelope, error:)
-        return unless envelope.light_name == @light_name
-
-        info = Domain::LightInfo.new(name: @light_name)
+        info = Domain::LightInfo.new(name: envelope.light_name)
         payload = envelope.payload
 
         @notifiers.each do |notifier|

--- a/lib/stoplight/wiring/system.rb
+++ b/lib/stoplight/wiring/system.rb
@@ -65,6 +65,9 @@ module Stoplight
         @failover_system = failover_system
         @registry = registry
         @telemetry = Domain::Telemetry::Bus.new(error_notifier: config.error_notifier)
+
+        notifiers = wrapped_notifiers
+        NotifierBridge.new(notifiers:).subscribe(@telemetry) unless notifiers.empty?
       end
 
       def persistent?
@@ -168,6 +171,20 @@ module Stoplight
       # @api private
       def __stoplight__registry
         @registry
+      end
+
+      private
+
+      def wrapped_notifiers
+        error_notifier = Infrastructure::FailSafe::ErrorNotifier.new(error_notifier: @config.error_notifier)
+
+        @config.notifiers.map do |notifier|
+          Infrastructure::Notifier::FailSafe.new(
+            notifier:,
+            error_notifier:,
+            circuit_breaker: T.must(@failover_system).register("notifier:#{notifier.class.name}")
+          )
+        end
       end
     end
   end

--- a/lib/stoplight/wiring/system.rb
+++ b/lib/stoplight/wiring/system.rb
@@ -66,8 +66,9 @@ module Stoplight
         @registry = registry
         @telemetry = Domain::Telemetry::Bus.new(error_notifier: config.error_notifier)
 
-        notifiers = wrapped_notifiers
-        NotifierBridge.new(notifiers:).subscribe(@telemetry) unless notifiers.empty?
+        unless config.notifiers.empty?
+          NotifierBridge.new(notifiers: wrapped_notifiers).subscribe(@telemetry)
+        end
       end
 
       def persistent?

--- a/sig/stoplight/domain/strategies/yellow_run_strategy.rbs
+++ b/sig/stoplight/domain/strategies/yellow_run_strategy.rbs
@@ -7,7 +7,6 @@ module Stoplight
         attr_reader state_store: Domain::_StateStore
         attr_reader metrics_store: _MetricsStore
         attr_reader recovery_lock_store: _RecoveryLockStore
-        attr_reader notifiers: Array[_StateTransitionNotifier]
         attr_reader request_tracker: Tracker::RecoveryProbe
 
         @name: String
@@ -18,7 +17,6 @@ module Stoplight
 
         def initialize: (
           name: String,
-          notifiers: Array[_StateTransitionNotifier],
           request_tracker: Tracker::RecoveryProbe,
           state_store: _StateStore,
           metrics_store: _MetricsStore,

--- a/sig/stoplight/domain/tracker/recovery_probe.rbs
+++ b/sig/stoplight/domain/tracker/recovery_probe.rbs
@@ -3,7 +3,6 @@ module Stoplight
     module Tracker
       class RecoveryProbe
         attr_reader traffic_recovery: _TrafficRecovery
-        attr_reader notifiers: Array[_StateTransitionNotifier]
         attr_reader config: Config
         attr_reader metrics_store: _MetricsStore
         attr_reader state_store: _StateStore
@@ -12,7 +11,6 @@ module Stoplight
         def initialize: (
           config: Config,
           traffic_recovery: _TrafficRecovery,
-          notifiers: Array[_StateTransitionNotifier],
           metrics_store: _MetricsStore,
           state_store: _StateStore,
           emitter: Telemetry::Emitter,
@@ -24,7 +22,7 @@ module Stoplight
         private
 
         def recover: (duration_ms: Float, exception: StandardError?) -> void
-        def transition: (from_color: color, to_color: color) -> bool
+        def transition: (to_color: color) -> bool
       end
     end
   end

--- a/sig/stoplight/domain/tracker/request.rbs
+++ b/sig/stoplight/domain/tracker/request.rbs
@@ -4,7 +4,6 @@ module Stoplight
       class Request
         attr_reader config: Config
         attr_reader traffic_control: _TrafficControl
-        attr_reader notifiers: Array[_StateTransitionNotifier]
         attr_reader metrics_store: _MetricsStore
         attr_reader state_store: _StateStore
         attr_reader emitter: Telemetry::Emitter
@@ -12,7 +11,6 @@ module Stoplight
         def initialize: (
           config: Config,
           traffic_control: _TrafficControl,
-          notifiers: Array[_StateTransitionNotifier],
           metrics_store: _MetricsStore,
           state_store: _StateStore,
           emitter: Telemetry::Emitter,

--- a/sig/stoplight/wiring/light_factory.rbs
+++ b/sig/stoplight/wiring/light_factory.rbs
@@ -26,13 +26,10 @@ module Stoplight
       attr_reader system_name: String
 
       @system_id: String
-      @notifiers: Array[Domain::_StateTransitionNotifier]
       @name: String
       @cool_off_time: Domain::duration_seconds
       @error_tracking_policy: Domain::ErrorTrackingPolicy
-      @wrapped_notifiers: Array[Domain::_StateTransitionNotifier]?
       @emitter: Domain::Telemetry::Emitter
-      @telemetry: Domain::_TelemetryPublisher & Domain::_Telemetry
       @failover_system: _System?
       @storage_set: StorageSet
       @key_space: Infrastructure::Redis::Key
@@ -42,14 +39,13 @@ module Stoplight
           config: Domain::Config,
           system_name: String,
           failover_system: _System?,
-          telemetry: Domain::_TelemetryPublisher & Domain::_Telemetry
+          telemetry: Domain::_TelemetryPublisher
         ) -> void
 
       def lock_control: -> Domain::LockControl
       def storage_set: -> StorageSet
       def key_space: -> Infrastructure::Redis::Key
       def state_store: -> Domain::_StateStore
-      def notifiers: -> Array[Domain::_StateTransitionNotifier]
 
       def metrics_store: -> Domain::_MetricsStore
       def recovery_lock_store: -> Domain::_RecoveryLockStore

--- a/sig/stoplight/wiring/light_factory.rbs
+++ b/sig/stoplight/wiring/light_factory.rbs
@@ -32,6 +32,7 @@ module Stoplight
       @error_tracking_policy: Domain::ErrorTrackingPolicy
       @wrapped_notifiers: Array[Domain::_StateTransitionNotifier]?
       @emitter: Domain::Telemetry::Emitter
+      @telemetry: Domain::_TelemetryPublisher & Domain::_Telemetry
       @failover_system: _System?
       @storage_set: StorageSet
       @key_space: Infrastructure::Redis::Key
@@ -41,7 +42,7 @@ module Stoplight
           config: Domain::Config,
           system_name: String,
           failover_system: _System?,
-          telemetry: Domain::_TelemetryPublisher
+          telemetry: Domain::_TelemetryPublisher & Domain::_Telemetry
         ) -> void
 
       def lock_control: -> Domain::LockControl

--- a/sig/stoplight/wiring/notifier_bridge.rbs
+++ b/sig/stoplight/wiring/notifier_bridge.rbs
@@ -1,10 +1,9 @@
 module Stoplight
   module Wiring
     class NotifierBridge
-      @light_name: String
       @notifiers: Array[Domain::_StateTransitionNotifier]
 
-      def initialize: (light_name: String, notifiers: Array[Domain::_StateTransitionNotifier]) -> void
+      def initialize: (notifiers: Array[Domain::_StateTransitionNotifier]) -> void
 
       def subscribe: (Domain::_Telemetry) -> void
 

--- a/sig/stoplight/wiring/notifier_bridge.rbs
+++ b/sig/stoplight/wiring/notifier_bridge.rbs
@@ -1,0 +1,16 @@
+module Stoplight
+  module Wiring
+    class NotifierBridge
+      @light_name: String
+      @notifiers: Array[Domain::_StateTransitionNotifier]
+
+      def initialize: (light_name: String, notifiers: Array[Domain::_StateTransitionNotifier]) -> void
+
+      def subscribe: (Domain::_Telemetry) -> void
+
+      private
+
+      def notify: (Domain::Telemetry::Envelope[Domain::Telemetry::state_transitioned], error: StandardError?) -> void
+    end
+  end
+end

--- a/sig/stoplight/wiring/system.rbs
+++ b/sig/stoplight/wiring/system.rbs
@@ -19,6 +19,10 @@ module Stoplight
       def persistent?: -> bool
       def __stoplight__storage: -> Storage
       def __stoplight__registry: -> Domain::_Registry
+
+      private
+
+      def wrapped_notifiers: -> Array[Domain::_StateTransitionNotifier]
     end
   end
 end

--- a/sig/stoplight/wiring/system/storage.rbs
+++ b/sig/stoplight/wiring/system/storage.rbs
@@ -6,13 +6,13 @@ module Stoplight
         @system_name: String
         @failover_system: _System
         @factories: Hash[Domain::Config, LightFactory]
-        @telemetry: Domain::_TelemetryPublisher & Domain::_Telemetry
+        @telemetry: Domain::_TelemetryPublisher
 
         def initialize: (
             system_id: String,
             system_name: String,
             failover_system: _System,
-            telemetry: Domain::_TelemetryPublisher & Domain::_Telemetry
+            telemetry: Domain::_TelemetryPublisher
           ) -> void
 
         def state_snapshot: (Domain::Config) -> Domain::StateSnapshot

--- a/sig/stoplight/wiring/system/storage.rbs
+++ b/sig/stoplight/wiring/system/storage.rbs
@@ -6,13 +6,13 @@ module Stoplight
         @system_name: String
         @failover_system: _System
         @factories: Hash[Domain::Config, LightFactory]
-        @telemetry: Domain::_TelemetryPublisher
+        @telemetry: Domain::_TelemetryPublisher & Domain::_Telemetry
 
         def initialize: (
             system_id: String,
             system_name: String,
             failover_system: _System,
-            telemetry: Domain::_TelemetryPublisher
+            telemetry: Domain::_TelemetryPublisher & Domain::_Telemetry
           ) -> void
 
         def state_snapshot: (Domain::Config) -> Domain::StateSnapshot

--- a/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
   subject(:strategy) do
     described_class.new(
       name:,
-      notifiers: notifiers,
       request_tracker:,
       state_store:,
       metrics_store:,
@@ -18,8 +17,6 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
 
   let(:name) { SecureRandom.uuid }
   let(:error_tracking_policy) { instance_double(Stoplight::Domain::ErrorTrackingPolicy) }
-  let(:notifiers) { [notifier] }
-  let(:notifier) { instance_double(NullNotifier) }
   let(:recovery_lock_store) { instance_double(NullRecoveryLockStore) }
   let(:state_store) { instance_double(NullStateStore) }
   let(:metrics_store) { instance_double(NullMetricsStore) }
@@ -325,9 +322,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
     context "when recovery has already started" do
       let(:state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot, recovery_started?: true) }
 
-      it "does not send notifications or emit events" do
-        expect(notifier).not_to receive(:notify)
-
+      it "does not emit events" do
         expect {
           enter_recovery
         }.not_to emit(Stoplight::Domain::Telemetry::RecoveryStarted)
@@ -338,10 +333,9 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
       let(:state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot, recovery_started?: false, breached_at:) }
       let(:breached_at) { instance_double(Time) }
 
-      it "notifies if able to transition to YELLOW" do
+      it "clears metrics and transitions to YELLOW" do
         expect(metrics_store).to receive(:clear)
         expect(state_store).to receive(:transition_to_color).with(Stoplight::Color::YELLOW)
-        expect(notifier).to receive(:notify).with(have_attributes(name:), Stoplight::Color::RED, Stoplight::Color::YELLOW, nil)
 
         enter_recovery
       end
@@ -349,7 +343,6 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
       it "emits RecoveryStarted" do
         allow(metrics_store).to receive(:clear)
         allow(state_store).to receive(:transition_to_color)
-        allow(notifier).to receive(:notify)
 
         expect {
           enter_recovery

--- a/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
+++ b/spec/unit/stoplight/domain/tracker/recovery_probe_spec.rb
@@ -1,19 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
-  subject(:recorder) { described_class.new(state_store:, traffic_recovery:, notifiers:, config:, metrics_store:, emitter:) }
+  subject(:recorder) { described_class.new(state_store:, traffic_recovery:, config:, metrics_store:, emitter:) }
 
   let(:metrics_store) { instance_double(NullMetricsStore) }
   let(:state_store) { instance_double(NullStateStore) }
   let(:traffic_recovery) { instance_double(NullTrafficRecovery) }
-  let(:notifiers) { [notifier] }
-  let(:notifier) { instance_double(NullNotifier) }
   let(:config) { instance_double(Stoplight::Domain::Config, name: name) }
   let(:name) { SecureRandom.uuid }
   let(:emitter) { TestTelemetryEmitter.new }
   let(:policy_name) { SecureRandom.uuid }
 
-  shared_examples "when recover to" do |recover_to:, transition_from:, transition_to:|
+  shared_examples "when recover to" do |recover_to:, transition_to:|
     context "when recover to #{recover_to}" do
       let(:metrics_after_probe) {
         instance_double(Stoplight::Domain::MetricsSnapshot,
@@ -30,9 +28,8 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
         allow(traffic_recovery).to receive(:name).and_return(policy_name)
       end
 
-      it "sends notifications" do
+      it "clears metrics" do
         expect(metrics_store).to receive(:clear)
-        expect(notifier).to receive(:notify).with(have_attributes(name:), transition_from, transition_to, nil)
 
         record_probe
       end
@@ -42,9 +39,8 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
           allow(state_store).to receive(:transition_to_color).with(transition_to).and_return(false)
         end
 
-        it "does not clear metrics or send notifications" do
+        it "does not clear metrics" do
           expect(metrics_store).not_to receive(:clear)
-          expect(notifier).not_to receive(:notify)
 
           record_probe
         end
@@ -55,12 +51,10 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
   shared_examples "recovering after probe" do
     include_examples "when recover to",
       recover_to: Stoplight::Domain::TrafficRecovery::GREEN,
-      transition_from: Stoplight::Color::YELLOW,
       transition_to: Stoplight::Color::GREEN
 
     include_examples "when recover to",
       recover_to: Stoplight::Domain::TrafficRecovery::RED,
-      transition_from: Stoplight::Color::YELLOW,
       transition_to: Stoplight::Color::RED
 
     context "when recover to unexpected to outcome" do
@@ -93,7 +87,6 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       it "don't transition" do
         expect(state_store).not_to receive(:transition_to_color)
         expect(metrics_store).not_to receive(:clear)
-        expect(notifier).not_to receive(:notify)
 
         record_probe
       end
@@ -137,7 +130,6 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       allow(metrics_store).to receive(:record_success)
       allow(metrics_store).to receive(:metrics_snapshot).and_return(metrics_after_probe)
       allow(metrics_store).to receive(:clear)
-      allow(notifier).to receive(:notify)
     end
 
     context "when the probe changes from yellow to green" do
@@ -222,7 +214,6 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
     before do
       allow(metrics_store).to receive(:metrics_snapshot).and_return(metrics_after_probe)
       allow(metrics_store).to receive(:clear)
-      allow(notifier).to receive(:notify)
       allow(traffic_recovery).to receive(:determine_color).and_return(Stoplight::Domain::TrafficRecovery::YELLOW)
     end
 
@@ -323,7 +314,6 @@ RSpec.describe Stoplight::Domain::Tracker::RecoveryProbe do
       allow(metrics_store).to receive(:record_failure).with(exception)
       allow(metrics_store).to receive(:metrics_snapshot).and_return(metrics_after_probe)
       allow(metrics_store).to receive(:clear)
-      allow(notifier).to receive(:notify)
       allow(traffic_recovery).to receive(:determine_color).and_return(Stoplight::Domain::TrafficRecovery::RED)
       allow(traffic_recovery).to receive(:name).and_return(policy_name)
       allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::RED).and_return(true)

--- a/spec/unit/stoplight/domain/tracker/request_spec.rb
+++ b/spec/unit/stoplight/domain/tracker/request_spec.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe Stoplight::Domain::Tracker::Request do
-  subject(:request_tracker) { described_class.new(state_store:, traffic_control:, notifiers:, config:, metrics_store:, emitter:) }
+  subject(:request_tracker) { described_class.new(state_store:, traffic_control:, config:, metrics_store:, emitter:) }
 
   let(:metrics_store) { instance_double(NullMetricsStore) }
   let(:state_store) { instance_double(NullStateStore) }
   let(:traffic_control) { instance_double(NullTrafficControl) }
-  let(:notifiers) { [notifier] }
-  let(:notifier) { instance_double(NullNotifier) }
   let(:config) { instance_double(Stoplight::Domain::Config, name: name) }
   let(:name) { SecureRandom.uuid }
   let(:emitter) { TestTelemetryEmitter.new }
@@ -25,21 +23,6 @@ RSpec.describe Stoplight::Domain::Tracker::Request do
 
     before do
       allow(metrics_store).to receive(:record_failure).with(exception).and_return(metrics)
-    end
-
-    context "when traffic control decides to stop the traffic" do
-      before do
-        allow(traffic_control).to receive(:stop_traffic?).with(config, metrics).and_return(true)
-      end
-
-      context "when failed to transition to RED" do
-        it "does not send notification about transition" do
-          allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::RED).and_return(false)
-          expect(notifier).not_to receive(:notify)
-
-          request_tracker.record_failure(exception)
-        end
-      end
     end
 
     specify "when traffic control decides to continue the traffic flow" do
@@ -63,18 +46,11 @@ RSpec.describe Stoplight::Domain::Tracker::Request do
       allow(metrics_store).to receive(:record_failure).with(exception).and_return(metrics)
       allow(traffic_control).to receive(:stop_traffic?).with(config, metrics).and_return(true)
       allow(traffic_control).to receive(:name).and_return(policy_name)
-      allow(notifier).to receive(:notify)
     end
 
     context "when the transition to RED succeeds" do
       before do
         allow(state_store).to receive(:transition_to_color).with(Stoplight::Color::RED).and_return(true)
-      end
-
-      it "sends a notification about the color transition" do
-        expect(notifier).to receive(:notify).with(have_attributes(name:), Stoplight::Color::GREEN, Stoplight::Color::RED, exception)
-
-        request_tracker.record_failure(exception)
       end
 
       it "emits a TrafficBreached event with the transition details" do

--- a/spec/unit/stoplight/wiring/notifier_bridge_spec.rb
+++ b/spec/unit/stoplight/wiring/notifier_bridge_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Stoplight::Wiring::NotifierBridge do
-  subject(:bridge) { described_class.new(light_name:, notifiers:) }
+  subject(:bridge) { described_class.new(notifiers:) }
 
   let(:light_name) { "checkout" }
   let(:notifiers) { [notifier] }
@@ -138,7 +138,7 @@ RSpec.describe Stoplight::Wiring::NotifierBridge do
     end
   end
 
-  describe "events for a different light" do
+  describe "events from multiple lights sharing the same system bus" do
     let(:payload) do
       Stoplight::Domain::Telemetry::RecoveryStarted.new(
         from_color: Stoplight::Color::RED,
@@ -147,10 +147,16 @@ RSpec.describe Stoplight::Wiring::NotifierBridge do
       )
     end
 
-    it "ignores them" do
-      expect(notifier).not_to receive(:notify)
+    it "notifies for each light, using its own name" do
+      expect(notifier).to receive(:notify).with(
+        have_attributes(name: "checkout"), Stoplight::Color::RED, Stoplight::Color::YELLOW, nil
+      )
+      expect(notifier).to receive(:notify).with(
+        have_attributes(name: "billing"), Stoplight::Color::RED, Stoplight::Color::YELLOW, nil
+      )
 
-      bus.publish(envelope(payload, light_name: "other-light"))
+      bus.publish(envelope(payload, light_name: "checkout"))
+      bus.publish(envelope(payload, light_name: "billing"))
     end
   end
 

--- a/spec/unit/stoplight/wiring/notifier_bridge_spec.rb
+++ b/spec/unit/stoplight/wiring/notifier_bridge_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Wiring::NotifierBridge do
+  subject(:bridge) { described_class.new(light_name:, notifiers:) }
+
+  let(:light_name) { "checkout" }
+  let(:notifiers) { [notifier] }
+  let(:notifier) { instance_double(NullNotifier) }
+  let(:error_notifier) { instance_spy(Proc) }
+  let(:bus) { Stoplight::Domain::Telemetry::Bus.new(error_notifier:) }
+
+  def envelope(payload, light_name: self.light_name)
+    Stoplight::Domain::Telemetry::Envelope.new(
+      system_name: "sys",
+      light_name:,
+      occurred_at: Time.at(0),
+      payload:
+    )
+  end
+
+  before { bridge.subscribe(bus) }
+
+  describe "TrafficBreached" do
+    let(:exception) { KeyError.new("bang") }
+    let(:payload) do
+      Stoplight::Domain::Telemetry::TrafficBreached.new(
+        from_color: Stoplight::Color::GREEN,
+        to_color: Stoplight::Color::RED,
+        policy: "error_rate",
+        failure: Stoplight::Domain::Telemetry::Failure.new(exception:, tracked: true),
+        metrics: nil
+      )
+    end
+
+    it "notifies with the transition and the underlying error" do
+      expect(notifier).to receive(:notify).with(
+        have_attributes(name: light_name), Stoplight::Color::GREEN, Stoplight::Color::RED, exception
+      )
+
+      bus.publish(envelope(payload))
+    end
+  end
+
+  describe "RecoveryStarted" do
+    let(:payload) do
+      Stoplight::Domain::Telemetry::RecoveryStarted.new(
+        from_color: Stoplight::Color::RED,
+        to_color: Stoplight::Color::YELLOW,
+        breached_at: Time.at(0)
+      )
+    end
+
+    it "notifies with the transition and no error" do
+      expect(notifier).to receive(:notify).with(
+        have_attributes(name: light_name), Stoplight::Color::RED, Stoplight::Color::YELLOW, nil
+      )
+
+      bus.publish(envelope(payload))
+    end
+  end
+
+  describe "RecoverySucceeded" do
+    let(:payload) do
+      Stoplight::Domain::Telemetry::RecoverySucceeded.new(
+        from_color: Stoplight::Color::YELLOW,
+        to_color: Stoplight::Color::GREEN,
+        policy: "consecutive_successes",
+        metrics: nil
+      )
+    end
+
+    it "notifies with the transition and no error" do
+      expect(notifier).to receive(:notify).with(
+        have_attributes(name: light_name), Stoplight::Color::YELLOW, Stoplight::Color::GREEN, nil
+      )
+
+      bus.publish(envelope(payload))
+    end
+  end
+
+  describe "RecoveryFailed" do
+    context "when the probe itself failed" do
+      let(:exception) { KeyError.new("bang") }
+      let(:payload) do
+        Stoplight::Domain::Telemetry::RecoveryFailed.new(
+          from_color: Stoplight::Color::YELLOW,
+          to_color: Stoplight::Color::RED,
+          policy: "consecutive_successes",
+          failure: Stoplight::Domain::Telemetry::Failure.new(exception:, tracked: true),
+          metrics: nil
+        )
+      end
+
+      it "notifies with the transition and the underlying error" do
+        expect(notifier).to receive(:notify).with(
+          have_attributes(name: light_name), Stoplight::Color::YELLOW, Stoplight::Color::RED, exception
+        )
+
+        bus.publish(envelope(payload))
+      end
+    end
+
+    context "when the probe succeeded but recovery still tripped back to red" do
+      let(:payload) do
+        Stoplight::Domain::Telemetry::RecoveryFailed.new(
+          from_color: Stoplight::Color::YELLOW,
+          to_color: Stoplight::Color::RED,
+          policy: "consecutive_successes",
+          failure: nil,
+          metrics: nil
+        )
+      end
+
+      it "notifies with no error" do
+        expect(notifier).to receive(:notify).with(
+          have_attributes(name: light_name), Stoplight::Color::YELLOW, Stoplight::Color::RED, nil
+        )
+
+        bus.publish(envelope(payload))
+      end
+    end
+  end
+
+  describe "LockChanged" do
+    let(:payload) do
+      Stoplight::Domain::Telemetry::LockChanged.new(
+        from_color: Stoplight::Color::GREEN,
+        to_color: Stoplight::Color::RED,
+        from_state: :unlocked,
+        to_state: :locked
+      )
+    end
+
+    it "does not notify - manual lock overrides are not legacy notifier events" do
+      expect(notifier).not_to receive(:notify)
+
+      bus.publish(envelope(payload))
+    end
+  end
+
+  describe "events for a different light" do
+    let(:payload) do
+      Stoplight::Domain::Telemetry::RecoveryStarted.new(
+        from_color: Stoplight::Color::RED,
+        to_color: Stoplight::Color::YELLOW,
+        breached_at: Time.at(0)
+      )
+    end
+
+    it "ignores them" do
+      expect(notifier).not_to receive(:notify)
+
+      bus.publish(envelope(payload, light_name: "other-light"))
+    end
+  end
+
+  describe "multiple notifiers" do
+    let(:notifiers) { [notifier, other_notifier] }
+    let(:other_notifier) { instance_double(NullNotifier) }
+    let(:payload) do
+      Stoplight::Domain::Telemetry::RecoveryStarted.new(
+        from_color: Stoplight::Color::RED,
+        to_color: Stoplight::Color::YELLOW,
+        breached_at: Time.at(0)
+      )
+    end
+
+    it "notifies every notifier" do
+      expect(notifier).to receive(:notify)
+      expect(other_notifier).to receive(:notify)
+
+      bus.publish(envelope(payload))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `Domain::Light`'s collaborators (`Tracker::Request`, `Tracker::RecoveryProbe`, `YellowRunStrategy`) used to call the legacy `Notifier` interface directly, duplicating the equivalent `TrafficBreached`/`RecoveryStarted`/`RecoverySucceeded`/`RecoveryFailed` telemetry emission. Domain code now only emits telemetry - it never touches notifiers directly.
- New `Wiring::NotifierBridge` subscribes those four transition events on the telemetry bus and calls the `FailSafe`-wrapped notifiers from there. `LockChanged` is deliberately excluded (manual lock overrides were never legacy notifier events).
