### PR TITLE
fix: Point configuration errors at the caller's own location

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -22,13 +22,14 @@ together, so two places could configure the same name differently and both would
 up with depended on which file it executed.
 
 In 6.0, `Stoplight()` registers the light on first call and returns that same cached instance afterwards. If a later
-call passes settings that differ from the registration, Stoplight raises `Stoplight::Error::ConfigurationError` and
-names both call sites:
+call passes settings that differ from the registration, Stoplight raises `Stoplight::Error::ConfigurationError`. The
+message names where the light was first registered, and the error's backtrace points at the conflicting call:
 
 ```
 Light `Payment Service` already registered with different configuration.
-Original registration: app/services/payment_service.rb:14:in 'charge'
-Current attempt: app/jobs/retry_payment_job.rb:9:in 'perform'
+
+Originally registered at:
+  app/services/payment_service.rb:14:in 'charge'
 
 Lights must have consistent configuration across all call sites.
 ```

--- a/docs/systems.md
+++ b/docs/systems.md
@@ -163,13 +163,14 @@ system.register("api", threshold: 3)
 system.register("api", threshold: 5) # raises ConfigurationError
 ```
 
-This prevents the subtle bug where two call sites silently disagree on a light's configuration. The error shows both
-registration locations:
+This prevents the subtle bug where two call sites silently disagree on a light's configuration. The message names
+where the light was originally registered, and the error's own backtrace points at the conflicting call:
 
 ```
 Light `api` already registered with different configuration.
-Original registration: config/initializers/stoplight.rb:42:in `<top (required)>'
-Current attempt: app/services/payment_service.rb:15:in `initialize'
+
+Originally registered at:
+  config/initializers/stoplight.rb:42:in `<top (required)>'
 
 Lights must have consistent configuration across all call sites.
 ```

--- a/lib/stoplight/wiring/config_compatibility_validator.rb
+++ b/lib/stoplight/wiring/config_compatibility_validator.rb
@@ -34,7 +34,7 @@ module Stoplight
           if compatibility_result.incompatible?
             raise Error::ConfigurationError,
               "#{traffic_control} incompatible with config: #{compatibility_result.error_messages}",
-              caller(8)
+              ExternalCaller.backtrace
           end
         end
       end
@@ -45,7 +45,7 @@ module Stoplight
           if compatibility_result.incompatible?
             raise Error::ConfigurationError,
               "#{traffic_recovery} incompatible with config: #{compatibility_result.error_messages}",
-              caller(8)
+              ExternalCaller.backtrace
           end
         end
       end

--- a/lib/stoplight/wiring/external_caller.rb
+++ b/lib/stoplight/wiring/external_caller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Stoplight
+  module Wiring
+    # Locates the application code that called into Stoplight, so configuration errors point at
+    # the light's call site instead of Stoplight's own internals.
+    #
+    # @api private
+    module ExternalCaller
+      LIB_ROOT = "#{File.expand_path("../../..", __FILE__)}/"
+
+      class << self
+        def backtrace
+          frames = caller_locations(1) || []
+          external = frames.reject { |frame| internal?(frame) }
+          external = frames if external.empty?
+          external.map(&:to_s)
+        end
+
+        private def internal?(frame)
+          path = frame.path.to_s
+          path.start_with?(LIB_ROOT, "<internal:")
+        end
+      end
+    end
+  end
+end

--- a/lib/stoplight/wiring/system.rb
+++ b/lib/stoplight/wiring/system.rb
@@ -43,6 +43,9 @@ module Stoplight
     #   returns that cached instance and raises +Stoplight::Error::UnregisteredLightError+
     #   if the name was never registered.
     class System
+      REGISTRATION_FRAME_LIMIT = 5
+      private_constant :REGISTRATION_FRAME_LIMIT
+
       attr_reader :name
       # @api private
       attr_reader :config
@@ -123,26 +126,29 @@ module Stoplight
         )
         config_digest = light_dsl.digest
 
-        light, existing_digest, existing_source_line = @lights.compute_if_absent(name) do
-          source_line = caller(6, 1)&.first # Very expensive call
+        light, existing_digest, existing_backtrace = @lights[name] || begin
+          registered_at = ExternalCaller.backtrace.first(REGISTRATION_FRAME_LIMIT)
           config = light_dsl.configure!(@config)
