### PR TITLE
Production Code: Use Redis Time in State & Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ profile_results
 .tmproj
 .idea
 Thumbs.db
+dump.rdb
+spec/tmp/

--- a/features/stoplight/global_configuration/window_size.feature
+++ b/features/stoplight/global_configuration/window_size.feature
@@ -53,8 +53,8 @@ Feature: Stoplight configuration - Window Size
       | Threshold   | 3  |
     And the service starts failing with "timeout"
     And 1 request is made
-    And 1000 days have elapsed
+    And 1 hour have elapsed
     And 1 request is made
-    And 1000 days have elapsed
+    And 1 hour have elapsed
     And 1 request is made
     Then the light color is red

--- a/features/stoplight/step_definitions/helpers_steps.rb
+++ b/features/stoplight/step_definitions/helpers_steps.rb
@@ -15,7 +15,7 @@ When(/^(\d+) (seconds|minutes|hours|days) have elapsed$/) do |seconds, unit|
   else
     raise ArgumentError, "Unknown time unit: #{unit}"
   end
-  Timecop.travel(Time.now + seconds)
+  sleep(seconds)
 end
 
 When(/^the service starts failing with "([^"]+)"(?: again)?$/) do |error_message|

--- a/lib/stoplight/infrastructure/redis/storage/state.rb
+++ b/lib/stoplight/infrastructure/redis/storage/state.rb
@@ -103,7 +103,7 @@ module Stoplight
           def transition_to_green
             became_green = scripting.call(
               "state/transition_to_green",
-              args: [clock.current_time.to_f],
+              args: [],
               keys: [state_key]
             )
             became_green == 1
@@ -114,7 +114,7 @@ module Stoplight
           def transition_to_yellow
             became_yellow = scripting.call(
               "state/transition_to_yellow",
-              args: [clock.current_time.to_f],
+              args: [],
               keys: [state_key]
             )
             became_yellow == 1
@@ -128,7 +128,7 @@ module Stoplight
 
             became_red = scripting.call(
               "state/transition_to_red",
-              args: [current_ts, recovery_scheduled_after_ts],
+              args: [recovery_scheduled_after_ts],
               keys: [state_key]
             )
 

--- a/lib/stoplight/infrastructure/redis/storage/state/transition_to_green.lua
+++ b/lib/stoplight/infrastructure/redis/storage/state/transition_to_green.lua
@@ -1,5 +1,7 @@
+-- @include now
+
 local meta_key = KEYS[1]
-local current_ts = tonumber(ARGV[1])
+local current_ts = now() / 1000
 
 --  1 if the field is a new field in the hash and the value was set
 local became_green = redis.call('HSETNX', meta_key, 'recovered_at', current_ts)

--- a/lib/stoplight/infrastructure/redis/storage/state/transition_to_red.lua
+++ b/lib/stoplight/infrastructure/redis/storage/state/transition_to_red.lua
@@ -1,6 +1,8 @@
+-- @include now
+
 local meta_key = KEYS[1]
-local current_ts = tonumber(ARGV[1])
-local recovery_scheduled_after_ts = tonumber(ARGV[2])
+local recovery_scheduled_after_ts = tonumber(ARGV[1])
+local current_ts = now() / 1000
 
 --  1 if the field is a new field in the hash and the value was set
 local became_red = redis.call('HSETNX', meta_key, 'breached_at', current_ts)

--- a/lib/stoplight/infrastructure/redis/storage/state/transition_to_yellow.lua
+++ b/lib/stoplight/infrastructure/redis/storage/state/transition_to_yellow.lua
@@ -1,5 +1,7 @@
+-- @include now
+
 local meta_key = KEYS[1]
-local current_ts = tonumber(ARGV[1])
+local current_ts = now() / 1000
 
 -- HSETNX returns 1 if field is new and was set, 0 if field already exists
 local became_yellow = redis.call('HSETNX', meta_key, 'recovery_started_at', current_ts)

--- a/lib/stoplight/infrastructure/redis/storage/unbounded_metrics.rb
+++ b/lib/stoplight/infrastructure/redis/storage/unbounded_metrics.rb
@@ -77,11 +77,9 @@ module Stoplight
           # Records successful circuit breaker execution
           #
           def record_success
-            timestamp = clock.current_time.to_f
-
             scripting.call(
               "unbounded_metrics/record_success",
-              args: [timestamp, metrics_ttl],
+              args: [metrics_ttl],
               keys: [metrics_key]
             )
           end
@@ -93,7 +91,7 @@ module Stoplight
 
             last_success_at, last_error_json, consecutive_errors, consecutive_successes = scripting.call(
               "unbounded_metrics/record_failure",
-              args: [timestamp, serialize_exception(exception, timestamp:), metrics_ttl],
+              args: [serialize_exception(exception, timestamp:), metrics_ttl],
               keys: [metrics_key]
             )
 

