### PR TITLE
Reduce GitHub Actions queue pressure with concurrency and path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,20 @@ name: 🚦Stoplight
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.docs/**'
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:  # added using https://github.com/step-security/secure-repo
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,10 @@
 name: '🔍Dependency Review'
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/proquo.yml
+++ b/.github/workflows/proquo.yml
@@ -2,6 +2,11 @@ name: 🏷️ ProQuo
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
## Summary

Optimize GitHub Actions job queue by canceling duplicate runs and skipping CI for non-code changes.

- **Concurrency groups**: Cancel stale runs on force-pushes and rapid commits (prevents queue pile-up from stacked duplicate runs)
- **Path filters**: Skip full test suite on docs-only changes (`.md`, `docs/`, `.docs/`)

## Why

Current configuration spawns 26+ jobs per event with no way to cancel stale runs. This causes:
- Job queue bottleneck (jobs waiting 12+ hours to start)
- Wasted runner capacity on docs-only PRs
- Fair-use throttling from GitHub (queue gets deprioritized)

This change targets the root cause: GitHub's 20-concurrent-job ceiling on Free plan.

## Impact

- **No coverage loss** on real (non-docs) code changes — full Ruby x datastore matrix still runs once per push
- **Immediate queue relief** from canceling duplicate runs on force-pushes
- **Zero CI time** for README/docs-only branches (like the current `feature/update-readme` branch)

## Testing

After merge, monitor job queue times:
- Legitimate code changes should complete within minutes (not hours)
- 31k minutes/month monthly usage should drop as queue clears

If queue still builds up after this ships, consider Option B (sparse matrix on PRs, full matrix post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDJsSSRwSJPGjRbF91L56X