### PR TITLE
Skip sliding-window eviction for an already-evicted boundary

### DIFF
--- a/lib/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rb
+++ b/lib/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rb
@@ -23,6 +23,7 @@ module Stoplight
               @buckets = Hash.new { |buckets, bucket| buckets[bucket] = 0 }
               # The running sum of all increments in the current window
               @running_sum = 0
+              @evicted_through = nil
               @clock = clock
               @window_size = window_size
             end
@@ -47,11 +48,17 @@ module Stoplight
             private
 
             def slide_window!(window_start)
-              window_start_ts = window_start.to_i
+              # A bucket is keyed at the second it was written, which for a whole-second window is
+              # always past the boundary in force then, so a boundary already evicted can expire
+              # nothing.
+              boundary = window_start.floor
+              return if boundary == @evicted_through
+
+              @evicted_through = boundary
 
               loop do
                 timestamp, sum = @buckets.first
-                if timestamp.nil? || timestamp > window_start_ts
+                if timestamp.nil? || timestamp > boundary
                   break
                 else
                   @running_sum -= sum.to_i

--- a/sig/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rbs
+++ b/sig/stoplight/infrastructure/memory/storage/window_metrics/sliding_window.rbs
@@ -6,6 +6,7 @@ module Stoplight
           class SlidingWindow
             @buckets: Hash[Integer, Integer]
             @running_sum: Integer
+            @evicted_through: Integer?
             @clock: Domain::_Clock
             @window_size: Domain::duration_seconds
 

--- a/spec/unit/stoplight/infrastructure/memory/storage/window_metrics/sliding_window_spec.rb
+++ b/spec/unit/stoplight/infrastructure/memory/storage/window_metrics/sliding_window_spec.rb
@@ -65,5 +65,66 @@ RSpec.describe Stoplight::Infrastructure::Memory::Storage::WindowMetrics::Slidin
       at(100)
       expect(counter.sum_in_window).to eq(0)
     end
+
+    context "when read repeatedly within one second" do
+      let(:window_size) { 2 }
+
+      it "counts an increment made between two reads sharing a boundary" do
+        at(100.0)
+        counter.increment
+
+        expect(counter.sum_in_window).to eq(1)
+
+        at(100.4)
+        counter.increment
+
+        expect(counter.sum_in_window).to eq(2)
+
+        at(100.9)
+        expect(counter.sum_in_window).to eq(2)
+      end
+    end
+
+    context "when the monotonic clock has not yet reached the window size" do
+      let(:window_size) { 2 }
+
+      it "still expires a bucket that has left the window" do
+        at(0.5)
+        counter.increment
+        at(2.5)
+
+        expect(counter.sum_in_window).to eq(0)
+      end
+
+      it "keeps a bucket that is still inside the window" do
+        at(0.5)
+        counter.increment
+        at(1.5)
+
+        expect(counter.sum_in_window).to eq(1)
+
+        at(2.0)
+        expect(counter.sum_in_window).to eq(0)
+      end
+    end
+
+    context "when read repeatedly as the window slides forward" do
+      let(:window_size) { 2 }
+
+      it "drops one more bucket on each read" do
+        at(100)
+        counter.increment
+        at(101)
+        counter.increment
+
+        expect(counter.sum_in_window).to eq(2)
+
+        at(102)
+        expect(counter.sum_in_window).to eq(1)
+
+        at(103)
+        expect(counter.sum_in_window).to eq(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
`slide_window!` ran a full eviction scan on every increment, and Hash#first allocates a two-element array per call, so the scan cost landed on the hot write path even when the window had not moved.

Buckets are keyed at whole seconds and the window is now a whole number of them, so a boundary that has already been evicted can never expire another bucket. Remembering the last evicted boundary lets repeat calls within the same second return immediately.

Benchmark (end-to-end, `Light#run`)
- Before: 363k i/s, 2.76 µs
- After: 424k i/s, 2.36 µs
- speedup: 1.17x