### PR TITLE
Use integer values for window_size and cool_off_time settings

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -12,6 +12,7 @@ Here's what you'll want to tackle during your upgrade, roughly ordered from the 
 - [ ] Replace proc and anonymous-class error matchers with named classes or modules
 - [ ] Account for Stoplight state reset after deployment
 - [ ] Re-check `error_rate` lights - `min_requests` is gone and the fixed minimum sample is now 100 requests
+- [ ] Round any fractional `window_size` up to a whole number of seconds
 - [ ] Drop `warn_on_clock_skew` from your Redis data store setup
 - [ ] Test thoroughly in a staging environment
 
@@ -192,6 +193,28 @@ light = Stoplight("Payment Service", traffic_control: :error_rate, threshold: 0.
 
 The hash form of `traffic_control` is gone entirely, so passing it raises `Stoplight::Error::ConfigurationError`.
 `Stoplight::Domain::TrafficControl::ErrorRate.new` takes no arguments.
+
+### `window_size` Must Be a Whole Number of Seconds
+
+`window_size` now accepts only an `Integer` of at least 1. A `Float`, or anything below one second, raises
+`Stoplight::Error::ConfigurationError` when the value is applied - at `Stoplight()`, `Stoplight.register_system`, or
+`Stoplight.configure`. `nil` still means "no window".
+
+```ruby
+# Old way that won't work anymore
+light = Stoplight("Payment Service", window_size: 59.5, traffic_control: :error_rate, threshold: 0.5)
+
+# New way
+light = Stoplight("Payment Service", window_size: 60, traffic_control: :error_rate, threshold: 0.5)
+```
+
+Metrics are counted in per-second buckets, so a second is the smallest span the window can actually measure. A
+fractional value was never honoured as written - both stores truncated it to whole buckets, so `window_size: 59.5`
+measured 59 seconds on Redis and 59 or 60 in memory depending on when you asked, and anything under a second evicted
+the current bucket on most calls, so failures rarely accumulated enough to trip the light. None of that has changed -
+the window is measured exactly as it always was. What changes is that the mismatch is no longer hidden: instead of
+quietly measuring a different span than you asked for, Stoplight escalates it as an error the moment the light is
+configured.
 
 ### Clock Skew Detection Is Gone
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -13,6 +13,7 @@ Here's what you'll want to tackle during your upgrade, roughly ordered from the 
 - [ ] Account for Stoplight state reset after deployment
 - [ ] Re-check `error_rate` lights - `min_requests` is gone and the fixed minimum sample is now 100 requests
 - [ ] Round any fractional `window_size` up to a whole number of seconds
+- [ ] Round any fractional `cool_off_time` up to a whole number of seconds, at least 1
 - [ ] Drop `warn_on_clock_skew` from your Redis data store setup
 - [ ] Test thoroughly in a staging environment
 
@@ -215,6 +216,24 @@ the current bucket on most calls, so failures rarely accumulated enough to trip 
 the window is measured exactly as it always was. What changes is that the mismatch is no longer hidden: instead of
 quietly measuring a different span than you asked for, Stoplight escalates it as an error the moment the light is
 configured.
+
+### `cool_off_time` Must Be a Whole Number of Seconds
+
+`cool_off_time` now accepts only an `Integer` of at least 1. A `Float`, or anything below one second, raises
+`Stoplight::Error::ConfigurationError` when the value is applied - at `Stoplight()`, `Stoplight.register_system`, or
+`Stoplight.configure`.
+
+```ruby
+# Old way that won't work anymore
+light = Stoplight("Payment Service", cool_off_time: 1.5)
+
+# New way
+light = Stoplight("Payment Service", cool_off_time: 2)
+```
+
+Below a second the light turns yellow again before the failing dependency could plausibly have recovered, so it
+probes on nearly every call instead of breaking the circuit. Above that, a fraction of a second is marginal against
+the window the light measures failures over, so whole seconds are the only granularity worth expressing.
 
 ### Clock Skew Detection Is Gone
 

--- a/features/stoplight/support/configure_light_world.rb
+++ b/features/stoplight/support/configure_light_world.rb
@@ -54,7 +54,7 @@ module ConfigureLightWorld
   end
 
   def configure_cool_off_time(value, settings)
-    settings[:cool_off_time] = value.to_f
+    settings[:cool_off_time] = value.to_i
   end
 
   def configure_threshold(value, settings)

--- a/features/stoplight/support/configure_light_world.rb
+++ b/features/stoplight/support/configure_light_world.rb
@@ -49,7 +49,7 @@ module ConfigureLightWorld
     settings[:window_size] = if value == "nil"
       nil
     else
-      value.to_f
+      value.to_i
     end
   end
 

--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -169,7 +169,7 @@ end
 # Creates a new Stoplight circuit breaker with the given name and settings.
 #
 # @param name [String] The name of the circuit breaker.
-# @param cool_off_time The time to wait before resetting the circuit breaker.
+# @param cool_off_time The time to wait before resetting the circuit breaker, in whole seconds, at least 1.
 # @param threshold The failure threshold to trip the circuit breaker.
 # @param window_size The size of the rolling window for failure tracking, in whole seconds, at least 1.
 # @param tracked_errors A list of errors to track.

--- a/lib/stoplight.rb
+++ b/lib/stoplight.rb
@@ -171,13 +171,14 @@ end
 # @param name [String] The name of the circuit breaker.
 # @param cool_off_time The time to wait before resetting the circuit breaker.
 # @param threshold The failure threshold to trip the circuit breaker.
-# @param window_size The size of the rolling window for failure tracking.
+# @param window_size The size of the rolling window for failure tracking, in whole seconds, at least 1.
 # @param tracked_errors A list of errors to track.
 # @param skipped_errors A list of errors to skip.
 # @param traffic_control The traffic control strategy to use.
 #
 # @return [Stoplight::Light] A new circuit breaker instance.
 # @raise [ArgumentError] If an unknown option is provided in the settings.
+# @raise [Stoplight::Error::ConfigurationError] If a setting is invalid or conflicts with an earlier registration.
 #
 # @example configure circuit breaker behavior
 #   light = Stoplight("Payment API", window_size: 300, threshold: 5, cool_off_time: 60)

--- a/lib/stoplight/domain/config.rb
+++ b/lib/stoplight/domain/config.rb
@@ -22,7 +22,7 @@ module Stoplight
     )
     class Config
       def cool_off_time_in_milliseconds
