### PR TITLE
Redis-Synchronized Time: Infrastructure & TimeTravel Helper

### DIFF
--- a/lib/stoplight/infrastructure/redis/storage/now.lua
+++ b/lib/stoplight/infrastructure/redis/storage/now.lua
@@ -1,0 +1,9 @@
+-- Returns current time in milliseconds since epoch.
+-- In production: calls redis.call("TIME") for server time.
+-- In tests: overridden with test double that reads from a Redis key.
+local function now()
+  local time = redis.call("TIME")
+  local seconds = tonumber(time[1])
+  local microseconds = tonumber(time[2])
+  return seconds * 1000 + math.floor(microseconds / 1000)
+end

--- a/lib/stoplight/infrastructure/redis/storage/scripting.rb
+++ b/lib/stoplight/infrastructure/redis/storage/scripting.rb
@@ -5,18 +5,18 @@ module Stoplight
     module Redis
       module Storage
         class Scripting
-          SCRIPTS_ROOT = __dir__ => String
+          SCRIPTS_ROOT = T.must(__dir__)
           private_constant :SCRIPTS_ROOT
 
           INCLUDE_DIRECTIVE = /^--\s*@include\s+([\w\-\/]+)$/
           private_constant :INCLUDE_DIRECTIVE
 
           class << self
-            def default_scripts_root = SCRIPTS_ROOT
+            def default_scripts_path = [SCRIPTS_ROOT]
           end
 
-          def initialize(redis:, scripts_root: self.class.default_scripts_root)
-            @scripts_root = scripts_root
+          def initialize(redis:, scripts_path: self.class.default_scripts_path)
+            @scripts_path = scripts_path
             @redis = redis
             @shas = Hash.new do |hash, script_name|
               hash[script_name] = Digest::SHA1.hexdigest(resolve_source(script_name))
@@ -50,8 +50,17 @@ module Stoplight
 
           # Redis's Lua sandbox has no `require`, so an included script is spliced in as source text.
           def resolve_source(script_name)
-            source = File.read(File.join(@scripts_root, "#{script_name}.lua"))
-            source.gsub(INCLUDE_DIRECTIVE) { resolve_source(T.must(Regexp.last_match(1))) }
+            file_name = "#{script_name}.lua"
+
+            @scripts_path.each do |path|
+              script_path = File.join(path, file_name)
+              if File.exist?(script_path)
+                source = File.read(script_path)
+                return source.gsub(INCLUDE_DIRECTIVE) { resolve_source(T.must(Regexp.last_match(1))) }
+              end
+            end
+
+            raise Errno::ENOENT, "No such file #{file_name} @ #{@scripts_path}"
           end
         end
       end

--- a/sig/stoplight/infrastructure/redis/storage/scripting.rbs
+++ b/sig/stoplight/infrastructure/redis/storage/scripting.rbs
@@ -7,15 +7,15 @@ module Stoplight
 
           INCLUDE_DIRECTIVE: Regexp
 
-          def self.default_scripts_root: -> String
+          def self.default_scripts_path: -> Array[String]
 
