### PR TITLE
Migration: Use TimeTravel in Unit Tests, Don't use TimeTravel in Feature Tests

### DIFF
--- a/features/stoplight/basic_functionality.feature
+++ b/features/stoplight/basic_functionality.feature
@@ -5,7 +5,8 @@ Feature: Stoplight Basic Functionality
 
   Background:
     Given a light "basic-service" configured with:
-      | Threshold | 5 |
+      | Threshold     | 5 |
+      | Cool Off Time | 1 |
 
   Scenario: Light allows traffic in green state
     Given the service is functioning normally
@@ -25,10 +26,10 @@ Feature: Stoplight Basic Functionality
     Given the service starts failing with "connection-timeout"
     When 3 request is made
     Then the light color is green
-    When 10 days have elapsed
+    When 2 seconds have elapsed
     And 1 request is made
     Then the light color is green
-    When 10 days have elapsed
+    When 2 seconds have elapsed
     And 1 request is made
     Then the light color is red
 
@@ -57,6 +58,7 @@ Feature: Stoplight Basic Functionality
     When 4 requests is made
     Then the light color is green
     When a light "basic-service" configured with:
-      | Threshold | 5 |
+      | Threshold     | 5 |
+      | Cool Off Time | 1 |
     When 1 request is made
     Then the light color is red

--- a/features/stoplight/configuration.feature
+++ b/features/stoplight/configuration.feature
@@ -33,9 +33,10 @@ Feature: Stoplight Custom Configuration
   Scenario: Light with custom recovery threshold recovers after specified successes
     Given a light configured with:
       | Recovery Threshold | 5 |
+      | Cool Off Time      | 1 |
     And the service starts failing with "connection-timeout"
     And the light enters red state
-    And 60 seconds have elapsed
+    And 2 seconds have elapsed
     And the service recovers and starts functioning normally
     And 4 requests are made
     And the light color is yellow
@@ -44,10 +45,10 @@ Feature: Stoplight Custom Configuration
 
   Scenario: Light with custom window size only counts recent failures
     Given a light configured with:
-      | Window Size | 10s |
+      | Window Size | 1s |
     And the service starts failing with "connection-timeout"
     And 2 request is made
-    When 11 seconds have elapsed
+    When 2 seconds have elapsed
     And 2 request is made
     Then the light color is green
     When 1 request is made
@@ -55,10 +56,10 @@ Feature: Stoplight Custom Configuration
 
   Scenario: Light with custom cool-off time recovers after specified period
     Given a light configured with:
-      | Cool Off Time | 5s |
+      | Cool Off Time | 1s |
     And the service starts failing with "connection-timeout"
     And the light enters red state
-    When 6 seconds have elapsed
+    When 2 seconds have elapsed
     Then the light color is yellow
 
   Scenario: Light with tracked_errors only counts specified errors

--- a/features/stoplight/fallback_behavior.feature
+++ b/features/stoplight/fallback_behavior.feature
@@ -4,7 +4,8 @@ Feature: Fallback Behavior
   a service under Stoplight protection.
 
   Background:
-    Given a light "custom-config" exists
+    Given a light "custom-config" configured with:
+      | Cool Off Time | 1 |
 
   Scenario: Fallback is ignored when light is green
     Given the light color is green

--- a/features/stoplight/global_configuration/cool_off_time.feature
+++ b/features/stoplight/global_configuration/cool_off_time.feature
@@ -5,40 +5,40 @@ Feature: Stoplight configuration - Cool Off Time
 
   Scenario: Global cool off time applies to newly created lights
     Given global configuration:
-      | Cool Off Time | 30 |
+      | Cool Off Time | 3 |
     When a light exists
     And the service starts failing with "timeout"
     And the light enters red state
-    And 28 seconds have elapsed
+    And 2 seconds have elapsed
     Then the light color is red
-    When 3 seconds have elapsed
+    When 2 seconds have elapsed
     Then the light color is yellow
 
   Scenario: Instance cool off time overrides global window size
     Given global configuration:
-      | Cool Off Time | 30 |
+      | Cool Off Time | 3 |
     And a light configured with:
-      | Cool Off Time | 10 |
+      | Cool Off Time | 1 |
     And the service starts failing with "timeout"
     And the light enters red state