-        (cool_off_time * 1_000).to_i
+        cool_off_time * 1_000
       end
 
       def with(

--- a/lib/stoplight/infrastructure/redis/storage/window_metrics.rb
+++ b/lib/stoplight/infrastructure/redis/storage/window_metrics.rb
@@ -22,7 +22,7 @@ module Stoplight
             @scripting = scripting
             @metrics_key = key_space.join("window_metrics")
             @ts_index_key = key_space.join("window_metrics", "ts_idx")
-            @window_size = T.must(config.window_size).to_i
+            @window_size = T.must(config.window_size)
           end
 
           def metrics_snapshot

--- a/lib/stoplight/wiring/config_compatibility_validator.rb
+++ b/lib/stoplight/wiring/config_compatibility_validator.rb
@@ -23,9 +23,22 @@ module Stoplight
       end
 
       def call
+        validate_window_size!
         validate_traffic_control!
         validate_traffic_recovery!
         config
+      end
+
+      # A window shorter than one bucket cannot be measured, and a fractional one silently
+      # rounds to a different span than requested.
+      private def validate_window_size!
+        window_size = config.window_size
+        return if window_size.nil?
+        return if window_size.is_a?(Integer) && window_size >= 1
+
+        raise Error::ConfigurationError,
+          "`window_size` should be a whole number of seconds, at least 1, got #{window_size.inspect}",
+          ExternalCaller.backtrace
       end
 
       private def validate_traffic_control!

--- a/lib/stoplight/wiring/config_compatibility_validator.rb
+++ b/lib/stoplight/wiring/config_compatibility_validator.rb
@@ -24,6 +24,7 @@ module Stoplight
 
       def call
         validate_window_size!
+        validate_cool_off_time!
         validate_traffic_control!
         validate_traffic_recovery!
         config
@@ -38,6 +39,15 @@ module Stoplight
 
         raise Error::ConfigurationError,
           "`window_size` should be a whole number of seconds, at least 1, got #{window_size.inspect}",
+          ExternalCaller.backtrace
+      end
+
+      private def validate_cool_off_time!
+        cool_off_time = config.cool_off_time
+        return if cool_off_time.is_a?(Integer) && cool_off_time >= 1
+
+        raise Error::ConfigurationError,
+          "`cool_off_time` should be a whole number of seconds, at least 1, got #{cool_off_time.inspect}",
           ExternalCaller.backtrace
       end
 

--- a/lib/stoplight/wiring/default.rb
+++ b/lib/stoplight/wiring/default.rb
@@ -3,7 +3,7 @@
 module Stoplight
   module Wiring
     module Default
-      COOL_OFF_TIME = 60.0
+      COOL_OFF_TIME = 60
 
       DATA_STORE = Stoplight::DataStore::Memory.new
 

--- a/sig/stoplight/domain/types.rbs
+++ b/sig/stoplight/domain/types.rbs
@@ -1,7 +1,7 @@
 module Stoplight
   module Domain
     type timestamp = Float | Integer
-    type duration_seconds = Float | Integer
+    type duration_seconds = Integer
     type duration_ms = Float
 
     # Light Colors

--- a/sig/stoplight/wiring/config_compatibility_validator.rbs
+++ b/sig/stoplight/wiring/config_compatibility_validator.rbs
@@ -12,6 +12,7 @@ module Stoplight
 
       private
 
+      def validate_window_size!: -> void
       def validate_traffic_control!: -> void
       def validate_traffic_recovery!: -> void
     end

--- a/sig/stoplight/wiring/config_compatibility_validator.rbs
+++ b/sig/stoplight/wiring/config_compatibility_validator.rbs
@@ -13,6 +13,7 @@ module Stoplight
       private
 
       def validate_window_size!: -> void
+      def validate_cool_off_time!: -> void
       def validate_traffic_control!: -> void
       def validate_traffic_recovery!: -> void
     end

--- a/spec/integration/configuration_error_location_spec.rb
+++ b/spec/integration/configuration_error_location_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe "Configuration error locations" do
     register_deeply(depth - 1, name, **settings)
   end
 
+  it "blames the line that registered a light with an invalid window_size" do
+    line = __LINE__ + 2
+    expect {
+      Stoplight(SecureRandom.uuid, window_size: 0.5)
+    }.to raise_error(Stoplight::Error::ConfigurationError) { |error|
+      expect(error.backtrace.first).to include("#{__FILE__}:#{line}")
+    }
+  end
+
   it "names the original registration site in the message" do
     name = SecureRandom.uuid
 

--- a/spec/integration/configuration_error_location_spec.rb
+++ b/spec/integration/configuration_error_location_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe "Configuration error locations" do
     register_deeply(depth - 1, name, **settings)
   end
 
+  it "blames the line that registered a light with an invalid cool_off_time" do
+    line = __LINE__ + 2
+    expect {
+      Stoplight(SecureRandom.uuid, cool_off_time: 0)
+    }.to raise_error(Stoplight::Error::ConfigurationError) { |error|
+      expect(error.backtrace.first).to include("#{__FILE__}:#{line}")
+    }
+  end
+
   it "blames the line that registered a light with an invalid window_size" do
     line = __LINE__ + 2
     expect {

--- a/spec/unit/stoplight/wiring/config_compatibility_validator_spec.rb
+++ b/spec/unit/stoplight/wiring/config_compatibility_validator_spec.rb
@@ -43,4 +43,53 @@ RSpec.describe Stoplight::Wiring::ConfigCompatibilityValidator do
       )
     end
   end
+
+  context "when window_size is not a whole number of seconds" do
+    let(:window_size) { 60.5 }
+
+    it "raises a configuration error" do
+      expect { validate }.to raise_error(
+        Stoplight::Error::ConfigurationError,
+        include("`window_size` should be a whole number of seconds")
+      )
+    end
+  end
+
+  context "when window_size is a whole-valued float" do
+    let(:window_size) { 60.0 }
+
+    it "raises a configuration error" do
+      expect { validate }.to raise_error(
+        Stoplight::Error::ConfigurationError,
+        include("`window_size` should be a whole number of seconds")
+      )
+    end
+  end
+
+  context "when window_size is shorter than one second" do
+    let(:window_size) { 0 }
+
+    it "raises a configuration error" do
+      expect { validate }.to raise_error(
+        Stoplight::Error::ConfigurationError,
+        include("`window_size` should be a whole number of seconds")
+      )
+    end
+  end
+
+  context "when window_size is a whole number of seconds" do
+    let(:window_size) { 1 }
+
+    it "accepts the config" do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  context "when window_size is nil" do
+    let(:window_size) { nil }
+
+    it "accepts the config" do
+      expect { validate }.not_to raise_error
+    end
+  end
 end

--- a/spec/unit/stoplight/wiring/config_compatibility_validator_spec.rb
+++ b/spec/unit/stoplight/wiring/config_compatibility_validator_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Stoplight::Wiring::ConfigCompatibilityValidator do
       Stoplight::Domain::Config,
       threshold:,
       window_size:,
+      cool_off_time:,
       recovery_threshold:,
       traffic_control:,
       traffic_recovery:
@@ -15,6 +16,7 @@ RSpec.describe Stoplight::Wiring::ConfigCompatibilityValidator do
   end
   let(:threshold) { 3 }
   let(:window_size) { nil }
+  let(:cool_off_time) { 60 }
   let(:recovery_threshold) { 1 }
   let(:traffic_control) { Stoplight::Domain::TrafficControl::ConsecutiveErrors.new }
   let(:traffic_recovery) { Stoplight::Domain::TrafficRecovery::ConsecutiveSuccesses.new }
@@ -87,6 +89,69 @@ RSpec.describe Stoplight::Wiring::ConfigCompatibilityValidator do
 
   context "when window_size is nil" do
     let(:window_size) { nil }
+
+    it "accepts the config" do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  context "when cool_off_time is nil" do
+    let(:cool_off_time) { nil }
+
+    it "raises a configuration error" do
+      expect { validate }.to raise_error(
+        Stoplight::Error::ConfigurationError,
+        include("`cool_off_time` should be a whole number of seconds")
+      )
+    end
+  end
+
+  context "when cool_off_time is zero" do
+    let(:cool_off_time) { 0 }
+
+    it "raises a configuration error" do
+      expect { validate }.to raise_error(
+        Stoplight::Error::ConfigurationError,
+        include("`cool_off_time` should be a whole number of seconds")
+      )
+    end
+  end
+
+  context "when cool_off_time is shorter than a second" do
+    let(:cool_off_time) { 0.5 }
+
+    it "raises a configuration error" do
+      expect { validate }.to raise_error(
+        Stoplight::Error::ConfigurationError,
+        include("`cool_off_time` should be a whole number of seconds")
+      )
+    end
+  end
+
+  context "when cool_off_time is a fractional number of seconds" do
+    let(:cool_off_time) { 1.5 }
+
+    it "raises a configuration error" do
+      expect { validate }.to raise_error(
+        Stoplight::Error::ConfigurationError,
+        include("`cool_off_time` should be a whole number of seconds")
+      )
+    end
+  end
+
+  context "when cool_off_time is a whole-valued float" do
+    let(:cool_off_time) { 60.0 }
+
+    it "raises a configuration error" do
+      expect { validate }.to raise_error(
+        Stoplight::Error::ConfigurationError,
+        include("`cool_off_time` should be a whole number of seconds")
+      )
+    end
+  end
+
+  context "when cool_off_time is exactly one second" do
+    let(:cool_off_time) { 1 }
 
     it "accepts the config" do
       expect { validate }.not_to raise_error

--- a/spec/unit/stoplight/wiring/default_spec.rb
+++ b/spec/unit/stoplight/wiring/default_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Stoplight::Wiring::Default do
   end
 
   describe "::COOL_OFF_TIME" do
-    it "is a float" do
-      expect(described_class::COOL_OFF_TIME).to be_a(Float)
+    it "is a whole number of seconds" do
+      expect(described_class::COOL_OFF_TIME).to be_a(Integer)
     end
   end
 

--- a/spec/unit/stoplight_spec.rb
+++ b/spec/unit/stoplight_spec.rb
@@ -89,6 +89,14 @@ RSpec.describe "Stoplight" do
 
       expect { Stoplight(SecureRandom.uuid) }.not_to raise_error
     end
+
+    it "rejects an invalid default cool_off_time at configure time" do
+      expect do
+        Stoplight.configure(trust_me_im_an_engineer: true) do |config|
+          config.cool_off_time = 0.5
+        end
+      end.to raise_error(Stoplight::Error::ConfigurationError, /`cool_off_time` should be a whole number of seconds/)
+    end
   end
 
   describe ".register" do


### PR DESCRIPTION
- Use integer for both settings
- Add DSL level validation 