### PR TITLE
Skip the digest when looking up a light registered without settings

### DIFF
--- a/lib/stoplight/wiring/system.rb
+++ b/lib/stoplight/wiring/system.rb
@@ -46,6 +46,9 @@ module Stoplight
       REGISTRATION_FRAME_LIMIT = 5
       private_constant :REGISTRATION_FRAME_LIMIT
 
+      Registration = Data.define(:light, :digest, :backtrace, :without_settings)
+      private_constant :Registration
+
       attr_reader :name
       # @api private
       attr_reader :config
@@ -113,6 +116,16 @@ module Stoplight
         traffic_control: T.undefined,
         traffic_recovery: T.undefined
       )
+        without_settings = cool_off_time.is_a?(Undefined) && threshold.is_a?(Undefined) &&
+          recovery_threshold.is_a?(Undefined) && window_size.is_a?(Undefined) &&
+          tracked_errors.is_a?(Undefined) && skipped_errors.is_a?(Undefined) &&
+          traffic_control.is_a?(Undefined) && traffic_recovery.is_a?(Undefined)
+
+        if without_settings
+          registration = @lights[name]
+          return registration.light if registration&.without_settings
+        end
+
         light_dsl = LightConfigurationDsl.new(
           name:,
           cool_off_time:,
@@ -126,8 +139,8 @@ module Stoplight
         )
         config_digest = light_dsl.digest
 
-        light, existing_digest, existing_backtrace = @lights[name] || begin
-          registered_at = ExternalCaller.backtrace.first(REGISTRATION_FRAME_LIMIT)
+        registration = @lights[name] || begin
+          backtrace = ExternalCaller.backtrace.first(REGISTRATION_FRAME_LIMIT)
           config = light_dsl.configure!(@config)
           @lights.compute_if_absent(name) do
             built = LightFactory.new(
@@ -137,12 +150,12 @@ module Stoplight
               telemetry: @telemetry
             ).build
             @registry.register(config)
-            [built, config_digest, registered_at]
+            Registration.new(light: built, digest: config_digest, backtrace:, without_settings:)
           end
         end
 
-        if config_digest != existing_digest
-          original_site = existing_backtrace.map { |frame| "  #{frame}" }.join("\n")
+        if config_digest != registration.digest
+          original_site = registration.backtrace.map { |frame| "  #{frame}" }.join("\n")
 
           raise Stoplight::Error::ConfigurationError, <<~MSG, ExternalCaller.backtrace
             Light `#{name}` already registered with different configuration.
@@ -154,12 +167,12 @@ module Stoplight
           MSG
         end
 
-        light
+        registration.light
       end
 
       # @raise [Stoplight::Error::UnregisteredLightError] if no light was registered under +name+
       def light(name)
-        @lights[name]&.first || raise(Stoplight::Error::UnregisteredLightError, <<~MSG)
+        @lights[name]&.light || raise(Stoplight::Error::UnregisteredLightError, <<~MSG)
           Light `#{name}` was never registered on system `#{@name}`.
           Call `.register(#{name.inspect}, ...)` at boot before using it.
         MSG

--- a/sig/stoplight/wiring/system.rbs
+++ b/sig/stoplight/wiring/system.rbs
@@ -6,7 +6,28 @@ module Stoplight
       @name: String
       REGISTRATION_FRAME_LIMIT: Integer
 
-      @lights: Concurrent::Map[String, [Domain::Light, Integer, Array[String]]]
+      class Registration < Data
+        attr_reader light: Domain::Light
+        attr_reader digest: Integer
+        attr_reader backtrace: Array[String]
+        attr_reader without_settings: bool
+
+        def self.new: (
+            light: Domain::Light,
+            digest: Integer,
+            backtrace: Array[String],
+            without_settings: bool,
+          ) -> instance
+
+        def initialize: (
+            light: Domain::Light,
+            digest: Integer,
+            backtrace: Array[String],
+            without_settings: bool,
+          ) -> void
+      end
+
+      @lights: Concurrent::Map[String, Registration]
       @failover_system: _System?
       @registry: Domain::_Registry
       @telemetry: Domain::Telemetry::Bus

--- a/spec/unit/stoplight/wiring/system_spec.rb
+++ b/spec/unit/stoplight/wiring/system_spec.rb
@@ -24,6 +24,21 @@ RSpec.describe Stoplight::Wiring::System do
       end
     end
 
+    describe "repeated registration without settings" do
+      before { system.register("foo") }
+
+      it "does not allocate on the lookup path" do
+        allocations = lambda do
+          before = GC.stat(:total_allocated_objects)
+          system.register("foo")
+          GC.stat(:total_allocated_objects) - before
+        end
+        allocations.call
+
+        expect(allocations.call).to eq(0)
+      end
+    end
+
     describe "isolation with different light names" do
       let(:light) { system.register(name) }
       let(:name) { "foo" }
@@ -138,6 +153,33 @@ RSpec.describe Stoplight::Wiring::System do
           system.register("foo", threshold: system_config.threshold)
         end.to raise_error(Stoplight::Error::ConfigurationError)
       end
+    end
+
+    describe "conflict detection for every setting" do
+      let(:settings) do
+        {
+          cool_off_time: 120,
+          threshold: 7,
+          recovery_threshold: 2,
+          window_size: 300,
+          tracked_errors: [IOError],
+          skipped_errors: [ArgumentError],
+          traffic_control: :error_rate,
+          traffic_recovery: :consecutive_successes
+        }
+      end
+
+      before { system.register("foo") }
+
+      described_class.instance_method(:register).parameters
+        .filter_map { |kind, keyword| keyword if kind == :key }
+        .each do |setting|
+          it "raises when `#{setting}` is given after a registration without settings" do
+            expect do
+              system.register("foo", setting => settings.fetch(setting))
+            end.to raise_error(Stoplight::Error::ConfigurationError)
+          end
+        end
     end
 
     describe "error messages" do


### PR DESCRIPTION
A bare `Stoplight(name)` rebuilt the registration digest on every call - SHA-256 of the name, a `higLtConfigurationDsl`, a nine-element array hash - only to compare it with the stored one. That lookup was 46% of a green `Stoplight(name).run {}` call (1.65us of 3.61us) and five allocations.

This PR remembers whether a registration was made without settings. A bare call can then return the cached light when the stored registration was bare too, with no digest at all - the digests of two bare registrations of the same name are equal by construction, so conflict detection is unchanged. Bare-then-explicit and explicit-then-bare still compare digests and raise.

The lookup path now allocates nothing.