-    When 11 seconds have elapsed
+    When 2 seconds have elapsed
     Then the light color is yellow
 
 
   @global_configuration
   Scenario: Global cool off time doesn't affect already-created lights
     Given a light configured with:
-      | Cool Off Time | 10 |
+      | Cool Off Time | 1 |
     And I update global configuration:
-      | Cool Off Time | 30 |
+      | Cool Off Time | 3 |
     And the service starts failing with "timeout"
     And the light enters red state
-    When 11 seconds have elapsed
+    When 2 seconds have elapsed
     Then the light color is yellow
 
     Given a light exists
     And the light enters red state
-    When 28 seconds have elapsed
+    When 2 seconds have elapsed
     Then the light color is red
-    When 3 seconds have elapsed
+    When 2 seconds have elapsed
     Then the light color is yellow

--- a/features/stoplight/global_configuration/recovery_threshold.feature
+++ b/features/stoplight/global_configuration/recovery_threshold.feature
@@ -7,7 +7,8 @@ Feature: Stoplight configuration - Recovery Threshold
     Given global configuration:
       | Recovery Threshold | 3 |
     And the service starts failing with "timeout"
-    When a light exists
+    When a light configured with:
+      | Cool Off Time | 1 |
     And the light enters yellow state
     And the service recovers and starts functioning normally
     When 2 requests are made
@@ -20,6 +21,7 @@ Feature: Stoplight configuration - Recovery Threshold
       | Recovery Threshold | 5 |
     When a light configured with:
       | Recovery Threshold | 2 |
+      | Cool Off Time      | 1 |
     And the service starts failing with "timeout"
     And the light enters yellow state
     And the service recovers and starts functioning normally
@@ -32,6 +34,7 @@ Feature: Stoplight configuration - Recovery Threshold
   Scenario: Global threshold doesn't affect already-created lights
     Given a light configured with:
       | Recovery Threshold | 3 |
+      | Cool Off Time      | 1 |
     And I update global configuration:
       | Recovery Threshold | 10 |
     And the service starts failing with "timeout"
@@ -42,7 +45,8 @@ Feature: Stoplight configuration - Recovery Threshold
     When 1 request is made
     Then the light color is green
 
-    When a light exists
+    When a light configured with:
+      | Cool Off Time | 1 |
     And the service starts failing with "timeout"
     And the light enters yellow state
     And the service recovers and starts functioning normally

--- a/features/stoplight/global_configuration/window_size.feature
+++ b/features/stoplight/global_configuration/window_size.feature
@@ -5,44 +5,44 @@ Feature: Stoplight configuration - Window Size
 
   Scenario: Global window size applies to newly created lights
     Given global configuration:
-      | Window Size | 30 |
+      | Window Size | 1 |
     When a light configured with:
-      | Threshold   | 3  |
+      | Threshold   | 3 |
     And the service starts failing with "timeout"
     And 2 requests are made
-    And 31 seconds have elapsed
+    And 2 seconds have elapsed
     When 1 request is made
     Then the light color is green
 
   Scenario: Instance window size overrides global window size
     Given global configuration:
-      | Window Size | 30 |
+      | Window Size | 5 |
     When a light configured with:
-      | Threshold   | 3  |
-      | Window Size | 10 |
+      | Threshold   | 3 |
+      | Window Size | 1 |
     And the service starts failing with "timeout"
     And 2 requests are made
-    And 11 seconds have elapsed
+    And 2 seconds have elapsed
     When 1 request is made
     Then the light color is green
 
   @global_configuration
   Scenario: Global window size doesn't affect already-created lights
     Given a light configured with:
-      | Window Size | 30 |
-      | Threshold   | 3  |
+      | Window Size | 1 |
+      | Threshold   | 3 |
     And I update global configuration:
-      | Window Size | 10 |
+      | Window Size | 5 |
     And the service starts failing with "timeout"
     And 2 requests are made
-    And 31 seconds have elapsed
+    And 2 seconds have elapsed
     When 1 request is made
     Then the light color is green
 
     When a light configured with:
-      | Threshold   | 3  |
+      | Threshold   | 3 |
     And 2 requests are made
-    And 9 seconds have elapsed
+    And 2 seconds have elapsed
     When 1 request is made
     Then the light color is red
 
@@ -50,11 +50,9 @@ Feature: Stoplight configuration - Window Size
     Given global configuration:
       | Window Size | nil |
     When a light configured with:
-      | Threshold   | 3  |
+      | Threshold   | 3 |
     And the service starts failing with "timeout"
-    And 1 request is made
-    And 1000 days have elapsed
-    And 1 request is made
-    And 1000 days have elapsed
-    And 1 request is made
+    And 2 requests are made
+    And 2 seconds have elapsed
+    When 1 request is made
     Then the light color is red

--- a/features/stoplight/step_definitions/circuit_breaker_steps.rb
+++ b/features/stoplight/step_definitions/circuit_breaker_steps.rb
@@ -27,9 +27,14 @@ end
 
 Given(/^(?:the light) enters yellow state$/) do
   step("the light enters red state")
-  Timecop.travel(Time.now + 1) until current_light.color == Stoplight::Color::YELLOW
 
-  expect(current_light.color).to eq(Stoplight::Color::YELLOW)
+  deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 10
+  until current_light.color == Stoplight::Color::YELLOW
+    if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+      raise "light stayed #{current_light.color} for 10s - is its cool off time longer than that?"
+    end
+    sleep(0.1)
+  end
 end
 
 Given(/^(?:the light) enters green state$/) do

--- a/features/stoplight/step_definitions/helpers_steps.rb
+++ b/features/stoplight/step_definitions/helpers_steps.rb
@@ -1,21 +1,7 @@
 # frozen_string_literal: true
 
-require "timecop"
-
-When(/^(\d+) (seconds|minutes|hours|days) have elapsed$/) do |seconds, unit|
-  case unit
-  when "seconds"
-    seconds = seconds.to_i
-  when "minutes"
-    seconds = seconds.to_i * 60
-  when "hours"
-    seconds = seconds.to_i * 60 * 60
-  when "days"
-    seconds = seconds.to_i * 60 * 60 * 24
-  else
-    raise ArgumentError, "Unknown time unit: #{unit}"
-  end
-  Timecop.travel(Time.now + seconds)
+When(/^(\d+) seconds? have elapsed$/) do |seconds|
+  sleep(seconds.to_i)
 end
 
 When(/^the service starts failing with "([^"]+)"(?: again)?$/) do |error_message|

--- a/features/stoplight/support/env.rb
+++ b/features/stoplight/support/env.rb
@@ -1,16 +1,11 @@
 # frozen_string_literal: true
 
 require "stoplight"
-require "timecop"
 require_relative "stoplight_world"
 require_relative "configure_light_world"
 require_relative "stoplight_assertion_helpers"
 
-# Window buckets age on the monotonic clock; travel/freeze must move it too.
-Timecop.mock_process_clock = true
-
 Before do
-  Timecop.return
   Stoplight.__stoplight__reset!
   reset!
 end

--- a/features/stoplight/traffic_control/consecutive_errors.feature
+++ b/features/stoplight/traffic_control/consecutive_errors.feature
@@ -6,6 +6,7 @@ Feature: Consecutive Errors Traffic Control Strategy
   Background:
     Given a light "basic-service" configured with:
       | Recovery Threshold | 2 |
+      | Cool Off Time      | 1 |
 
   Scenario: Light transitions to red after threshold failures
     Given the service starts failing with "connection-timeout"
@@ -23,7 +24,7 @@ Feature: Consecutive Errors Traffic Control Strategy
   Scenario: Light transitions to yellow after cool-off period
     And the service starts failing with "connection-timeout"
     And the light enters red state
-    When 61 seconds have elapsed
+    When 2 seconds have elapsed
     Then the light color is yellow
     And the service recovers and starts functioning normally
     When 1 request is made

--- a/features/stoplight/traffic_control/error_rate.feature
+++ b/features/stoplight/traffic_control/error_rate.feature
@@ -7,7 +7,7 @@ Feature: Error Rate Traffic Control Strategy
     Given a light configured with:
         | Threshold          | 0.4        |
         | Window Size        | 60 seconds |
-        | Cool Off Time      | 10 seconds |
+        | Cool Off Time      | 1 second   |
         | Traffic Control    | Error Rate |
         | Recovery Threshold | 2          |
 
@@ -27,7 +27,7 @@ Feature: Error Rate Traffic Control Strategy
   Scenario: Light transitions to yellow after cool-off period
     Given the service starts failing with "connection-timeout"
     And the light enters red state
-    When 11 seconds have elapsed
+    When 2 seconds have elapsed
     Then the light color is yellow
     And the service recovers and starts functioning normally
     When 1 request is made