-          built = LightFactory.new(
-            system_id: @config.id,
-            system_name: @name, config:,
-            failover_system: @failover_system,
-            telemetry: @telemetry
-          ).build
-          @registry.register(config)
-          [built, config_digest, source_line]
+          @lights.compute_if_absent(name) do
+            built = LightFactory.new(
+              system_id: @config.id,
+              system_name: @name, config:,
+              failover_system: @failover_system,
+              telemetry: @telemetry
+            ).build
+            @registry.register(config)
+            [built, config_digest, registered_at]
+          end
         end
 
         if config_digest != existing_digest
-          source_line = caller(1, 1)&.first # Very expensive call
+          original_site = existing_backtrace.map { |frame| "  #{frame}" }.join("\n")
 
-          raise Stoplight::Error::ConfigurationError, <<~MSG
+          raise Stoplight::Error::ConfigurationError, <<~MSG, ExternalCaller.backtrace
             Light `#{name}` already registered with different configuration.
-            Original registration: #{existing_source_line}
-            Current attempt: #{source_line}
+
+            Originally registered at:
+            #{original_site}
 
             Lights must have consistent configuration across all call sites.
           MSG

--- a/sig/stoplight/wiring/external_caller.rbs
+++ b/sig/stoplight/wiring/external_caller.rbs
@@ -1,0 +1,13 @@
+module Stoplight
+  module Wiring
+    module ExternalCaller
+      LIB_ROOT: String
+
+      def self.backtrace: () -> Array[String]
+
+      private
+
+      def self.internal?: (Thread::Backtrace::Location) -> bool
+    end
+  end
+end

--- a/sig/stoplight/wiring/system.rbs
+++ b/sig/stoplight/wiring/system.rbs
@@ -4,7 +4,9 @@ module Stoplight
       include _System
 
       @name: String
-      @lights: Concurrent::Map[String, [Domain::Light, Integer, String?]]
+      REGISTRATION_FRAME_LIMIT: Integer
+
+      @lights: Concurrent::Map[String, [Domain::Light, Integer, Array[String]]]
       @failover_system: _System?
       @registry: Domain::_Registry
       @telemetry: Domain::Telemetry::Bus

