### PR TITLE
Display metrics statistics properly

### DIFF
--- a/lib/stoplight/admin/light_view.rb
+++ b/lib/stoplight/admin/light_view.rb
@@ -35,7 +35,26 @@ module Stoplight
       def name = @config.name
       def state = @state_snapshot.locked_state
       def latest_failure = @metrics_snapshot.last_error
-      def failure_count = @metrics_snapshot.consecutive_errors
+
+      def traffic_metric_label
+        if @metrics_snapshot.requests.nil?
+          "Consecutive failures"
+        else
+          "Errors"
+        end
+      end
+
+      def traffic_metric_value
+        requests = @metrics_snapshot.requests
+        if requests.nil?
+          @metrics_snapshot.consecutive_errors.to_s
+        else
+          error_rate = @metrics_snapshot.error_rate
+          raise TypeError, "error_rate must not be nil" if error_rate.nil?
+
+          "#{@metrics_snapshot.errors!} / #{requests} requests (#{format("%.1f%%", error_rate * 100)})"
+        end
+      end
 
       def unlocked?
         @state_snapshot.locked_state == Stoplight::State::UNLOCKED

--- a/lib/stoplight/admin/views/_card.erb
+++ b/lib/stoplight/admin/views/_card.erb
@@ -122,7 +122,7 @@
   <!-- Stats Row -->
   <div class="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-3" style="margin-top: auto;">
     <div>
-      <span class="font-medium">Failures:</span> <%= light.failure_count %>
+      <span class="font-medium"><%= light.traffic_metric_label %>:</span> <%= light.traffic_metric_value %>
     </div>
 
     <% if light.last_check %>

--- a/sig/stoplight/admin/light_view.rbs
+++ b/sig/stoplight/admin/light_view.rbs
@@ -22,7 +22,8 @@ module Stoplight
       def color: -> Domain::color
       def name: -> String
       def state: -> Domain::state
-      def failure_count: -> Integer
+      def traffic_metric_label: -> String
+      def traffic_metric_value: -> String
       def locked?: -> bool
       def unlocked?: -> bool
       def as_json: -> Hash[Symbol, _ToS]

--- a/spec/unit/stoplight/admin/actions/stats_spec.rb
+++ b/spec/unit/stoplight/admin/actions/stats_spec.rb
@@ -34,7 +34,14 @@ RSpec.describe Stoplight::Admin::Actions::Stats do
       instance_double(Stoplight::Domain::StateSnapshot, color: "green", locked_state: "unlocked")
     end
     let(:metrics_snapshot) do
-      instance_double(Stoplight::Domain::MetricsSnapshot, last_error: nil, consecutive_errors: 0)
+      instance_double(
+        Stoplight::Domain::MetricsSnapshot,
+        last_error: nil,
+        consecutive_errors: 0,
+        requests: nil,
+        errors: nil,
+        error_rate: nil
+      )
     end
     let(:recovery_metrics_snapshot) { instance_double(Stoplight::Domain::MetricsSnapshot) }
 
@@ -49,7 +56,13 @@ RSpec.describe Stoplight::Admin::Actions::Stats do
 
       expect(lights).to contain_exactly(
         have_attributes(
-          id: "light-id", name: "foo", color: "green", state: "unlocked", failures: [], failure_count: 0
+          id: "light-id",
+          name: "foo",
+          color: "green",
+          state: "unlocked",
+          failures: [],
+          traffic_metric_label: "Consecutive failures",
+          traffic_metric_value: "0"
         )
       )
     end
@@ -58,6 +71,31 @@ RSpec.describe Stoplight::Admin::Actions::Stats do
       _, stats = call
 
       expect(stats).to eq(Stoplight::Admin::LightsStats::EMPTY_STATS.merge(count_green: 1, percent_green: 100))