--- a/lib/stoplight/infrastructure/redis/storage/unbounded_metrics/record_failure.lua
+++ b/lib/stoplight/infrastructure/redis/storage/unbounded_metrics/record_failure.lua
@@ -1,37 +1,27 @@
-local failure_ts = tonumber(ARGV[1])
-local failure_json = ARGV[2]
-local metrics_ttl = tonumber(ARGV[3])
+-- @include now
 
 local metrics_key = KEYS[1]
+local error_json = ARGV[1]
+local metrics_ttl = tonumber(ARGV[2])
 
 -- Update metadata
-local meta = redis.call('HMGET', metrics_key, 'last_error_at', 'consecutive_errors')
-local prev_failure_ts = tonumber(meta[1])
-local prev_consecutive_errors = tonumber(meta[2])
+local meta = redis.call('HMGET', metrics_key, 'consecutive_errors', "last_success_at")
+local prev_consecutive_errors = tonumber(meta[1])
+local last_success_at = meta[2]
+local failure_ts = now() / 1000.0
 
 local consecutive_errors = (prev_consecutive_errors or 0) + 1
 local consecutive_successes = 0
 
-if not prev_failure_ts or failure_ts > prev_failure_ts then
-  redis.call(
-    'HSET', metrics_key,
-    'last_error_at', failure_ts,
-    'last_error_json', failure_json,
-    'consecutive_errors', consecutive_errors,
-    'consecutive_successes', consecutive_successes
-  )
-  redis.call('EXPIRE', metrics_key, metrics_ttl)
+-- Always update with current timestamp (out-of-order impossible with Redis time)
+redis.call(
+  'HSET', metrics_key,
+  'last_error_at', failure_ts,
+  'last_error_json', error_json,
+  'consecutive_errors', consecutive_errors,
+  'consecutive_successes', consecutive_successes
+)
 
-  local last_success_at = redis.call("HGET", metrics_key, "last_success_at")
-  return {last_success_at, failure_json, consecutive_errors, consecutive_successes}
-else
-  redis.call(
-    'HSET', metrics_key,
-    'consecutive_errors', consecutive_errors,
-    'consecutive_successes', consecutive_successes
-  )
-  redis.call('EXPIRE', metrics_key, metrics_ttl)
+redis.call('EXPIRE', metrics_key, metrics_ttl)
 
-  local meta = redis.call("HMGET", metrics_key, "last_success_at", "last_error_json")
-  return {meta[1], meta[2], consecutive_errors, consecutive_successes}
-end
+return {last_success_at, error_json, consecutive_errors, consecutive_successes}

--- a/lib/stoplight/infrastructure/redis/storage/unbounded_metrics/record_success.lua
+++ b/lib/stoplight/infrastructure/redis/storage/unbounded_metrics/record_success.lua
@@ -1,26 +1,18 @@
-local request_ts = tonumber(ARGV[1])
-local metrics_ttl = tonumber(ARGV[2])
+-- @include now
 
 local metrics_key = KEYS[1]
+local metrics_ttl = tonumber(ARGV[1])
 
 -- Update metadata
-local meta = redis.call('HMGET', metrics_key, 'last_success_at', 'consecutive_successes')
-local prev_success_ts = tonumber(meta[1])
-local prev_consecutive_successes = tonumber(meta[2])
+local prev_consecutive_successes = tonumber(redis.call('HGET', metrics_key, 'consecutive_successes'))
+local request_ts = now() / 1000.0
 
-if not prev_success_ts or request_ts > prev_success_ts then
-  redis.call(
-    'HSET', metrics_key,
-    'last_success_at', request_ts,
-    'consecutive_errors', 0,
-    'consecutive_successes', (prev_consecutive_successes or 0) + 1
-  )
-else
-  redis.call(
-    'HSET', metrics_key,
-    'consecutive_errors', 0,
-    'consecutive_successes', (prev_consecutive_successes or 0) + 1
-  )
-end
+-- Always update with current timestamp (out-of-order impossible with Redis time)
+redis.call(
+  'HSET', metrics_key,
+  'last_success_at', request_ts,
+  'consecutive_errors', 0,
+  'consecutive_successes', (prev_consecutive_successes or 0) + 1
+)
 
 redis.call('EXPIRE', metrics_key, metrics_ttl)

--- a/lib/stoplight/infrastructure/redis/storage/window_metrics.rb
+++ b/lib/stoplight/infrastructure/redis/storage/window_metrics.rb
@@ -26,12 +26,10 @@ module Stoplight
           end
 
           def metrics_snapshot