--- a/spec/integration/configuration_error_location_spec.rb
+++ b/spec/integration/configuration_error_location_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+RSpec.describe "Configuration error locations" do
+  before do
+    Stoplight.configure(trust_me_im_an_engineer: true) do |config|
+      config.data_store = Stoplight::DataStore::Memory.new
+    end
+  end
+
+  def register_deeply(depth, name, **settings)
+    return Stoplight(name, **settings) if depth.zero?
+
+    register_deeply(depth - 1, name, **settings)
+  end
+
+  it "names the original registration site in the message" do
+    name = SecureRandom.uuid
+
+    original_line = __LINE__ + 1
+    Stoplight(name, threshold: 5)
+
+    expect {
+      Stoplight(name, threshold: 10)
+    }.to raise_error(
+      Stoplight::Error::ConfigurationError,
+      include("#{__FILE__}:#{original_line}")
+    )
+  end
+
+  it "points the error's own backtrace at the conflicting call site" do
+    name = SecureRandom.uuid
+    Stoplight(name, threshold: 5)
+
+    conflicting_line = __LINE__ + 2
+    expect {
+      Stoplight(name, threshold: 10)
+    }.to raise_error(Stoplight::Error::ConfigurationError) { |error|
+      expect(error.backtrace.first).to include("#{__FILE__}:#{conflicting_line}")
+    }
+  end
+
+  it "names the nested registration site before the enclosing light's, with no Stoplight frames" do
+    outer = SecureRandom.uuid
+    name = SecureRandom.uuid
+
+    outer_line = __LINE__ + 1
+    Stoplight(outer).run do
+      Stoplight(name, threshold: 5)
+    end
+    inner_line = outer_line + 1
+
+    expect {
+      Stoplight(outer).run { Stoplight(name, threshold: 10) }
+    }.to raise_error(Stoplight::Error::ConfigurationError) { |error|
+      frames = error.message.lines.grep(/^  /).map(&:strip)
+
+      expect(frames[0]).to include("#{__FILE__}:#{inner_line}")
+      expect(frames[1]).to include("#{__FILE__}:#{outer_line}")
+      expect(frames).not_to include(a_string_matching(%r{lib/stoplight/}))
+    }
+  end
+
+  it "shows how the original registration was reached, not just its line" do
+    name = SecureRandom.uuid
+
+    calling_line = __LINE__ + 1
+    register_deeply(2, name, threshold: 5)
+
+    expect {
+      Stoplight(name, threshold: 10)
+    }.to raise_error(
+      Stoplight::Error::ConfigurationError,
+      include("#{__FILE__}:#{calling_line}").and(include("register_deeply"))
+    )
+  end
+
+  it "points an incompatible-configuration error at the caller" do
+    incompatible_line = __LINE__ + 3
+
+    expect {
+      Stoplight(
+        SecureRandom.uuid,
+        traffic_control: Stoplight::Domain::TrafficControl::ErrorRate.new,
+        threshold: 5,
+        window_size: 20
+      )
+    }.to raise_error(Stoplight::Error::ConfigurationError) { |error|
+      expect(error.backtrace.first).to include("#{__FILE__}:#{incompatible_line}")
+    }
+  end
+
+  it "keeps the full stack on the error itself" do
+    name = SecureRandom.uuid
+    Stoplight(name, threshold: 5)
+
+    expect {
+      register_deeply(10, name, threshold: 10)
+    }.to raise_error(Stoplight::Error::ConfigurationError) { |error|
+      expect(error.backtrace.grep(/register_deeply/).size).to eq(11)
+    }
+  end
+
+  it "caps the stored registration stack so deep stacks stay readable" do
+    name = SecureRandom.uuid
+    register_deeply(40, name, threshold: 5)
+
+    expect {
+      Stoplight(name, threshold: 10)
+    }.to raise_error(Stoplight::Error::ConfigurationError) { |error|
+      frames = error.message.lines.grep(/#{Regexp.escape(__FILE__)}/)
+      expect(frames.size).to eq(5)
+    }
+  end
+end

--- a/spec/unit/stoplight/wiring/external_caller_spec.rb
+++ b/spec/unit/stoplight/wiring/external_caller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe Stoplight::Wiring::ExternalCaller do
+  describe ".backtrace" do
+    it "starts at the calling line" do
+      line = __LINE__ + 1
+      backtrace = described_class.backtrace
+
+      expect(backtrace.first).to include("#{__FILE__}:#{line}")
+    end
+
+    it "drops Stoplight's own frames" do
+      inside_lib = "#{described_class::LIB_ROOT}wiring/anything.rb"
+      backtrace = Object.new.instance_eval("Stoplight::Wiring::ExternalCaller.backtrace", inside_lib, 1) # rubocop:disable Style/EvalWithLocation
+
+      expect(backtrace).not_to include(a_string_including(inside_lib))
+    end
+
+    it "drops Ruby core frames" do
+      backtrace = 1.then { described_class.backtrace }
+
+      expect(backtrace).not_to include(a_string_including("<internal:"))
+    end
+  end
+end

--- a/spec/unit/stoplight/wiring/system_spec.rb
+++ b/spec/unit/stoplight/wiring/system_spec.rb
@@ -141,16 +141,27 @@ RSpec.describe Stoplight::Wiring::System do
     end
 
     describe "error messages" do
-      before { system.register("bar", cool_off_time: 30) }
+      before do
+        @registered_at = __LINE__ + 1
+        system.register("bar", cool_off_time: 30)
+      end
 
-      it "includes both configs in error message" do
+      it "names the original registration site in the message" do
         expect do
           system.register("bar", cool_off_time: 30, threshold: 44)
         end.to raise_error(
           include(/Light `bar` already registered with different configuration/)
-            .and(include(/system_spec\.rb:144/))
-            .and(include(/system_spec\.rb:148/))
+            .and(include("system_spec.rb:#{@registered_at}"))
         )
+      end
+
+      it "points the error's backtrace at the conflicting call site" do
+        conflicting_line = __LINE__ + 2
+        expect do
+          system.register("bar", cool_off_time: 30, threshold: 44)
+        end.to raise_error(Stoplight::Error::ConfigurationError) { |error|
+          expect(error.backtrace.first).to include("system_spec.rb:#{conflicting_line}")
+        }
       end
     end
 


### PR DESCRIPTION
The compatibility validator and the duplicate-registration message picked their frame by counting stack depth, but the depth is not fixed: Stoplight() adds delegator frames and Concurrent::Map sandwiches gem frames between Stoplight's own. So the conflict message named lib/stoplight.rb instead of the application line, and the validator's backtrace started inside concurrent-ruby.

ExternalCaller now drops every Stoplight and Ruby-internal frame wherever it sits. Cutting at the outermost Stoplight frame is not enough: a light registered inside another light's run block has application frames on both sides of Stoplight's.

The conflict error's message now names only the original registration site (first five frames), and the conflicting call is the error's own backtrace. System captures the site once, on first registration, so the per-call path never touches caller_locations.