--- a/features/stoplight/traffic_recovery/consecutive_successes.feature
+++ b/features/stoplight/traffic_recovery/consecutive_successes.feature
@@ -6,10 +6,10 @@ Feature: Consecutive Errors Traffic Control Strategy
   Background:
     Given a light "basic-service" configured with:
       | Recovery Threshold | 3 |
-      | Cool Off Time     | 60 |
+      | Cool Off Time      | 1 |
     And the service starts failing with "connection-timeout"
     And the light enters red state
-    And 60 seconds have elapsed
+    And 2 seconds have elapsed
 
   Scenario: Light transitions to green after recover threshold successes
     When the service recovers and starts functioning normally

--- a/spec/properties/notifications_spec.rb
+++ b/spec/properties/notifications_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Notifications" do
         notifications_before_run = notifier.notifications(light.name).count
 
         executions_sequence.each do |(should_fail, time_gap)|
-          Timecop.freeze(Time.now + time_gap)
+          Stoplight::TimeTravel.freeze(Time.now + time_gap)
           suppress(StandardError) { light.run { raise if should_fail } }
 
           color_after_run = light.color

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ RSpec.configure do |rspec|
   end
 
   rspec.after do
-    Timecop.return
+    Stoplight::TimeTravel.return
     redis = Redis.new
     redis.del("stoplight:test_now_ms_stack")
   end

--- a/spec/support/data_store/transition_to_color.rb
+++ b/spec/support/data_store/transition_to_color.rb
@@ -40,7 +40,7 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
       it { expect(transition_to_color(Stoplight::Color::GREEN)).to be(true) }
 
       it "resets timestamps" do
-        Timecop.freeze(current_time) do
+        Stoplight::TimeTravel.freeze(current_time) do
           transition_to_color(Stoplight::Color::GREEN)
         end
 
@@ -73,7 +73,7 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
 
       it "sets the recovery_started_at timestamp" do
         expect do
-          Timecop.freeze(current_time) do
+          Stoplight::TimeTravel.freeze(current_time) do
             transition_to_color(Stoplight::Color::YELLOW)
           end
         end.to change { state_snapshot }
@@ -83,7 +83,7 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
 
       context "when cleared" do
         it "looses persisted state" do
-          Timecop.freeze(current_time) do
+          Stoplight::TimeTravel.freeze(current_time) do
             transition_to_color(Stoplight::Color::YELLOW)
           end
           clear
@@ -113,7 +113,7 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
 
       it "sets the breached_at and recovery_scheduled_after timestamps" do
         expect do
-          Timecop.freeze(current_time) do
+          Stoplight::TimeTravel.freeze(current_time) do
             transition_to_color(Stoplight::Color::RED)
           end
         end.to change { state_snapshot }
@@ -123,7 +123,7 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
 
       context "when cleared" do
         it "looses persisted state" do
-          Timecop.freeze(current_time) do
+          Stoplight::TimeTravel.freeze(current_time) do
             transition_to_color(Stoplight::Color::YELLOW)
           end
           clear
@@ -143,7 +143,7 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
 
       it "sets the breached_at and recovery_scheduled_after timestamps" do
         expect do
-          Timecop.freeze(current_time) do
+          Stoplight::TimeTravel.freeze(current_time) do
             transition_to_color(Stoplight::Color::RED)
           end
         end.to change { state_snapshot }
@@ -153,7 +153,7 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#transition_to_color" do
 
       context "when cleared" do
         it "looses persisted state" do
-          Timecop.freeze(current_time) do
+          Stoplight::TimeTravel.freeze(current_time) do
             transition_to_color(Stoplight::Color::YELLOW)
           end
           clear

--- a/spec/support/timecop.rb
+++ b/spec/support/timecop.rb
@@ -5,6 +5,6 @@ require "timecop"
 RSpec.configure do |config|
   config.around(:each, freeze: ->(value) { value.present? }) do |example|
     time = Time.now.to_i
-    Timecop.freeze(time) { example.run }
+    Stoplight::TimeTravel.freeze(time) { example.run }
   end
 end

--- a/spec/unit/stoplight/domain/failure_spec.rb
+++ b/spec/unit/stoplight/domain/failure_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Stoplight::Domain::Failure do
 
   describe ".from_error" do
     it "creates a failure" do