-            timestamp = @clock.current_time.to_f
-
             successes, errors, last_success_at, last_error_json, consecutive_errors, consecutive_successes =
               @scripting.call(
                 "window_metrics/metrics_snapshot",
-                args: [timestamp, @window_size, *METRICS_FIELDS],
+                args: [@window_size, *METRICS_FIELDS],
                 keys: [@metrics_key, @ts_index_key]
               )
 
@@ -40,11 +38,9 @@ module Stoplight
           end
 
           def record_success
-            timestamp = @clock.current_time.to_f
-
             @scripting.call(
               "window_metrics/record_success",
-              args: [timestamp, @window_size, metrics_ttl],
+              args: [@window_size, metrics_ttl],
               keys: [@metrics_key, @ts_index_key]
             )
           end
@@ -55,7 +51,7 @@ module Stoplight
             successes, errors, last_success_at, last_error_json, consecutive_errors, consecutive_successes =
               @scripting.call(
                 "window_metrics/record_failure",
-                args: [timestamp, serialize_exception(exception, timestamp:), @window_size, metrics_ttl],
+                args: [serialize_exception(exception, timestamp:), @window_size, metrics_ttl],
                 keys: [@metrics_key, @ts_index_key]
               )
 

--- a/lib/stoplight/infrastructure/redis/storage/window_metrics/metrics_snapshot.lua
+++ b/lib/stoplight/infrastructure/redis/storage/window_metrics/metrics_snapshot.lua
@@ -1,15 +1,16 @@
+-- @include now
 -- @include window_metrics/_evict
 
-local current_ts  = tonumber(ARGV[1])
-local window_size = tonumber(ARGV[2])
+local window_size = tonumber(ARGV[1])
 
 local metrics_key  = KEYS[1]
 local ts_index_key = KEYS[2]
 
+local current_ts = now() / 1000.0
 evict_buckets(metrics_key, ts_index_key, math.floor(current_ts) - window_size)
 
--- copy arguments starting from index 3 to fields' tail
-local fields = {'total_successes','total_failures', unpack(ARGV, 3) }
+-- copy arguments starting from index 2 to fields' tail
+local fields = {'total_successes','total_failures', unpack(ARGV, 2) }
 local metrics = redis.call('HMGET', metrics_key, unpack(fields))
 
 metrics[1] = tonumber(metrics[1]) or 0 -- total_successes

--- a/lib/stoplight/infrastructure/redis/storage/window_metrics/record_failure.lua
+++ b/lib/stoplight/infrastructure/redis/storage/window_metrics/record_failure.lua
@@ -1,35 +1,31 @@
+-- @include now
 -- @include window_metrics/_evict
 
-local request_ts   = tonumber(ARGV[1]) -- float, used for metadata timestamps
-local failure_json = ARGV[2]
-local window_size  = tonumber(ARGV[3])
-local metadata_ttl = tonumber(ARGV[4])
+local failure_json = ARGV[1]
+local window_size  = tonumber(ARGV[2])
+local metadata_ttl = tonumber(ARGV[3])
 
 local metrics_key  = KEYS[1]
 local ts_index_key = KEYS[2]
-local bucket_ts    = math.floor(request_ts) -- integer second, used for bucket keys
+local request_ts   = now() / 1000.0
+local bucket_ts    = math.floor(request_ts)
 
 evict_buckets(metrics_key, ts_index_key, bucket_ts - window_size)
 
 local bucket = 'bucket:' .. bucket_ts
-redis.call('HINCRBY', metrics_key, bucket .. ':f', 1)    -- increment second's bucket
-redis.call('HINCRBY', metrics_key, 'total_failures', 1)  -- increment running sum
-redis.call('ZADD', ts_index_key, bucket_ts, bucket)      -- index bucket used bucket name
+redis.call('HINCRBY', metrics_key, bucket .. ':f', 1)
+redis.call('HINCRBY', metrics_key, 'total_failures', 1)
+redis.call('ZADD', ts_index_key, bucket_ts, bucket)
 
-local prev_request_ts = tonumber(redis.call('HGET', metrics_key, 'last_error_at'))
 local consecutive_errors = redis.call('HINCRBY', metrics_key, 'consecutive_errors', 1)
 
-if not prev_request_ts or request_ts > prev_request_ts then
-  redis.call(
-    'HSET', metrics_key,
-    'last_error_at', request_ts,
-    'last_error_json', failure_json,
-    'consecutive_successes', 0
-  )
-else
-  redis.call('HSET', metrics_key, 'consecutive_successes', 0)
-  failure_json = redis.call('HGET', metrics_key, 'last_error_json')
-end
+-- Always update with current timestamp (out-of-order impossible with Redis time)
+redis.call(
+  'HSET', metrics_key,
+  'last_error_at', request_ts,
+  'last_error_json', failure_json,
+  'consecutive_successes', 0
+)
 
 redis.call('EXPIRE', metrics_key, metadata_ttl)
 redis.call('EXPIRE', ts_index_key, metadata_ttl)