+    end
+
+    context "with windowed metrics" do
+      let(:metrics_snapshot) do
+        instance_double(
+          Stoplight::Domain::MetricsSnapshot,
+          last_error: nil,
+          consecutive_errors: 9,
+          requests: 5,
+          errors: 2,
+          errors!: 2,
+          error_rate: 0.4
+        )
+      end
+
+      it "builds a light view that reflects the full metrics snapshot" do
+        lights, = call
+
+        expect(lights).to contain_exactly(
+          have_attributes(
+            traffic_metric_label: "Errors",
+            traffic_metric_value: "2 / 5 requests (40.0%)"
+          )
+        )
+      end
     end
   end
 end

--- a/spec/unit/stoplight/admin/light_view_spec.rb
+++ b/spec/unit/stoplight/admin/light_view_spec.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe Stoplight::Admin::LightView do
+  def build_metrics_snapshot(**attributes)
+    Stoplight::Domain::MetricsSnapshot.new(
+      successes: nil,
+      errors: nil,
+      consecutive_errors: 0,
+      consecutive_successes: 0,
+      last_error: nil,
+      last_success_at: nil,
+      **attributes
+    )
+  end
+
   subject(:light) do
     described_class.new(
       config:,
@@ -141,17 +153,88 @@ RSpec.describe Stoplight::Admin::LightView do
     it { is_expected.to eq(latest_failure) }
   end
 
+  describe "#traffic_metric_label and #traffic_metric_value" do
+    subject(:traffic_metric) { [light.traffic_metric_label, light.traffic_metric_value] }
+
+    context "with unbounded metrics" do
+      let(:metrics_snapshot) { build_metrics_snapshot(consecutive_errors: 3) }
+
+      it "describes the consecutive failure streak" do
+        expect(traffic_metric).to eq(["Consecutive failures", "3"])
+      end
+    end
+
+    context "with windowed metrics" do
+      let(:metrics_snapshot) { build_metrics_snapshot(successes: 3, errors: 2) }
+
+      it "describes errors within the request window" do
+        expect(traffic_metric).to eq(["Errors", "2 / 5 requests (40.0%)"])
+      end
+    end
+
+    context "with an empty window" do
+      let(:metrics_snapshot) { build_metrics_snapshot(successes: 0, errors: 0) }
+
+      it "renders a zero error rate" do
+        expect(traffic_metric).to eq(["Errors", "0 / 0 requests (0.0%)"])
+      end
+    end
+
+    context "with a windowed snapshot missing its error rate" do
+      let(:metrics_snapshot) do
+        instance_double(
+          Stoplight::Domain::MetricsSnapshot,
+          last_error: nil,
+          requests: 1,
+          errors!: 0,
+          error_rate: nil
+        )
+      end
+
+      it "raises instead of rendering a misleading zero percent rate" do
+        expect { light.traffic_metric_value }.to raise_error(TypeError, "error_rate must not be nil")
+      end
+    end
+  end
+
   describe "#as_json" do
     subject(:json) { light.as_json }
 
-    it "returns a hash with the light's attributes" do
-      is_expected.to eq({
-        id:,
-        name:,
-        color:,
-        locked: false,
-        failures: [latest_failure]
-      })
+    context "with unbounded metrics" do
+      let(:metrics_snapshot) { build_metrics_snapshot(consecutive_errors: 3, last_error: latest_failure) }
+
+      it "returns the existing JSON fields" do
+        expect(json.keys).to eq([:id, :name, :color, :failures, :locked])
+        expect(json).to eq({
+          id:,
+          name:,
+          color:,
+          failures: [latest_failure],
+          locked: false
+        })
+      end
+    end
+
+    context "with windowed metrics" do
+      let(:metrics_snapshot) do
+        build_metrics_snapshot(successes: 3, errors: 2, consecutive_errors: 2, last_error: latest_failure)
+      end
+
+      it "returns the existing JSON shape without metric fields" do
+        expect(json.keys).to eq([:id, :name, :color, :failures, :locked])
+        expect(json).not_to include(:metrics, :failure_count, :errors, :requests, :error_rate)
+        expect(json).to eq({
+          id:,
+          name:,
+          color:,
+          failures: [latest_failure],
+          locked: false
+        })
+      end
+    end
+
+    it "does not expose the obsolete card metric reader" do
+      expect(light).not_to respond_to(:failure_count)
     end
   end
 

--- a/spec/unit/stoplight/admin_spec.rb
+++ b/spec/unit/stoplight/admin_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
           expect(last_response.body).to include("Unlock")
           expect(last_response.body).to include("Lock Red")
           expect(last_response.body).to include("Lock Green")
-          expect(last_response.body).to include("Failures")
+          expect(last_response.body).to include("Consecutive failures")
 
           expect(last_response.body).to_not include("No lights found")
           expect(last_response.body).not_to include("Ensure lights are registered and this Admin instance uses the same data store as your application.")
@@ -249,12 +249,43 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
           end
         end
 
-        it "displays the correct failure count" do
+        it "displays the consecutive failure count" do
           get "/systems/#{system_id}/lights"
 
           expect(last_response).to be_ok
 
-          expect(last_response.body).to include(">Failures:</span> 3")
+          expect(last_response.body).to include(">Consecutive failures:</span> 3")
+        end
+      end
+
+      context "with an error-rate light that has requests" do
+        let(:light) { system.register(SecureRandom.uuid, traffic_control: :error_rate, threshold: 0.5, window_size: 60) }
+
+        before do
+          3.times { light.run { "ok" } }
+          2.times { light.run(->(_) {}) { raise "whoops" } }
+        end
+
+        it "displays errors from the current request window" do
+          get "/systems/#{system_id}/lights"
+
+          expect(last_response).to be_ok
+
+          expect(last_response.body).to include(">Errors:</span> 2 / 5 requests (40.0%)")
+        end
+      end
+
+      context "with an error-rate light that has no requests" do
+        let(:light) { system.register(SecureRandom.uuid, traffic_control: :error_rate, threshold: 0.5, window_size: 60) }
+
+        before { light }
+
+        it "displays the empty request window as zero percent" do
+          get "/systems/#{system_id}/lights"
+
+          expect(last_response).to be_ok
+
+          expect(last_response.body).to include(">Errors:</span> 0 / 0 requests (0.0%)")
         end
       end
 
@@ -383,6 +414,32 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
       end
     end
 
+    context "with an error-rate light" do
+      let(:light) { system.register(light_name, traffic_control: :error_rate, threshold: 0.5, window_size: 60) }
+
+      before { light.run { "ok" } }
+
+      it "returns the existing response shape" do
+        get "/stats"
+
+        expect(last_response).to be_ok
+        expect(response_body).to eq(
+          {
+            "stats" =>
+              {"count_red" => 0,
+               "count_yellow" => 0,
+               "count_green" => 1,
+               "percent_red" => 0,
+               "percent_yellow" => 0,
+               "percent_green" => 100},
+            "lights" => [
+              {"id" => id, "name" => light_name, "color" => "green", "failures" => [], "locked" => false}
+            ]
+          }
+        )
+      end
+    end
+
     context "with more than one system configured" do
       let(:other_data_store) { Stoplight::DataStore::Redis.new(redis) }
       let(:other_system) { Stoplight.register_system(SecureRandom.uuid, data_store: other_data_store) }
@@ -450,6 +507,32 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
                "percent_green" => 100},
             "lights" => [
               {"id" => id, "color" => "green", "failures" => [], "locked" => false, "name" => light_name}
+            ]
+          }
+        )
+      end
+    end
+
+    context "with an error-rate light" do
+      let(:light) { system.register(light_name, traffic_control: :error_rate, threshold: 0.5, window_size: 60) }
+
+      before { light.run { "ok" } }
+
+      it "returns the existing response shape" do
+        get "/systems/#{system_id}/lights.json"
+
+        expect(last_response).to be_ok
+        expect(response_body).to eq(
+          {
+            "stats" =>
+              {"count_red" => 0,
+               "count_yellow" => 0,
+               "count_green" => 1,
+               "percent_red" => 0,
+               "percent_yellow" => 0,
+               "percent_green" => 100},
+            "lights" => [
+              {"id" => id, "name" => light_name, "color" => "green", "failures" => [], "locked" => false}
             ]
           }
         )


### PR DESCRIPTION
Closes #882 

Display: `Consecutive failures: 2` or `Errors: 2 / 5 requests (40.0%)`
Instead of: `Failures: 2`