-      Timecop.freeze do
+      Stoplight::TimeTravel.freeze do
         failure = described_class.from_error(error, time: Time.now)
         expect(failure.error_class).to eql(error_class)
         expect(failure.error_message).to eql(error_message)

--- a/spec/unit/stoplight/infrastructure/data_store/metrics_snapshot.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/metrics_snapshot.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples "a metrics snapshot" do
       record_success
 
       expect do
-        Timecop.freeze(last_success_time) do
+        Stoplight::TimeTravel.freeze(last_success_time) do
           record_success
         end
       end.to change { metrics_snapshot.last_success_at }.to(be_within(rounding_error).of(last_success_time))
@@ -21,7 +21,7 @@ RSpec.shared_examples "a metrics snapshot" do
 
     specify "when first success tracked" do
       expect do
-        Timecop.freeze(last_success_time) do
+        Stoplight::TimeTravel.freeze(last_success_time) do
           record_success
         end
       end.to change { metrics_snapshot.last_success_at }.from(nil).to(be_within(rounding_error).of(last_success_time))
@@ -35,7 +35,7 @@ RSpec.shared_examples "a metrics snapshot" do
       record_failure(error)
 
       expect do
-        Timecop.freeze(last_error_time) do
+        Stoplight::TimeTravel.freeze(last_error_time) do
           record_failure(error)
         end
       end.to change { metrics_snapshot.last_error_at }.to(be_within(rounding_error).of(last_error_time))
@@ -43,7 +43,7 @@ RSpec.shared_examples "a metrics snapshot" do
 
     specify "when first failure tracked" do
       expect do
-        Timecop.freeze(last_error_time) do
+        Stoplight::TimeTravel.freeze(last_error_time) do
           record_failure(error)
         end
       end.to change { metrics_snapshot.last_error_at }.from(nil).to(be_within(rounding_error).of(last_error_time))

--- a/spec/unit/stoplight/infrastructure/data_store/recovery_metrics.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/recovery_metrics.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#get_recovery_metrics" do
       record_success
 
       expect do
-        Timecop.freeze(last_success_time) do
+        Stoplight::TimeTravel.freeze(last_success_time) do
           record_success
         end
       end.to change { get_metrics.last_success_at }.to(be_within(rounding_error).of(last_success_time))
@@ -21,7 +21,7 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#get_recovery_metrics" do
 
     specify "when first success tracked" do
       expect do
-        Timecop.freeze(last_success_time) do
+        Stoplight::TimeTravel.freeze(last_success_time) do
           record_success
         end
       end.to change { get_metrics.last_success_at }.from(nil).to(be_within(rounding_error).of(last_success_time))
@@ -35,7 +35,7 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#get_recovery_metrics" do
       record_failure(error)
 
       expect do
-        Timecop.freeze(last_error_time) do
+        Stoplight::TimeTravel.freeze(last_error_time) do
           record_failure(error)
         end
       end.to change { get_metrics.last_error_at }.to(be_within(rounding_error).of(last_error_time))
@@ -43,7 +43,7 @@ RSpec.shared_examples "Stoplight::Domain::DataStore#get_recovery_metrics" do
 
     specify "when first failure tracked" do
       expect do
-        Timecop.freeze(last_error_time) do
+        Stoplight::TimeTravel.freeze(last_error_time) do
           record_failure(error)
         end
       end.to change { get_metrics.last_error_at }.to(be_within(rounding_error).of(last_error_time))

--- a/spec/unit/stoplight/infrastructure/data_store/window_metrics_snapshot.rb
+++ b/spec/unit/stoplight/infrastructure/data_store/window_metrics_snapshot.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples "a window metrics snapshot" do
         let(:window_size) { 5000 }
 
         before do
-          Timecop.freeze(-window_size - 10) do
+          Stoplight::TimeTravel.freeze(-window_size - 10) do
             record_success
           end
         end
@@ -27,7 +27,7 @@ RSpec.shared_examples "a window metrics snapshot" do
         let(:window_size) { 5000 }
 
         before do
-          Timecop.freeze(-window_size - 10) do
+          Stoplight::TimeTravel.freeze(-window_size - 10) do
             record_failure(error)
           end
         end
@@ -79,10 +79,10 @@ RSpec.shared_examples "a window metrics snapshot" do
         let(:window_size) { 300 }
 
         it "excludes it from the count" do