-          @scripts_root: String
+          @scripts_path: Array[String]
           @shas: Hash[String, String]
           @redis: redis
 
           def initialize: (
               redis: redis,
-              ?scripts_root: String,
+              ?scripts_path: Array[String],
             ) -> void
 
           def call: (

--- a/spec/integration/redis_time_travel_integration_spec.rb
+++ b/spec/integration/redis_time_travel_integration_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe "Redis time travel integration", :redis do
+  let(:script_manager) { Stoplight::Infrastructure::Redis::Storage::Scripting.new(redis:) }
+  let(:test_script_name) { :test_now_integration }
+  let(:test_script_path) { Pathname.new(Dir.tmpdir).join(SecureRandom.uuid) }
+
+  before do
+    Dir.mkdir(test_script_path.to_s)
+    support_lua_path = Pathname.new(File.expand_path("../support/lua", __dir__)).to_s
+    script_manager_with_path = Stoplight::Infrastructure::Redis::Storage::Scripting.new(
+      redis:,
+      scripts_path: [test_script_path.to_s, support_lua_path]
+    )
+    @script_manager = script_manager_with_path
+
+    script_content = <<~LUA
+      -- @include now
+      return now()
+    LUA
+    File.write(test_script_path.join("test_now_integration.lua"), script_content)
+  end
+
+  after do
+    FileUtils.rm_rf(test_script_path.to_s)
+  end
+
+  describe "now() with TimeTravel.freeze" do
+    it "returns frozen time from within Lua script" do
+      frozen_time = Time.new(2025, 6, 15, 14, 30, 45)
+
+      Stoplight::TimeTravel.freeze(frozen_time) do
+        result = @script_manager.call(test_script_name, keys: [], args: [])
+        expected_ms = (frozen_time.to_f * 1000).to_i
+
+        expect(result).to eq(expected_ms)
+      end
+    end
+
+    it "preserves nested freeze contexts" do
+      start_time = Time.new(2025, 1, 1, 12, 0, 0)
+      inner_time = Time.new(2025, 6, 15, 14, 30, 45)
+
+      Stoplight::TimeTravel.freeze(start_time) do
+        outer_result = @script_manager.call(test_script_name, keys: [], args: [])
+
+        Stoplight::TimeTravel.freeze(inner_time) do
+          inner_result = @script_manager.call(test_script_name, keys: [], args: [])
+          expect(inner_result).to eq((inner_time.to_f * 1000).to_i)
+        end
+
+        # After inner freeze exits, outer freeze is restored
+        restored_result = @script_manager.call(test_script_name, keys: [], args: [])
+        expect(restored_result).to eq(outer_result)
+      end
+    end
+  end
+
+  describe "now() returns actual time when not mocked" do
+    it "returns current Redis server time" do
+      result = @script_manager.call(test_script_name, keys: [], args: [])
+
+      now_ms = (Time.now.to_f * 1000).to_i
+      # Allow 1 second tolerance for test execution time
+      expect(result).to be_within(1000).of(now_ms)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ require_relative "support/database_cleaner"
 require_relative "support/exception_helpers"
 require_relative "support/route_helpers"
 require_relative "support/matchers/emit"
+require_relative "support/time_travel"
 
 Timecop.safe_mode = true
 # Window buckets age on the monotonic clock; travel/freeze must move it too.
@@ -39,7 +40,17 @@ RSpec.configure do |rspec|
   rspec.include ExceptionHelpers
   rspec.include RouteHelpers, type: :request
 
-  rspec.before { Stoplight.__stoplight__reset! }
+  rspec.before do
+    redis = Redis.new
+    redis.del("stoplight:test_now_ms_stack")
+    Stoplight.__stoplight__reset!
+  end
+
+  rspec.after do
+    Timecop.return
+    redis = Redis.new
+    redis.del("stoplight:test_now_ms_stack")
+  end
 
   rspec.filter_run_when_matching :focus
   rspec.color = true

--- a/spec/support/lua/now.lua
+++ b/spec/support/lua/now.lua
@@ -1,0 +1,14 @@
+-- Test double for now(). Reads from a Redis stack that timecop extension controls.
+-- Falls back to redis.call("TIME") if stack is empty (for backward compatibility).
+local function now()
+  local test_time = redis.call("LINDEX", "stoplight:test_now_ms_stack", -1)
+  if test_time then
+    return tonumber(test_time)
+  end
+
+  -- Fallback to actual time if stack is empty
+  local time = redis.call("TIME")
+  local seconds = tonumber(time[1])
+  local microseconds = tonumber(time[2])
+  return seconds * 1000 + math.floor(microseconds / 1000)
+end

--- a/spec/support/time_travel.rb
+++ b/spec/support/time_travel.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module TimeTravel
+    STACK_KEY = "stoplight:test_now_ms_stack"
+
+    class << self
+      def freeze(time = Time.now)
+        if block_given?
+          Timecop.freeze(time) do
+            redis_time_ms = Time.now.to_f * 1000.0
+            redis.rpush(STACK_KEY, redis_time_ms)
+            begin
+              yield
+            ensure
+              redis.rpop(STACK_KEY)
+            end
+          end
+        else
+          redis.del(STACK_KEY)
+          Timecop.freeze(time)
+          redis_time_ms = Time.now.to_f * 1000.0
+          redis.rpush(STACK_KEY, redis_time_ms)
+        end
+      end
+
+      def return
+        redis.del(STACK_KEY)
+        Timecop.return
+      end
+
+      private
+
+      def redis
+        @redis ||= Redis.new
+      end
+    end
+  end
+end

--- a/spec/unit/stoplight/infrastructure/redis/storage/scripting_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/scripting_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::Scripting, :redis do
 
   let(:script_file) { Tempfile.create(["script", ".lua"]) }
   let(:script_file_path) { Pathname.new(script_file.path) }
-  let(:scripts_root) { script_file_path.dirname.to_s }
+  let(:scripts_path) { [script_file_path.dirname.to_s] }
   let(:script_name) { script_file_path.basename.to_s.sub(".lua", "").to_sym }
   let(:script) { <<~LUA }
     local value = ARGV[1]
@@ -23,7 +23,7 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::Scripting, :redis do
   let(:value) { SecureRandom.uuid }
   let(:key) { SecureRandom.uuid }
 
-  def script_manager_factory = described_class.new(redis:, scripts_root:)
+  def script_manager_factory = described_class.new(redis:, scripts_path:)
 
   it "can call existing script" do
     result = script_manager.call(script_name, args: [value], keys: [key])
@@ -57,7 +57,7 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::Scripting, :redis do
     LUA
 
     before do
-      File.write(File.join(scripts_root, "multiply.lua"), <<~LUA)
+      File.write(File.join(scripts_path, "multiply.lua"), <<~LUA)
         local function multiply(a, b)
           return a * b
         end
@@ -65,13 +65,55 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::Scripting, :redis do
     end
 
     after do
-      File.delete(File.join(scripts_root, "multiply.lua"))
+      File.delete(File.join(scripts_path, "multiply.lua"))
     end
 
     it "splices the included script's source into the calling script" do
       script_manager.call(script_name, args: [21], keys: [key])
 
       expect(redis.get(key)).to eq("42")
+    end
+  end
+
+  context "when the script includes another script defined in two locations" do
+    let(:tmp_dir) { Dir.tmpdir }
+    let(:scripts_path1) { File.join(tmp_dir, SecureRandom.uuid) }
+    let(:scripts_path2) { File.join(tmp_dir, SecureRandom.uuid) }
+    let(:scripts_path) { [scripts_path1, scripts_path2, *super()] }
+
+    let(:script1) { <<~LUA }
+      local function magic()
+        return 1 
+      end
+    LUA
+
+    let(:script2) { <<~LUA }
+      local function magic()
+        return 2
+      end
+    LUA
+
+    let(:script) { <<~LUA }
+      -- @include magic
+
+      return magic()
+    LUA
+
+    before do
+      Dir.mkdir(scripts_path1)
+      Dir.mkdir(scripts_path2)
+      File.write(File.join(scripts_path1, "magic.lua"), script1)
+      File.write(File.join(scripts_path2, "magic.lua"), script2)
+    end
+
+    after do
+      FileUtils.rm_r([scripts_path1, scripts_path2])
+    end
+
+    it "splices the included script's source into the calling script" do
+      magic = script_manager.call(script_name, args: [], keys: [])
+
+      expect(magic).to eq(1)
     end
   end
 
@@ -85,13 +127,13 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::Scripting, :redis do
     LUA
 
     before do
-      File.write(File.join(scripts_root, "multiply.lua"), <<~LUA)
+      File.write(File.join(scripts_path, "multiply.lua"), <<~LUA)
         -- @include multiply/double
         local function multiply_by_four(a)
           return double(double(a))
         end
       LUA
-      File.write(File.join(scripts_root, "multiply", "double.lua"), <<~LUA)
+      File.write(File.join(scripts_path, "multiply", "double.lua"), <<~LUA)
         local function double(a)
           return a * 2
         end
@@ -99,14 +141,14 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::Scripting, :redis do
     end
 
     around do |example|
-      Dir.mkdir(File.join(scripts_root, "multiply"))
+      Dir.mkdir(File.join(scripts_path, "multiply"))
       example.run
     ensure
-      FileUtils.rm_rf(File.join(scripts_root, "multiply"))
+      FileUtils.rm_rf(File.join(scripts_path, "multiply"))
     end
 
     after do
-      File.delete(File.join(scripts_root, "multiply.lua"))
+      File.delete(File.join(scripts_path, "multiply.lua"))
     end
 
     it "resolves transitively included scripts" do
@@ -127,12 +169,12 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::Scripting, :redis do
     LUA
 
     before do
-      File.write(File.join(scripts_root, "double.lua"), <<~LUA)
+      File.write(File.join(scripts_path, "double.lua"), <<~LUA)
         local function double(a)
           return a * 2
         end
       LUA
-      File.write(File.join(scripts_root, "triple.lua"), <<~LUA)
+      File.write(File.join(scripts_path, "triple.lua"), <<~LUA)
         local function triple(a)
           return a * 3
         end
@@ -140,8 +182,8 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::Scripting, :redis do
     end
 
     after do
-      File.delete(File.join(scripts_root, "double.lua"))
-      File.delete(File.join(scripts_root, "triple.lua"))
+      File.delete(File.join(scripts_path, "double.lua"))
+      File.delete(File.join(scripts_path, "triple.lua"))
     end
 
     it "splices in every included script" do
@@ -164,13 +206,13 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::Scripting, :redis do
     end
   end
 
-  context "when the include target attempts to traverse outside scripts_root" do
+  context "when the include target attempts to traverse outside scripts_path" do
     let(:script) { <<~LUA }
       -- @include ../../../../../../etc/passwd
       return "safe"
     LUA
 
-    it "treats the directive as inert instead of reading outside scripts_root" do
+    it "treats the directive as inert instead of reading outside scripts_path" do
       result = script_manager.call(script_name, args: [value], keys: [key])
 
       expect(result).to eq("safe")

--- a/spec/unit/stoplight/infrastructure/redis/storage/time_travel_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/time_travel_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::TimeTravel, :redis do
+  describe ".freeze" do
+    it "sets Ruby and Redis time to the same frozen moment" do
+      frozen_time = Time.new(2025, 6, 15, 14, 30, 45)
+
+      Stoplight::TimeTravel.freeze(frozen_time) do
+        ruby_time = Time.now
+        redis_time_ms = redis.lindex("stoplight:test_now_ms_stack", -1).to_i
+
+        expect(ruby_time.to_i).to eq(frozen_time.to_i)
+        expect(redis_time_ms).to eq((frozen_time.to_f * 1000).to_i)
+      end
+    end
+
+    it "preserves outer context after nested freeze block" do
+      start_time = Time.new(2025, 1, 1, 12, 0, 0)
+      inner_time = Time.new(2025, 6, 15, 14, 30, 45)
+
+      Stoplight::TimeTravel.freeze(start_time) do
+        inner_captured_time = nil
+        Stoplight::TimeTravel.freeze(inner_time) do
+          inner_captured_time = Time.now
+        end
+
+        outer_time = Time.now
+        redis_time_ms = redis.lindex("stoplight:test_now_ms_stack", -1).to_i
+
+        expect(outer_time.to_i).to eq(start_time.to_i)
+        expect(inner_captured_time.to_i).to eq(inner_time.to_i)
+        expect(redis_time_ms).to eq((start_time.to_f * 1000).to_i)
+      end
+    end
+
+    it "handles non-block freeze with relative offset (integer)" do
+      base_time = Time.new(2025, 6, 15, 14, 30, 45)
+      offset_seconds = 5000
+
+      Stoplight::TimeTravel.freeze(base_time) do
+        # Inside outer frozen time, call non-block freeze with relative offset
+        Stoplight::TimeTravel.freeze(offset_seconds)
+
+        ruby_time = Time.now
+        redis_stack_value = redis.lindex("stoplight:test_now_ms_stack", -1)
+
+        # Ruby should be at base_time + offset (Timecop interprets integer as relative)
+        expected_ruby = (base_time + offset_seconds).to_i
+        expect(ruby_time.to_i).to eq(expected_ruby)
+
+        # Redis stack should have the resolved frozen time in milliseconds
+        # (what Timecop actually resolved, not the raw offset)
+        expected_redis_ms = (ruby_time.to_f * 1000).to_i
+        expect(redis_stack_value.to_i).to eq(expected_redis_ms)
+      end
+    end
+
+    it "clears Redis stack on non-block freeze" do
+      base_time = Time.new(2025, 6, 15, 14, 30, 45)
+      offset_seconds = 5000
+
+      Stoplight::TimeTravel.freeze(base_time) do
+        expect(redis.llen("stoplight:test_now_ms_stack")).to eq(1)
+
+        # Non-block freeze should clear and reset the stack
+        Stoplight::TimeTravel.freeze(offset_seconds)
+
+        # Stack should have exactly one entry (not accumulated)
+        expect(redis.llen("stoplight:test_now_ms_stack")).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates infrastructure for Redis-synchronized time across distributed Stoplight instances, eliminating clock skew. Implements:
- `now()` Lua function that reads from `redis.call("TIME")` for server-authoritative timestamps
- Script inclusion system (`@include` directives) supporting multiple lookup paths
- `Stoplight::TimeTravel` helper for deterministic test time control with Redis stack awareness

Time-dependent logic (recovery windows, metrics snapshots, state transitions) requires consistent time across distributed instances. This phase creates the foundation.

Part of: 3-phase refactoring (Phase 1/3) - See GitHub stack below.
 - Phase 1: Infrastructure (this PR)
 - Phase 2: Test migration (#918) - no production code changes, tests still pass
 - Phase 3: Production code updates (#921) - no tests changes

Considered alternatives:
- using `FUNCTION LOAD`/`PCALL` - convenient, but essentially requires a migration to be executed before the code
- injecting time in tests through an script argument and using "TIME" Redis function in production - two completely different mechanism could be error-prone, sometimes we have varargs and this complicates injection. 