--- a/lib/stoplight/infrastructure/redis/storage/window_metrics/record_success.lua
+++ b/lib/stoplight/infrastructure/redis/storage/window_metrics/record_success.lua
@@ -1,28 +1,28 @@
+-- @include now
 -- @include window_metrics/_evict
 
-local request_ts   = tonumber(ARGV[1])         -- float, used for metadata timestamps
-local window_size  = tonumber(ARGV[2])
-local metadata_ttl = tonumber(ARGV[3])
+local window_size  = tonumber(ARGV[1])
+local metadata_ttl = tonumber(ARGV[2])
 
 local metrics_key  = KEYS[1]
 local ts_index_key = KEYS[2]
-local bucket_ts    = math.floor(request_ts) -- integer second, used for bucket keys
+local request_ts   = now() / 1000.0
+local bucket_ts    = math.floor(request_ts)
 
 evict_buckets(metrics_key, ts_index_key, bucket_ts - window_size)
 
 local bucket = 'bucket:' .. bucket_ts
-redis.call('HINCRBY', metrics_key, bucket .. ':s', 1)     -- increment second's bucket
-redis.call('HINCRBY', metrics_key, 'total_successes', 1)  -- increment running sum
-redis.call('ZADD', ts_index_key, bucket_ts, bucket)       -- index bucket used bucket name
+redis.call('HINCRBY', metrics_key, bucket .. ':s', 1)
+redis.call('HINCRBY', metrics_key, 'total_successes', 1)
+redis.call('ZADD', ts_index_key, bucket_ts, bucket)
 
-local prev_success_ts = tonumber(redis.call('HGET', metrics_key, 'last_success_at'))
+-- Always update with current timestamp (out-of-order impossible with Redis time)
+redis.call(
+  'HSET', metrics_key,
+  'last_success_at', request_ts,
+  'consecutive_errors', 0
+)
+
 redis.call('HINCRBY', metrics_key, 'consecutive_successes', 1)
-
-if not prev_success_ts or request_ts > prev_success_ts then
-  redis.call('HSET', metrics_key, 'last_success_at', request_ts, 'consecutive_errors', 0)
-else
-  redis.call('HSET', metrics_key, 'consecutive_errors', 0)
-end
-
 redis.call('EXPIRE', metrics_key, metadata_ttl)
 redis.call('EXPIRE', ts_index_key, metadata_ttl)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,7 @@ require_relative "support/exception_helpers"
 require_relative "support/route_helpers"
 require_relative "support/matchers/emit"
 require_relative "support/time_travel"
+require_relative "support/scripting_helper"
 
 Timecop.safe_mode = true
 # Window buckets age on the monotonic clock; travel/freeze must move it too.

--- a/spec/support/scripting_helper.rb
+++ b/spec/support/scripting_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# For :redis specs with TimeTravel, Lua scripts need test stub version of now() that reads
+# frozen time from Redis stack, not production version that calls redis.call("TIME").
+# This hook makes that transparent: all :redis specs get the stubs path prepended.
+
+STUBS_PATH = File.expand_path("../stubs", __FILE__)
+PROD_PATHS = Stoplight::Infrastructure::Redis::Storage::Scripting.default_scripts_path
+
+RSpec.configure do |config|
+  config.before(:each, :redis) do
+    allow(Stoplight::Infrastructure::Redis::Storage::Scripting)
+      .to receive(:default_scripts_path)
+      .and_return([STUBS_PATH, *PROD_PATHS])
+  end
+end

--- a/spec/support/stubs/now.lua
+++ b/spec/support/stubs/now.lua
@@ -1,0 +1,11 @@
+-- Test stub for now() - checks Redis stack first (for tests), falls back to redis.call("TIME").
+local function now()
+  local test_time = redis.call("LINDEX", "stoplight:test_now_ms_stack", -1)
+  if test_time then
+    return tonumber(test_time)
+  end
+  local time = redis.call("TIME")
+  local seconds = tonumber(time[1])
+  local microseconds = tonumber(time[2])
+  return seconds * 1000 + math.floor(microseconds / 1000)
+end


### PR DESCRIPTION
Updates production Lua scripts and Ruby code to use Redis-synchronized `now()` for all time-dependent operations:

1. Lua scripts call `now()` instead of duplicating time logic
   - State transitions (green→yellow→red) use Redis time
   - Metrics snapshots (`last_success_at`, `consecutive_errors`) use Redis time
2. Out-of-order protection removed ээ impossible with monotonic Redis time - time leaping backwards possible in theory but rather theoretical - in practice time adjustments is done by slowing down time.
3. Feature tests use real `sleep()` instead of time-travel to advance time with actual Redis calls
4. Cleanup removes unused `TimeTravel` from feature test helpers

 Part of: 3-phase refactoring (Phase 3/3)