-          Timecop.freeze(Time.now) do
+          Stoplight::TimeTravel.freeze(Time.now) do
             record_success
 
-            Timecop.freeze(window_size) do
+            Stoplight::TimeTravel.freeze(window_size) do
               expect(metrics_snapshot.successes).to eq(0)
             end
           end
@@ -93,10 +93,10 @@ RSpec.shared_examples "a window metrics snapshot" do
         let(:window_size) { 300 }
 
         it "excludes it from the count" do
-          Timecop.freeze(Time.now) do
+          Stoplight::TimeTravel.freeze(Time.now) do
             record_failure(error)
 
-            Timecop.freeze(window_size) do
+            Stoplight::TimeTravel.freeze(window_size) do
               expect(metrics_snapshot.errors).to eq(0)
             end
           end
@@ -110,10 +110,10 @@ RSpec.shared_examples "a window metrics snapshot" do
         let(:bucket_count) { window_size }
 
         it "evicts the whole backlog without raising, keeping successes correct" do
-          Timecop.freeze(Time.now) do
-            bucket_count.times { |second| Timecop.freeze(second) { record_success } }
+          Stoplight::TimeTravel.freeze do
+            bucket_count.times { |second| Stoplight::TimeTravel.freeze(second) { record_success } }
 
-            Timecop.freeze(bucket_count + window_size + 10) do
+            Stoplight::TimeTravel.freeze(bucket_count + window_size + 10) do
               expect { record_success }.not_to raise_error
 
               expect(metrics_snapshot.successes).to eq(1)
@@ -122,10 +122,10 @@ RSpec.shared_examples "a window metrics snapshot" do
         end
 
         it "evicts the whole backlog without raising, keeping errors correct" do
-          Timecop.freeze(Time.now) do
-            bucket_count.times { |second| Timecop.freeze(second) { record_failure(error) } }
+          Stoplight::TimeTravel.freeze do
+            bucket_count.times { |second| Stoplight::TimeTravel.freeze(second) { record_failure(error) } }
 
-            Timecop.freeze(bucket_count + window_size + 10) do
+            Stoplight::TimeTravel.freeze(bucket_count + window_size + 10) do
               expect { record_failure(error) }.not_to raise_error
 
               expect(metrics_snapshot.errors).to eq(1)
@@ -134,12 +134,12 @@ RSpec.shared_examples "a window metrics snapshot" do
         end
 
         it "subtracts successes and failures independently when buckets mix both" do
-          Timecop.freeze(Time.now) do
+          Stoplight::TimeTravel.freeze do
             bucket_count.times do |second|
-              Timecop.freeze(second) { second.even? ? record_success : record_failure(error) }
+              Stoplight::TimeTravel.freeze(second) { second.even? ? record_success : record_failure(error) }
             end
 
-            Timecop.freeze(bucket_count + window_size + 10) do
+            Stoplight::TimeTravel.freeze(bucket_count + window_size + 10) do
               record_success
 
               expect(metrics_snapshot.successes).to eq(1)

--- a/spec/unit/stoplight/infrastructure/redis/storage/unbounded_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/unbounded_metrics_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::UnboundedMetrics, :red
     it "keeps the TTL on the metrics key for a subsequent out-of-order failure" do
       unbounded_metrics.record_failure(StandardError.new)
 
-      Timecop.freeze(Time.now - 30) do
+      Stoplight::TimeTravel.freeze(Time.now - 30) do
         unbounded_metrics.record_failure(StandardError.new)
       end
 

--- a/spec/unit/stoplight/infrastructure/system_clock_spec.rb
+++ b/spec/unit/stoplight/infrastructure/system_clock_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Stoplight::Infrastructure::SystemClock do
     subject(:current_time) { clock.current_time }
 
     around do |example|
-      Timecop.freeze { example.run }
+      Stoplight::TimeTravel.freeze { example.run }
     end
 
     it "returns current wall-clock time" do


### PR DESCRIPTION
What changed:
- All unit tests updated to use `TimeTravel` for metrics snapshots, state transitions, recovery timing
- All assertions on timestamped values now use frozen time
- Tests run 100% deterministically regardless of system clock
- All feature tests use real time, not time traveling

Part of: 3-phase refactoring (Phase 2/3)
- Depends on: #917 (infrastructure)
- Enables: #921 (production code to use `now()`)