### PR TITLE
Stage CI so a push runs five jobs instead of twenty

### DIFF
--- a/.github/ci-versions.yml
+++ b/.github/ci-versions.yml
@@ -1,0 +1,22 @@
+# Single source of truth for every version CI tests: adding or dropping one is an edit here and
+# nowhere else. bin/ci.rb derives the matrices from this file and refuses to run if latest_* drifts.
+
+latest_ruby: '4.0'
+
+rubies:
+  - '3.3'
+  - '3.4'
+  - '4.0'
+
+images:
+  - redis:7.4
+  - redis:8.4
+  - redis:8.6
+  - valkey/valkey:7.2-alpine
+  - valkey/valkey:8.1-alpine
+  - valkey/valkey:9.1-alpine
+
+# Newest of each engine. Drives the smoke specs and the cucumber features.
+latest_images:
+  - redis:8.6
+  - valkey/valkey:9.1-alpine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ spec, versions ]
     environment:
-      name: ${{ github.base_ref == 'develop' && 'extended-manual' || 'extended-auto' }}
+      name: ${{ github.base_ref == 'develop' && 'Full test suite' || 'Full test suite (automatic)' }}
       # The gate is an approval, not a release: reviewers still block the job, but no
       # deployment object is created. Incompatible with custom (GitHub App) protection rules.
       deployment: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,33 @@ permissions:  # added using https://github.com/step-security/secure-repo
   contents: read
 
 jobs:
+  versions:
+    name: Resolve versions 🧮
+    runs-on: ubuntu-latest
+    outputs:
+      latest-ruby: ${{ steps.resolve.outputs.latest-ruby }}
+      smoke: ${{ steps.resolve.outputs.smoke }}
+      extended: ${{ steps.resolve.outputs.extended }}
+      features: ${{ steps.resolve.outputs.features }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Reads .github/ci-versions.yml. Stdlib only, so the runner's preinstalled Ruby is enough.
+      - name: Resolve matrices
+        id: resolve
+        run: bin/ci.rb matrices
+
   steep:
     name: Type Check 🔍
     runs-on: ubuntu-latest
+    needs: versions
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
-          ruby-version: 4.0
+          ruby-version: ${{ needs.versions.outputs.latest-ruby }}
           bundler-cache: true
       - run: bundle exec rbs collection install
       - run: bundle exec steep check --format=github
@@ -39,6 +56,7 @@ jobs:
   rubocop:
     name: Standard 👮
     runs-on: ubuntu-latest
+    needs: versions
     permissions:
       checks: write
       contents: read
@@ -53,28 +71,17 @@ jobs:
       - name: Standard Ruby
         uses: standardrb/standard-ruby-action@df5152f6106147e13feb6ee0fa820b0d435cb8cd # v1.6.0
         with:
-          ruby-version: '4.0'
+          ruby-version: ${{ needs.versions.outputs.latest-ruby }}
           autofix: false
 
   features:
     name: Features (${{ matrix.data-store }} Data Store and ${{ matrix.data-store-image }} Data Store image using ${{matrix.light-creation}}) 🥒
     runs-on: ubuntu-latest
-    environment: ${{ github.base_ref == 'develop' && 'features-manual' || 'features-auto' }}
+    # Gated transitively: spec-full cannot start without approval, so neither can this. Its own
+    # environment would go pending only after spec-full finished, costing a second approval click.
+    needs: [ spec-full, versions ]
     strategy:
-      matrix:
-        light-creation: [ 'Stoplight()', 'System#register' ]
-        data-store: [ 'Redis' ]
-        data-store-image:
-          - 'redis:7.4'
-          - 'valkey/valkey:8-alpine'
-        include:
-          # Memory does not depend on the Data Store so we only want to run its suite once
-          - data-store: 'Memory'
-            data-store-image: 'redis:7.4'
-            light-creation: 'Stoplight()'
-          - data-store: 'Memory'
-            data-store-image: 'redis:7.4'
-            light-creation: 'System#register'
+      matrix: ${{ fromJSON(needs.versions.outputs.features) }}
     services:
       data-store:
         image: ${{ matrix.data-store-image }}
@@ -97,7 +104,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
-          ruby-version: 4.0
+          ruby-version: ${{ needs.versions.outputs.latest-ruby }}
           bundler-cache: true
 
       - name: Run Features
@@ -111,18 +118,11 @@ jobs:
   spec:
     permissions:
       contents: read  # for actions/checkout to fetch code
-    name: Specs on Ruby ${{ matrix.ruby }} with Data Store as ${{ matrix.data-store-image }} 💚
+    name: Smoke Specs on Ruby ${{ matrix.ruby }} with Data Store as ${{ matrix.data-store-image }} 💚
     runs-on: ubuntu-latest
+    needs: [ steep, rubocop, versions ]
     strategy:
-      matrix:
-        data-store-image:
-          - 'redis:7.4'
-          - 'redis:8.4'
-          - 'redis:8.6'
-          - 'valkey/valkey:7.2-alpine'
-          - 'valkey/valkey:8.1-alpine'
-          - 'valkey/valkey:9.1-alpine'
-        ruby: ['3.3', '3.4', '4.0' ]
+      matrix: ${{ fromJSON(needs.versions.outputs.smoke) }}
     services:
       data-store:
         image: ${{ matrix.data-store-image }}
@@ -152,3 +152,61 @@ jobs:
         run: bundle exec rake spec
         env:
           STOPLIGHT_REDIS_URL: 'redis://127.0.0.1:6379/0'
+
+  spec-full:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+    name: Specs on Ruby ${{ matrix.ruby }} with Data Store as ${{ matrix.data-store-image }} 💚
+    runs-on: ubuntu-latest
+    needs: [ spec, versions ]
+    environment:
+      name: ${{ github.base_ref == 'develop' && 'extended-manual' || 'extended-auto' }}
+      # The gate is an approval, not a release: reviewers still block the job, but no
+      # deployment object is created. Incompatible with custom (GitHub App) protection rules.
+      deployment: false
+    strategy:
+      matrix: ${{ fromJSON(needs.versions.outputs.extended) }}
+    services:
+      data-store:
+        image: ${{ matrix.data-store-image }}
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run Tests
+        run: bundle exec rake spec
+        env:
+          STOPLIGHT_REDIS_URL: 'redis://127.0.0.1:6379/0'
+
+  # The single name to set as the required status check on develop. Branch protection counts a
+  # skipped job as success, so requiring the stage jobs directly would pass a PR whose stage 3 never ran.
+  ci:
+    name: CI 🚦
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [ versions, steep, rubocop, spec, spec-full, features ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Verify every stage succeeded
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: bin/ci.rb verify

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,16 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: '🔍Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+    # Every path Dependabot touches. Workflow files and the Dockerfile are dependency manifests
+    # too - the github-actions and docker ecosystems are configured alongside bundler.
+    paths:
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '*.gemspec'
+      - 'Dockerfile'
+      - '.github/workflows/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/bin/ci.rb
+++ b/bin/ci.rb
@@ -1,0 +1,139 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "yaml"
+
+# Derives the CI matrices from .github/ci-versions.yml and grades a finished run.
+# Both are used by .github/workflows/ci.yml and are covered by spec/unit/bin/ci_spec.rb.
+module CI
+  Error = Class.new(StandardError)
+
+  CONFIG_PATH = File.expand_path("../.github/ci-versions.yml", __dir__)
+
+  class Versions
+    # The two supported ways to build a light. Part of the public API, not a version knob,
+    # so it lives here rather than in ci-versions.yml.
+    LIGHT_CREATIONS = ["Stoplight()", "System#register"].freeze
+
+    def initialize(config)
+      @config = config
+    end
+
+    def latest_ruby
+      config.fetch("latest_ruby")
+    end
+
+    # The gating run: the pinned Ruby against the newest image of every engine.
+    def smoke
+      {"include" => latest_images.map { |image| {"ruby" => latest_ruby, "data-store-image" => image} }}
+    end
+
+    # Deliberately overlaps smoke. Subtracting the overlap would couple the two lists so that
+    # editing one silently drops coverage from the other, which costs more than the repeated jobs.
+    def extended
+      {"ruby" => rubies, "data-store-image" => images}
+    end
+
+    def features
+      redis = latest_images.flat_map do |image|
+        LIGHT_CREATIONS.map { |creation| feature_entry("Redis", creation, image) }
+      end
+      memory = LIGHT_CREATIONS.map { |creation| feature_entry("Memory", creation, latest_images.first) }
+
+      {"include" => redis + memory}
+    end
+
+    # Collects every problem before raising so a half-finished version bump is reported in one run.
+    def validate!
+      problems = []
+      problems << "latest_ruby #{latest_ruby} is not in rubies" unless rubies.include?(latest_ruby)
+      (latest_images - images).each do |image|
+        problems << "latest_images entry #{image} is not in images"
+      end
+
+      raise Error, problems.join("\n") unless problems.empty?
+    end
+
+    private
+
+    attr_reader :config
+
+    def rubies
+      config.fetch("rubies")
+    end
+
+    def images
+      config.fetch("images")
+    end
+
+    def latest_images
+      config.fetch("latest_images")
+    end
+
+    # The Memory store ignores the image, but a service container is started regardless.
+    def feature_entry(store, creation, image)
+      {"data-store" => store, "light-creation" => creation, "data-store-image" => image}
+    end
+  end
+
+  class Results
+    def initialize(needs)
+      @needs = needs
+    end
+
+    # A job skipped because an upstream failed, or because its approval gate never opened, is not a pass.
+    def failures
+      needs.reject { |_, outcome| outcome["result"] == "success" }
+        .map { |name, outcome| "#{name}: #{outcome["result"]}" }
+    end
+
+    private
+
+    attr_reader :needs
+  end
+
+  module CLI
+    module_function
+
+    def run(argv)
+      case argv.first
+      when "matrices" then matrices
+      when "verify" then verify
+      else abort("usage: bin/ci {matrices|verify}")
+      end
+    end
+
+    def matrices
+      versions = Versions.new(YAML.load_file(CONFIG_PATH))
+      versions.validate!
+
+      write_outputs(
+        "latest-ruby" => versions.latest_ruby,
+        "smoke" => versions.smoke.to_json,
+        "extended" => versions.extended.to_json,
+        "features" => versions.features.to_json
+      )
+    rescue Error => e
+      abort(e.message)
+    end
+
+    def verify
+      results = Results.new(JSON.parse(ENV.fetch("RESULTS")))
+      failures = results.failures
+
+      abort("Not every stage succeeded:\n#{failures.join("\n")}") unless failures.empty?
+      warn("Every stage succeeded.")
+    end
+
+    def write_outputs(outputs)
+      outputs.each { |name, value| warn("#{name}=#{value}") }
+
+      File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |file|
+        outputs.each { |name, value| file.puts("#{name}=#{value}") }
+      end
+    end
+  end
+end
+
+CI::CLI.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/bin/ci.rb
+++ b/bin/ci.rb
@@ -26,13 +26,15 @@ module CI
 
     # The gating run: the pinned Ruby against the newest image of every engine.
     def smoke
-      {"include" => latest_images.map { |image| {"ruby" => latest_ruby, "data-store-image" => image} }}
+      {"include" => latest_images.map { |image| spec_entry(latest_ruby, image) }}
     end
 
-    # Deliberately overlaps smoke. Subtracting the overlap would couple the two lists so that
-    # editing one silently drops coverage from the other, which costs more than the repeated jobs.
+    # Everything smoke did not already run. Safe to subtract because both sides are derived from
+    # the same lists here - the pair cannot drift the way two hand-written matrices would.
     def extended
-      {"ruby" => rubies, "data-store-image" => images}
+      every_combination = rubies.flat_map { |ruby| images.map { |image| spec_entry(ruby, image) } }
+
+      {"include" => every_combination - smoke["include"]}
     end
 
     def features
@@ -69,6 +71,10 @@ module CI
 
     def latest_images
       config.fetch("latest_images")
+    end
+
+    def spec_entry(ruby, image)
+      {"ruby" => ruby, "data-store-image" => image}
     end
 
     # The Memory store ignores the image, but a service container is started regardless.

--- a/spec/unit/bin/ci_spec.rb
+++ b/spec/unit/bin/ci_spec.rb
@@ -27,17 +27,28 @@ RSpec.describe CI do
     end
 
     describe "#extended" do
-      it "spans every Ruby against every image" do
+      it "covers every combination the smoke run did not already run" do
         expect(versions.extended).to eq(
-          "ruby" => ["3.3", "3.4", "4.0"],
-          "data-store-image" => ["redis:7.4", "redis:8.6", "valkey/valkey:9.1-alpine"]
+          "include" => [
+            {"ruby" => "3.3", "data-store-image" => "redis:7.4"},
+            {"ruby" => "3.3", "data-store-image" => "redis:8.6"},
+            {"ruby" => "3.3", "data-store-image" => "valkey/valkey:9.1-alpine"},
+            {"ruby" => "3.4", "data-store-image" => "redis:7.4"},
+            {"ruby" => "3.4", "data-store-image" => "redis:8.6"},
+            {"ruby" => "3.4", "data-store-image" => "valkey/valkey:9.1-alpine"},
+            {"ruby" => "4.0", "data-store-image" => "redis:7.4"}
+          ]
         )
       end
 
-      it "keeps the combinations the smoke run already covered" do
-        combinations = versions.extended["ruby"].product(versions.extended["data-store-image"])
+      it "omits what smoke already covered" do
+        expect(versions.extended["include"]).not_to include(*versions.smoke["include"])
+      end
 
-        expect(combinations).to include(["4.0", "redis:8.6"])
+      it "together with smoke covers the whole matrix exactly once" do
+        every_run = versions.smoke["include"] + versions.extended["include"]
+
+        expect(every_run.uniq.size).to eq(config["rubies"].size * config["images"].size)
       end
     end
 

--- a/spec/unit/bin/ci_spec.rb
+++ b/spec/unit/bin/ci_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require_relative "../../../bin/ci"
+
+RSpec.describe CI do
+  let(:config) do
+    {
+      "latest_ruby" => "4.0",
+      "rubies" => ["3.3", "3.4", "4.0"],
+      "images" => ["redis:7.4", "redis:8.6", "valkey/valkey:9.1-alpine"],
+      "latest_images" => ["redis:8.6", "valkey/valkey:9.1-alpine"]
+    }
+  end
+
+  describe CI::Versions do
+    subject(:versions) { described_class.new(config) }
+
+    describe "#smoke" do
+      it "pairs the latest Ruby with every latest image" do
+        expect(versions.smoke).to eq(
+          "include" => [
+            {"ruby" => "4.0", "data-store-image" => "redis:8.6"},
+            {"ruby" => "4.0", "data-store-image" => "valkey/valkey:9.1-alpine"}
+          ]
+        )
+      end
+    end
+
+    describe "#extended" do
+      it "spans every Ruby against every image" do
+        expect(versions.extended).to eq(
+          "ruby" => ["3.3", "3.4", "4.0"],
+          "data-store-image" => ["redis:7.4", "redis:8.6", "valkey/valkey:9.1-alpine"]
+        )
+      end
+
+      it "keeps the combinations the smoke run already covered" do
+        combinations = versions.extended["ruby"].product(versions.extended["data-store-image"])
+
+        expect(combinations).to include(["4.0", "redis:8.6"])
+      end
+    end
+
+    describe "#features" do
+      it "runs every light creation against every latest image on the Redis store" do
+        redis = versions.features["include"].select { |entry| entry["data-store"] == "Redis" }
+
+        expect(redis).to eq(
+          [
+            {"data-store" => "Redis", "light-creation" => "Stoplight()", "data-store-image" => "redis:8.6"},
+            {"data-store" => "Redis", "light-creation" => "System#register", "data-store-image" => "redis:8.6"},
+            {"data-store" => "Redis", "light-creation" => "Stoplight()", "data-store-image" => "valkey/valkey:9.1-alpine"},
+            {"data-store" => "Redis", "light-creation" => "System#register", "data-store-image" => "valkey/valkey:9.1-alpine"}
+          ]
+        )
+      end
+
+      it "runs the Memory store once per light creation, since it ignores the image" do
+        memory = versions.features["include"].select { |entry| entry["data-store"] == "Memory" }
+
+        expect(memory).to eq(
+          [
+            {"data-store" => "Memory", "light-creation" => "Stoplight()", "data-store-image" => "redis:8.6"},
+            {"data-store" => "Memory", "light-creation" => "System#register", "data-store-image" => "redis:8.6"}
+          ]
+        )
+      end
+    end
+
+    describe "#latest_ruby" do
+      it "returns the pinned Ruby" do
+        expect(versions.latest_ruby).to eq("4.0")
+      end
+    end
+
+    describe "validation" do
+      it "accepts a consistent configuration" do
+        expect { versions.validate! }.not_to raise_error
+      end
+
+      it "rejects a latest Ruby that is not among the tested Rubies" do
+        config["latest_ruby"] = "4.1"
+
+        expect { versions.validate! }
+          .to raise_error(CI::Error, /latest_ruby 4\.1 is not in rubies/)
+      end
+
+      it "rejects a latest image that is not among the tested images" do
+        config["latest_images"] = ["redis:9.0", "valkey/valkey:9.1-alpine"]
+
+        expect { versions.validate! }
+          .to raise_error(CI::Error, %r{latest_images entry redis:9\.0 is not in images})
+      end
+
+      it "reports every problem at once rather than stopping at the first" do
+        config["latest_ruby"] = "4.1"
+        config["latest_images"] = ["redis:9.0"]
+
+        expect { versions.validate! }
+          .to raise_error(CI::Error, /latest_ruby 4\.1.*latest_images entry redis:9\.0/m)
+      end
+    end
+  end
+
+  describe CI::Results do
+    subject(:results) { described_class.new(needs) }
+
+    context "when every job succeeded" do
+      let(:needs) { {"spec" => {"result" => "success"}, "steep" => {"result" => "success"}} }
+
+      it "reports no failures" do
+        expect(results.failures).to be_empty
+      end
+    end
+
+    context "when a job was skipped because its gate never opened" do
+      let(:needs) { {"spec" => {"result" => "success"}, "spec-full" => {"result" => "skipped"}} }
+
+      it "treats the skip as a failure" do
+        expect(results.failures).to eq(["spec-full: skipped"])
+      end
+    end
+
+    context "when jobs failed and were cancelled" do
+      let(:needs) do
+        {
+          "steep" => {"result" => "failure"},
+          "spec" => {"result" => "cancelled"},
+          "rubocop" => {"result" => "success"}
+        }
+      end
+
+      it "reports each non-success job" do
+        expect(results.failures).to contain_exactly("steep: failure", "spec: cancelled")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Every push to a pull request ran the full 18-job spec matrix alongside lint. Now lint gates a two-job smoke run, and the full matrix and the cucumber features sit behind the reviewer-approved environment that previously guarded features alone, so they run once per pull request rather than once per push. Nothing merges unverified: the gated stages still have to pass against the pull request's own code.

The environment declares deployment: false, so approving the gate no longer records a deployment against the repository.

The new ci job is the single name to require as a status check on develop. Branch protection counts a skipped job as success, so requiring the stage jobs directly would pass a pull request whose gated stage never ran.

Ruby and data store versions were pinned in five places across ci.yml, two of them in a matrix exclude block where a half-finished edit silently dropped coverage rather than failing the build. bin/ci.rb now reads .github/ci-versions.yml and emits every matrix from it, refusing to run when latest_ruby or latest_images fall outside the lists they are drawn from.

Cucumber now exercises the newest image of each engine rather than redis:7.4 and the floating valkey:8-alpine tag, which matched nothing in the spec matrix.