### PR TITLE
Inject the now() Lua stub via scripts_path in Redis specs

### DIFF
--- a/spec/integration/redis_time_travel_integration_spec.rb
+++ b/spec/integration/redis_time_travel_integration_spec.rb
@@ -1,24 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe "Redis time travel integration", :redis do
-  let(:script_manager) { Stoplight::Infrastructure::Redis::Storage::Scripting.new(redis:) }
+  let(:script_manager) do
+    Stoplight::Infrastructure::Redis::Storage::Scripting.new(
+      redis:,
+      scripts_path: [test_script_path.to_s, *Stoplight::TimeTravel.scripts_path]
+    )
+  end
   let(:test_script_name) { :test_now_integration }
   let(:test_script_path) { Pathname.new(Dir.tmpdir).join(SecureRandom.uuid) }
 
   before do
     Dir.mkdir(test_script_path.to_s)
-    support_lua_path = Pathname.new(File.expand_path("../support/lua", __dir__)).to_s
-    script_manager_with_path = Stoplight::Infrastructure::Redis::Storage::Scripting.new(
-      redis:,
-      scripts_path: [test_script_path.to_s, support_lua_path]
-    )
-    @script_manager = script_manager_with_path
-
-    script_content = <<~LUA
+    File.write(test_script_path.join("test_now_integration.lua"), <<~LUA)
       -- @include now
       return now()
     LUA
-    File.write(test_script_path.join("test_now_integration.lua"), script_content)
   end
 
   after do
@@ -30,7 +27,7 @@ RSpec.describe "Redis time travel integration", :redis do
       frozen_time = Time.new(2025, 6, 15, 14, 30, 45)
 
       Stoplight::TimeTravel.freeze(frozen_time) do
-        result = @script_manager.call(test_script_name, keys: [], args: [])
+        result = script_manager.call(test_script_name, keys: [], args: [])
         expected_ms = (frozen_time.to_f * 1000).to_i
 
         expect(result).to eq(expected_ms)
@@ -42,15 +39,15 @@ RSpec.describe "Redis time travel integration", :redis do
       inner_time = Time.new(2025, 6, 15, 14, 30, 45)
 
       Stoplight::TimeTravel.freeze(start_time) do
-        outer_result = @script_manager.call(test_script_name, keys: [], args: [])
+        outer_result = script_manager.call(test_script_name, keys: [], args: [])
 
         Stoplight::TimeTravel.freeze(inner_time) do
-          inner_result = @script_manager.call(test_script_name, keys: [], args: [])
+          inner_result = script_manager.call(test_script_name, keys: [], args: [])
           expect(inner_result).to eq((inner_time.to_f * 1000).to_i)
         end
 
         # After inner freeze exits, outer freeze is restored
-        restored_result = @script_manager.call(test_script_name, keys: [], args: [])
+        restored_result = script_manager.call(test_script_name, keys: [], args: [])
         expect(restored_result).to eq(outer_result)
       end
     end
@@ -58,7 +55,7 @@ RSpec.describe "Redis time travel integration", :redis do
 
   describe "now() returns actual time when not mocked" do
     it "returns current Redis server time" do
-      result = @script_manager.call(test_script_name, keys: [], args: [])
+      result = script_manager.call(test_script_name, keys: [], args: [])
 
       now_ms = (Time.now.to_f * 1000).to_i
       # Allow 1 second tolerance for test execution time

--- a/spec/support/time_travel.rb
+++ b/spec/support/time_travel.rb
@@ -3,8 +3,14 @@
 module Stoplight
   module TimeTravel
     STACK_KEY = "stoplight:test_now_ms_stack"
+    LUA_PATH = File.expand_path("lua", __dir__)
 
     class << self
+      # LUA_PATH must stay first: the first now.lua on the path wins, and only that one reads STACK_KEY.
+      def scripts_path
+        [LUA_PATH, *Infrastructure::Redis::Storage::Scripting.default_scripts_path]
+      end
+
       def freeze(time = Time.now)
         if block_given?
           Timecop.freeze(time) do

--- a/spec/unit/stoplight/infrastructure/redis/storage/recovery_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/recovery_metrics_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::RecoveryMetrics, :redi
 
   let(:clock) { Stoplight::Infrastructure::SystemClock.new }
   let(:key_space) { Stoplight::DataStore::Redis.key_space.join(SecureRandom.uuid) }
-  let(:scripting) { Stoplight::Infrastructure::Redis::Storage::Scripting.new(redis:) }
+  let(:scripting) do
+    Stoplight::Infrastructure::Redis::Storage::Scripting.new(redis:, scripts_path: Stoplight::TimeTravel.scripts_path)
+  end
 
   it_behaves_like "Stoplight::Domain::DataStore#get_recovery_metrics" do
     def get_metrics = metrics_store.metrics_snapshot

--- a/spec/unit/stoplight/infrastructure/redis/storage/state_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/state_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::State, :redis do
   shared_examples Stoplight::Infrastructure::Redis::Storage::State do
     subject(:storage) { described_class.new(clock:, redis: connection, scripting:, key_space:, cool_off_time:) }
 
-    let(:scripting) { Stoplight::Infrastructure::Redis::Storage::Scripting.new(redis:) }
+    let(:scripting) do
+      Stoplight::Infrastructure::Redis::Storage::Scripting.new(redis:, scripts_path: Stoplight::TimeTravel.scripts_path)
+    end
     let(:key_space) { Stoplight::DataStore::Redis.key_space.join(SecureRandom.uuid) }
     let(:clock) { Stoplight::Infrastructure::SystemClock.new }
 

--- a/spec/unit/stoplight/infrastructure/redis/storage/unbounded_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/unbounded_metrics_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::UnboundedMetrics, :red
 
   let(:clock) { Stoplight::Infrastructure::SystemClock.new }
   let(:key_space) { Stoplight::DataStore::Redis.key_space.join(SecureRandom.uuid) }
-  let(:scripting) { Stoplight::Infrastructure::Redis::Storage::Scripting.new(redis:) }
+  let(:scripting) do
+    Stoplight::Infrastructure::Redis::Storage::Scripting.new(redis:, scripts_path: Stoplight::TimeTravel.scripts_path)
+  end
 
   it_behaves_like "a metrics snapshot" do
     def metrics_snapshot = unbounded_metrics.metrics_snapshot

--- a/spec/unit/stoplight/infrastructure/redis/storage/window_metrics_spec.rb
+++ b/spec/unit/stoplight/infrastructure/redis/storage/window_metrics_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe Stoplight::Infrastructure::Redis::Storage::WindowMetrics, :redis 
   let(:key_space) { Stoplight::DataStore::Redis.key_space.join(SecureRandom.uuid) }
   let(:clock) { Stoplight::Infrastructure::SystemClock.new }
   let(:config) { instance_double(Stoplight::Domain::Config, window_size:) }
-  let(:scripting) { Stoplight::Infrastructure::Redis::Storage::Scripting.new(redis:) }
+  let(:scripting) do
+    Stoplight::Infrastructure::Redis::Storage::Scripting.new(redis:, scripts_path: Stoplight::TimeTravel.scripts_path)
+  end
   let(:window_size) { 300 }
 
   it_behaves_like "a window metrics snapshot" do


### PR DESCRIPTION
TimeTravel.scripts_path prepends spec/support/lua so `-- @include now` resolves to the stub reading the frozen-time stack. Redis storage specs pass it to Scripting.new instead of taking the default path.