### PR TITLE
chore: Change Color and Lock state constants type to symbols

### DIFF
--- a/features/stoplight/step_definitions/assertions_steps.rb
+++ b/features/stoplight/step_definitions/assertions_steps.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-match_color = "red|yellow|green"
-
-Given(/^(?:the light|its) color is (?:the )?(#{match_color})$/) do |color|
+Given(/^(?:the light|its) color is (red|yellow|green)$/) do |color|
   expect(current_light.color).to eq(color)
 end
 
-And(/^notification about transition from (#{match_color}) to (#{match_color}) is sent$/) do |from_color, to_color|
+Then("notification about transition from {color} to {color} is sent") do |from_color, to_color|
   notification = notifications.last_notification(current_light.name)
   expect(notification).not_to be_empty, "Expected a notification to be sent, but none was found."
   expect(notification)
@@ -35,6 +33,6 @@ Then(/^the fallback have received an error:$/) do |table|
   expect_error(last_fallback_received_argument, table)
 end
 
-Then(/^the light is in "([^"]+)" state$/) do |state|
+Then('the light is in "{state}" state') do |state|
   expect(current_light.state).to eq(state)
 end

--- a/features/stoplight/step_definitions/assertions_steps.rb
+++ b/features/stoplight/step_definitions/assertions_steps.rb
@@ -4,7 +4,7 @@ Given(/^(?:the light|its) color is (red|yellow|green)$/) do |color|
   expect(current_light.color).to eq(color)
 end
 
-Then("notification about transition from {color} to {color} is sent") do |from_color, to_color|
+And("notification about transition from {color} to {color} is sent") do |from_color, to_color|
   notification = notifications.last_notification(current_light.name)
   expect(notification).not_to be_empty, "Expected a notification to be sent, but none was found."
   expect(notification)

--- a/features/stoplight/step_definitions/circuit_breaker_steps.rb
+++ b/features/stoplight/step_definitions/circuit_breaker_steps.rb
@@ -75,7 +75,7 @@ And(/^(\d+) request(?:s)? (?:is|are) made with:$/) do |count, table|
   end
 end
 
-When(/^I lock the light to ([^"]*)$/) do |color|
+When("I lock the light to {color}") do |color|
   current_light.lock(color)
 end
 

--- a/features/stoplight/support/parameter_types.rb
+++ b/features/stoplight/support/parameter_types.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+ParameterType(
+  name: "color",
+  regexp: /red|yellow|green/,
+  transformer: ->(name) { Stoplight::Color.const_get(name.upcase) }
+)
+
+ParameterType(
+  name: "state",
+  regexp: /unlocked|locked_green|locked_red/,
+  transformer: ->(name) { Stoplight::State.const_get(name.upcase) }
+)

--- a/lib/stoplight/admin.rb
+++ b/lib/stoplight/admin.rb
@@ -142,14 +142,14 @@ module Stoplight
 
     patch "/systems/:system_id/lights/:light_id/lock" do
       light_id = T.must(params[:light_id])
-      color = T.must(params[:color])
+      color = T.must(params[:color]).to_sym
       dependencies.lock_action.call(light_id:, color:)
 
       redirect system_url(current_system_id, "/lights")
     end
 
     patch "/systems/:system_id/lights/lock" do
-      color = T.must(params[:color])
+      color = T.must(params[:color]).to_sym
       dependencies.lock_all_action.call(color:)
 
       redirect system_url(current_system_id, "/lights")

--- a/lib/stoplight/admin/helpers.rb
+++ b/lib/stoplight/admin/helpers.rb
@@ -9,6 +9,10 @@ module Stoplight
         Color::RED
       ].freeze
 
+      def red?(light) = light.color == Color::RED
+
+      def yellow?(light) = light.color == Color::YELLOW
+
       def dependencies
         Dependencies.new(system: current_system)
       end

--- a/lib/stoplight/admin/views/_card.erb
+++ b/lib/stoplight/admin/views/_card.erb
@@ -28,15 +28,15 @@
       </p>
       <span class="flex items-center text-sm font-medium text-gray-500 dark:text-gray-400 truncate me-3">
         <span class="flex w-2.5 h-2.5 bg-<%= color %>-600 rounded-full me-1.5 shrink-0"></span>
-        <% if light.color == "red" %>
+        <% if red?(light) %>
           Open
-        <% elsif light.color == "yellow" %>
+        <% elsif yellow?(light) %>
           Half-Open
         <% else %>
           Closed
         <% end %>
 
-        <% if light.color == "yellow" %>
+        <% if yellow?(light) %>
           (Recovering)
         <% elsif light.locked? %>
           (Locked)

--- a/lib/stoplight/color.rb
+++ b/lib/stoplight/color.rb
@@ -2,8 +2,8 @@
 
 module Stoplight
   module Color
-    GREEN = "green"
-    YELLOW = "yellow"
-    RED = "red"
+    GREEN = :green
+    YELLOW = :yellow
+    RED = :red
   end
 end

--- a/lib/stoplight/domain/state_snapshot.rb
+++ b/lib/stoplight/domain/state_snapshot.rb
@@ -23,7 +23,7 @@ module Stoplight
       # @!attribute time
       #   The time when the snapshot was taken
 
-      # @return [String] one of +Color::GREEN+, +Color::RED+, or +Color::YELLOW+
+      # @return [Symbol] one of +Color::GREEN+, +Color::RED+, or +Color::YELLOW+
       def color
         if locked_state == State::LOCKED_GREEN
           Color::GREEN

--- a/lib/stoplight/infrastructure/redis/storage/state.rb
+++ b/lib/stoplight/infrastructure/redis/storage/state.rb
@@ -63,7 +63,7 @@ module Stoplight
 
             Domain::StateSnapshot.new(
               breached_at: breached_at_raw && clock.at(breached_at_raw.to_f),
-              locked_state: locked_state || Stoplight::State::UNLOCKED,
+              locked_state: locked_state&.to_sym || Stoplight::State::UNLOCKED,
               recovery_scheduled_after: recovery_scheduled_after_raw && clock.at(recovery_scheduled_after_raw.to_f),
               recovery_started_at: recovery_started_at_raw && clock.at(recovery_started_at_raw.to_f),
               time: clock.current_time

--- a/lib/stoplight/state.rb
+++ b/lib/stoplight/state.rb
@@ -2,8 +2,8 @@
 
 module Stoplight
   module State
-    UNLOCKED = "unlocked"
-    LOCKED_GREEN = "locked_green"
-    LOCKED_RED = "locked_red"
+    UNLOCKED = :unlocked
+    LOCKED_GREEN = :locked_green
+    LOCKED_RED = :locked_red
   end
 end

--- a/sig/stoplight/admin/actions/action.rbs
+++ b/sig/stoplight/admin/actions/action.rbs
@@ -3,7 +3,7 @@ module Stoplight
   class Admin
     module Actions
       class Action
-        def halt: (Integer status) -> void
+        def halt: (Integer status) -> bot
       end
     end
   end

--- a/sig/stoplight/admin/helpers.rbs
+++ b/sig/stoplight/admin/helpers.rbs
@@ -3,6 +3,9 @@ module Stoplight
     module Helpers : Sinatra::Base
       COLORS: Array[Domain::color]
 
+      def red?: (LightView) -> bool
+      def yellow?: (LightView) -> bool
+
       def dependencies: -> Dependencies
       def system_url: (String system_id, String path) -> String
       def asset_path: (String) -> String

--- a/sig/stoplight/domain/types.rbs
+++ b/sig/stoplight/domain/types.rbs
@@ -5,15 +5,15 @@ module Stoplight
     type duration_ms = Float
 
     # Light Colors
-    type green = "green"
-    type yellow = "yellow"
-    type red = "red"
+    type green = :green
+    type yellow = :yellow
+    type red = :red
     type color = green | yellow | red
 
     # Light States
-    type unlocked = "unlocked"
-    type locked_green = "locked_green"
-    type locked_red = "locked_red"
+    type unlocked = :unlocked
+    type locked_green = :locked_green
+    type locked_red = :locked_red
     type state = unlocked | locked_green | locked_red
 
     type recovery_decision = :green | :yellow | :red

--- a/spec/integration/admin_config_ru_spec.rb
+++ b/spec/integration/admin_config_ru_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "config.ru", :redis do
     patch "/systems/#{system_id}/lights/#{Stoplight::Domain::Id.for("foo")}/lock", color: "green"
 
     expect(last_response.status).to eq(302)
-    expect(Stoplight.light("foo").state).to eq("locked_green")
+    expect(Stoplight.light("foo").state).to eq(Stoplight::State::LOCKED_GREEN)
   end
 
   it "surfaces a light a separate process already wrote to the same Redis" do

--- a/spec/support/data_store/set_state.rb
+++ b/spec/support/data_store/set_state.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "Stoplight::Domain::DataStore#set_state" do
-  let(:state) { "state" }
+  let(:state) { Stoplight::State::LOCKED_RED }
 
   it "returns the state" do
     expect(set_state(state)).to eql(state)

--- a/spec/unit/stoplight/admin/actions/lock_all_spec.rb
+++ b/spec/unit/stoplight/admin/actions/lock_all_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe Stoplight::Admin::Actions::LockAll do
   let(:storage) { instance_double(Stoplight::Wiring::System::Storage) }
 
   let(:red_light) { instance_double(Stoplight::Domain::Config, id: SecureRandom.uuid) }
-  let(:red_light_state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot, color: "red") }
+  let(:red_light_state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot, color: Stoplight::Color::RED) }
 
   let(:yellow_light) { instance_double(Stoplight::Domain::Config, id: SecureRandom.uuid) }
-  let(:yellow_light_state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot, color: "yellow") }
+  let(:yellow_light_state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot, color: Stoplight::Color::YELLOW) }
 
   let(:green_light) { instance_double(Stoplight::Domain::Config, id: SecureRandom.uuid) }
-  let(:green_light_state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot, color: "green") }
+  let(:green_light_state_snapshot) { instance_double(Stoplight::Domain::StateSnapshot, color: Stoplight::Color::GREEN) }
 
   it "fetches red and yellow lights and lock them green" do
     expect(config_registry).to receive(:all).and_return([red_light, yellow_light, green_light])
@@ -22,8 +22,8 @@ RSpec.describe Stoplight::Admin::Actions::LockAll do
     expect(storage).to receive(:state_snapshot).with(yellow_light).and_return(yellow_light_state_snapshot)
     expect(storage).to receive(:state_snapshot).with(green_light).and_return(green_light_state_snapshot)
 
-    expect(storage).to receive(:lock).with(red_light, "green")
-    expect(storage).to receive(:lock).with(yellow_light, "green")
+    expect(storage).to receive(:lock).with(red_light, Stoplight::Color::GREEN)
+    expect(storage).to receive(:lock).with(yellow_light, Stoplight::Color::GREEN)
 
     call
   end
@@ -42,7 +42,7 @@ RSpec.describe Stoplight::Admin::Actions::LockAll do
   end
 
   context "when color is not lockable" do
-    subject(:call) { action.call(color: "yellow") }
+    subject(:call) { action.call(color: Stoplight::Color::YELLOW) }
 
     it "throws halt without fetching or locking any light" do
       expect(config_registry).not_to receive(:all)

--- a/spec/unit/stoplight/admin/actions/lock_spec.rb
+++ b/spec/unit/stoplight/admin/actions/lock_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Stoplight::Admin::Actions::Lock do
   let(:config_registry) { instance_double(Stoplight::Admin::ConfigRegistry) }
   let(:storage) { instance_double(Stoplight::Wiring::System::Storage) }
   let(:light_id) { SecureRandom.uuid }
-  let(:color) { "green" }
+  let(:color) { Stoplight::Color::GREEN }
 
   before do
     allow(config_registry).to receive(:find_by_id).with(light_id).and_return(config)
@@ -36,7 +36,7 @@ RSpec.describe Stoplight::Admin::Actions::Lock do
   end
 
   context "when color is not lockable" do
-    let(:color) { "yellow" }
+    let(:color) { Stoplight::Color::YELLOW }
     let(:config) { instance_double(Stoplight::Domain::Config) }
 
     it "throws halt without locking" do

--- a/spec/unit/stoplight/admin/actions/stats_spec.rb
+++ b/spec/unit/stoplight/admin/actions/stats_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Stoplight::Admin::Actions::Stats do
     let(:config) { instance_double(Stoplight::Domain::Config, id: "light-id", name: "foo") }
     let(:configs) { [config] }
     let(:state_snapshot) do
-      instance_double(Stoplight::Domain::StateSnapshot, color: "green", locked_state: "unlocked")
+      instance_double(Stoplight::Domain::StateSnapshot, color: Stoplight::Color::GREEN, locked_state: Stoplight::State::UNLOCKED)
     end
     let(:metrics_snapshot) do
       instance_double(
@@ -58,8 +58,8 @@ RSpec.describe Stoplight::Admin::Actions::Stats do
         have_attributes(
           id: "light-id",
           name: "foo",
-          color: "green",
-          state: "unlocked",
+          color: Stoplight::Color::GREEN,
+          state: Stoplight::State::UNLOCKED,
           failures: [],
           traffic_metric_label: "Consecutive failures",
           traffic_metric_value: "0"

--- a/spec/unit/stoplight/admin/helpers_spec.rb
+++ b/spec/unit/stoplight/admin/helpers_spec.rb
@@ -43,4 +43,40 @@ RSpec.describe Stoplight::Admin::Helpers, :redis do
       end
     end
   end
+
+  describe "#red?" do
+    let(:light) { instance_double(Stoplight::Admin::LightView, color: Stoplight::Color::RED) }
+
+    context "when light is red" do
+      it "returns true" do
+        expect(helper.red?(light)).to be_truthy
+      end
+    end
+
+    context "when light is not red" do
+      let(:light) { instance_double(Stoplight::Admin::LightView, color: Stoplight::Color::GREEN) }
+
+      it "returns false" do
+        expect(helper.red?(light)).to be_falsey
+      end
+    end
+  end
+
+  describe "#yellow?" do
+    let(:light) { instance_double(Stoplight::Admin::LightView, color: Stoplight::Color::YELLOW) }
+
+    context "when light is yellow" do
+      it "returns true" do
+        expect(helper.yellow?(light)).to be_truthy
+      end
+    end
+
+    context "when light is not yellow" do
+      let(:light) { instance_double(Stoplight::Admin::LightView, color: Stoplight::Color::RED) }
+
+      it "returns false" do
+        expect(helper.yellow?(light)).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/unit/stoplight/admin/light_view_spec.rb
+++ b/spec/unit/stoplight/admin/light_view_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Stoplight::Admin::LightView do
   let(:id) { SecureRandom.uuid }
   let(:latest_failure) { Stoplight::Domain::Failure.from_error(latest_exception, time: Time.now) }
   let(:latest_exception) { StandardError.new("bang!") }
-  let(:color) { "green" }
+  let(:color) { Stoplight::Color::GREEN }
   let(:name) { "light-specs" }
   let(:state) { Stoplight::State::UNLOCKED }
   let(:metrics_snapshot) do
@@ -240,19 +240,19 @@ RSpec.describe Stoplight::Admin::LightView do
 
   describe "#locked?" do
     context "when locked green" do
-      let(:state) { "locked_green" }
+      let(:state) { Stoplight::State::LOCKED_GREEN }
 
       it { is_expected.to be_locked }
     end
 
     context "when locked red" do
-      let(:state) { "locked_green" }
+      let(:state) { Stoplight::State::LOCKED_RED }
 
       it { is_expected.to be_locked }
     end
 
     context "when unlocked" do
-      let(:state) { "unlocked" }
+      let(:state) { Stoplight::State::UNLOCKED }
 
       it { is_expected.not_to be_locked }
     end

--- a/spec/unit/stoplight/admin/lights_stats_spec.rb
+++ b/spec/unit/stoplight/admin/lights_stats_spec.rb
@@ -19,19 +19,19 @@ RSpec.describe Stoplight::Admin::LightsStats do
           Stoplight::Admin::LightView.new(
             config: instance_double(Stoplight::Domain::Config, name: "green", id: "a"),
             metrics_snapshot: instance_double(Stoplight::Domain::MetricsSnapshot, last_error: nil),
-            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot, color: "green", locked_state: "unlocked"),
+            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot, color: Stoplight::Color::GREEN, locked_state: Stoplight::State::UNLOCKED),
             recovery_metrics_snapshot: nil
           ),
           Stoplight::Admin::LightView.new(
             config: instance_double(Stoplight::Domain::Config, name: "yellow", id: "b"),
             metrics_snapshot: instance_double(Stoplight::Domain::MetricsSnapshot, last_error: nil),
-            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot, color: "yellow", locked_state: "unlocked"),
+            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot, color: Stoplight::Color::YELLOW, locked_state: Stoplight::State::UNLOCKED),
             recovery_metrics_snapshot: instance_double(Stoplight::Domain::MetricsSnapshot, requests: 4)
           ),
           Stoplight::Admin::LightView.new(
             config: instance_double(Stoplight::Domain::Config, name: "red", id: "c"),
             metrics_snapshot: instance_double(Stoplight::Domain::MetricsSnapshot, last_error: nil),
-            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot, color: "red", locked_state: "locked"),
+            state_snapshot: instance_double(Stoplight::Domain::StateSnapshot, color: Stoplight::Color::RED, locked_state: Stoplight::State::LOCKED_RED),
             recovery_metrics_snapshot: nil
           )
         ]

--- a/spec/unit/stoplight/admin_spec.rb
+++ b/spec/unit/stoplight/admin_spec.rb
@@ -226,6 +226,38 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
         end
       end
 
+      context "with a light locked red" do
+        before { light.lock(Stoplight::Color::RED) }
+
+        it "renders the card with open and locked Light" do
+          get "/systems/#{system_id}/lights"
+
+          expect(last_response).to be_ok
+          expect(last_response.body).to match(/(?<!Half-)Open\s+\(Locked\)/)
+        end
+      end
+
+      context "with a light in recovery" do
+        let(:light) { system.register(light_name, cool_off_time: 1) }
+
+        before do
+          3.times do
+            light.run { raise "boom" }
+          rescue
+            nil
+          end
+        end
+
+        it "renders the card with half-open and recovering Light" do
+          Timecop.travel(Time.now + 2) do
+            get "/systems/#{system_id}/lights"
+
+            expect(last_response).to be_ok
+            expect(last_response.body).to match(/Half-Open\s+\(Recovering\)/)
+          end
+        end
+      end
+
       context "when the light's name contains HTML" do
         let(:light_name) { %(<script>alert("xss")</script>) }
 

--- a/spec/unit/stoplight/admin_spec.rb
+++ b/spec/unit/stoplight/admin_spec.rb
@@ -79,14 +79,14 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
       patch "/systems/#{system_id}/lights/#{other_light_id}/unlock"
 
       expect(last_response.status).to eq(404)
-      expect(other_light.state).to eq("locked_green")
+      expect(other_light.state).to eq(Stoplight::State::LOCKED_GREEN)
     end
 
     it "does not lock a light belonging to another system" do
       patch "/systems/#{system_id}/lights/#{other_light_id}/lock", color: "green"
 
       expect(last_response.status).to eq(404)
-      expect(other_light.state).to eq("unlocked")
+      expect(other_light.state).to eq(Stoplight::State::UNLOCKED)
     end
 
     it "bulk-locks only the requested system's lights" do
@@ -96,8 +96,8 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
       patch "/systems/#{system_id}/lights/lock", color: "green"
 
       expect(last_response.status).to eq(302)
-      expect(light.state).to eq("locked_green")
-      expect(other_light.state).to eq("locked_red")
+      expect(light.state).to eq(Stoplight::State::LOCKED_GREEN)
+      expect(other_light.state).to eq(Stoplight::State::LOCKED_RED)
     end
 
     it "does not delete a light belonging to another system" do
@@ -551,7 +551,7 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
 
       expect(last_response.status).to eq(302)
       expect(last_response.headers["location"]).to include("#{last_request.env["HTTP_HOST"]}/systems/#{system_id}/lights")
-      expect(light.state).to eq "unlocked"
+      expect(light.state).to eq(Stoplight::State::UNLOCKED)
     end
 
     it "cannot unlock non-existent light" do
@@ -575,7 +575,7 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
 
       expect(last_response.status).to eq(302)
       expect(last_response.headers["location"]).to include("#{last_request.env["HTTP_HOST"]}/systems/#{system_id}/lights")
-      expect(light.state).to eq "locked_green"
+      expect(light.state).to eq(Stoplight::State::LOCKED_GREEN)
     end
 
     it "locks the light red" do
@@ -583,7 +583,7 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
 
       expect(last_response.status).to eq(302)
       expect(last_response.headers["location"]).to include("#{last_request.env["HTTP_HOST"]}/systems/#{system_id}/lights")
-      expect(light.state).to eq "locked_red"
+      expect(light.state).to eq(Stoplight::State::LOCKED_RED)
     end
 
     it "cannot lock non-existent light" do
@@ -616,7 +616,7 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
       expect(last_response.headers["location"]).to include("#{last_request.env["HTTP_HOST"]}/systems/#{system_id}/lights")
 
       [light, another_light].each do |light|
-        expect(light.state).to eq "locked_green"
+        expect(light.state).to eq(Stoplight::State::LOCKED_GREEN)
       end
     end
 
@@ -625,14 +625,14 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
 
       expect(last_response.status).to eq(302)
       expect(last_response.headers["location"]).to include("#{last_request.env["HTTP_HOST"]}/systems/#{system_id}/lights")
-      expect(green_light.state).to_not eq("locked_green")
+      expect(green_light.state).to_not eq(Stoplight::State::LOCKED_GREEN)
     end
 
     it "refuses to bulk-lock lights to any color other than green" do
       patch "/systems/#{system_id}/lights/lock", color: "red"
 
       expect(last_response.status).to eq(400)
-      expect(light.state).to eq("locked_red")
+      expect(light.state).to eq(Stoplight::State::LOCKED_RED)
     end
 
     it "returns not found for an unknown system_id" do
@@ -745,7 +745,7 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
 
         expect(last_response.status).to eq(403)
         expect(last_response.body).to include("read-only mode")
-        expect(light.state).to eq("locked_green")
+        expect(light.state).to eq(Stoplight::State::LOCKED_GREEN)
       end
     end
 
@@ -756,7 +756,7 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
         patch "/systems/#{system_id}/lights/#{light_id}/lock"
 
         expect(last_response.status).to eq(403)
-        expect(light.state).to eq("unlocked")
+        expect(light.state).to eq(Stoplight::State::UNLOCKED)
       end
     end
 
@@ -767,7 +767,7 @@ RSpec.describe Stoplight::Admin, :redis, type: %i[request] do
         patch "/systems/#{system_id}/lights/lock"
 
         expect(last_response.status).to eq(403)
-        expect(light.state).to eq("locked_red")
+        expect(light.state).to eq(Stoplight::State::LOCKED_RED)
       end
     end
 

--- a/spec/unit/stoplight/color_spec.rb
+++ b/spec/unit/stoplight/color_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Stoplight::Color do
   end
 
   describe "::GREEN" do
-    it "is a string" do
-      expect(described_class::GREEN).to be_a(String)
+    it "is a symbol" do
+      expect(described_class::GREEN).to be_a(Symbol)
     end
 
     it "is frozen" do
@@ -16,8 +16,8 @@ RSpec.describe Stoplight::Color do
   end
 
   describe "::YELLOW" do
-    it "is a string" do
-      expect(described_class::YELLOW).to be_a(String)
+    it "is a symbol" do
+      expect(described_class::YELLOW).to be_a(Symbol)
     end
 
     it "is frozen" do
@@ -26,8 +26,8 @@ RSpec.describe Stoplight::Color do
   end
 
   describe "::RED" do
-    it "is a string" do
-      expect(described_class::RED).to be_a(String)
+    it "is a symbol" do
+      expect(described_class::RED).to be_a(Symbol)
     end
 
     it "is frozen" do

--- a/spec/unit/stoplight/domain/run_strategies/green_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/green_run_strategy_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Stoplight::Domain::Strategies::GreenRunStrategy do
 
       expect { result }.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
         outcome: :success,
-        color: "green",
+        color: Stoplight::Color::GREEN,
         duration_ms: be_within(0.00001).of(0.8),
         failure: nil,
         fallback_used: false,
@@ -80,7 +80,7 @@ RSpec.describe Stoplight::Domain::Strategies::GreenRunStrategy do
             expect { result }.to raise_error(error)
           end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
             outcome: :failure,
-            color: "green",
+            color: Stoplight::Color::GREEN,
             duration_ms: be_within(0.00001).of(0.8),
             failure: have_attributes(exception: error, tracked: true),
             fallback_used: false,
@@ -105,7 +105,7 @@ RSpec.describe Stoplight::Domain::Strategies::GreenRunStrategy do
             expect(result).to eq("Fallback")
           end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
             outcome: :failure,
-            color: "green",
+            color: Stoplight::Color::GREEN,
             duration_ms: be_within(0.00001).of(0.8),
             failure: have_attributes(exception: error, tracked: true),
             fallback_used: true,
@@ -129,7 +129,7 @@ RSpec.describe Stoplight::Domain::Strategies::GreenRunStrategy do
           expect { result }.to raise_error(StandardError, "Test error")
         end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
           outcome: :success,
-          color: "green",
+          color: Stoplight::Color::GREEN,
           duration_ms: be_within(0.00001).of(0.8),
           failure: have_attributes(exception: error, tracked: false),
           fallback_used: false,

--- a/spec/unit/stoplight/domain/run_strategies/red_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/red_run_strategy_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Stoplight::Domain::Strategies::RedRunStrategy, :freeze do
     it "produces RunCompleted event" do
       expect { result }.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
         outcome: :blocked,
-        color: "red",
+        color: Stoplight::Color::RED,
         duration_ms: nil,
         failure: nil,
         fallback_used: true,
@@ -59,7 +59,7 @@ RSpec.describe Stoplight::Domain::Strategies::RedRunStrategy, :freeze do
         expect { result }.to raise_error(Stoplight::Error::RedLight)
       end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
         outcome: :blocked,
-        color: "red",
+        color: Stoplight::Color::RED,
         duration_ms: nil,
         failure: nil,
         fallback_used: false,

--- a/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
+++ b/spec/unit/stoplight/domain/run_strategies/yellow_run_strategy_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
 
           expect { result }.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
             outcome: :success,
-            color: "yellow",
+            color: Stoplight::Color::YELLOW,
             duration_ms: be_within(0.00001).of(0.8),
             failure: nil,
             fallback_used: false,
@@ -113,7 +113,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
                 expect { result }.to raise_error(error)
               end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
                 outcome: :failure,
-                color: "yellow",
+                color: Stoplight::Color::YELLOW,
                 duration_ms: be_within(0.00001).of(0.8),
                 failure: have_attributes(exception: error, tracked: true),
                 fallback_used: false,
@@ -145,7 +145,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
 
               expect { result }.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
                 outcome: :failure,
-                color: "yellow",
+                color: Stoplight::Color::YELLOW,
                 duration_ms: be_within(0.00001).of(0.8),
                 failure: have_attributes(exception: error, tracked: true),
                 fallback_used: true,
@@ -168,7 +168,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
               expect { result }.to raise_error(StandardError, "Test error")
             end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
               outcome: :success,
-              color: "yellow",
+              color: Stoplight::Color::YELLOW,
               duration_ms: be_within(0.00001).of(0.8),
               failure: have_attributes(exception: error, tracked: false),
               fallback_used: false,
@@ -264,7 +264,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
             strategy.execute(fallback, state_snapshot:, error_tracking_policy:) {}
           }.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
             outcome: :blocked,
-            color: "yellow",
+            color: Stoplight::Color::YELLOW,
             duration_ms: nil,
             failure: nil,
             fallback_used: true,
@@ -305,7 +305,7 @@ RSpec.describe Stoplight::Domain::Strategies::YellowRunStrategy do
             }
           end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
             outcome: :blocked,
-            color: "yellow",
+            color: Stoplight::Color::YELLOW,
             duration_ms: nil,
             failure: nil,
             fallback_used: false,

--- a/spec/unit/stoplight/domain/state_spec.rb
+++ b/spec/unit/stoplight/domain/state_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Stoplight::State do
   end
 
   describe "::UNLOCKED" do
-    it "is a string" do
-      expect(described_class::UNLOCKED).to be_a(String)
+    it "is a symbol" do
+      expect(described_class::UNLOCKED).to be_a(Symbol)
     end
 
     it "is frozen" do
@@ -16,8 +16,8 @@ RSpec.describe Stoplight::State do
   end
 
   describe "::LOCKED_GREEN" do
-    it "is a string" do
-      expect(described_class::LOCKED_GREEN).to be_a(String)
+    it "is a symbol" do
+      expect(described_class::LOCKED_GREEN).to be_a(Symbol)
     end
 
     it "is frozen" do
@@ -26,8 +26,8 @@ RSpec.describe Stoplight::State do
   end
 
   describe "::LOCKED_RED" do
-    it "is a string" do
-      expect(described_class::LOCKED_RED).to be_a(String)
+    it "is a symbol" do
+      expect(described_class::LOCKED_RED).to be_a(Symbol)
     end
 
     it "is frozen" do

--- a/spec/unit/stoplight/domain/telemetry/run_recorder_spec.rb
+++ b/spec/unit/stoplight/domain/telemetry/run_recorder_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Stoplight::Domain::Telemetry::RunRecorder do
     it "emits a success event for the recorder's color" do
       expect { run_recorder.record_success(duration_ms: 1.2) }.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
         outcome: :success,
-        color: "green",
+        color: Stoplight::Color::GREEN,
         duration_ms: 1.2,
         failure: nil,
         fallback_used: false,
@@ -34,7 +34,7 @@ RSpec.describe Stoplight::Domain::Telemetry::RunRecorder do
         run_recorder.record_success(duration_ms: 1.2, error:)
       end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
         outcome: :success,
-        color: "green",
+        color: Stoplight::Color::GREEN,
         duration_ms: 1.2,
         failure: have_attributes(exception: error, tracked: false),
         fallback_used: false,
@@ -51,7 +51,7 @@ RSpec.describe Stoplight::Domain::Telemetry::RunRecorder do
         run_recorder.record_failure(error, duration_ms: 1.2, fallback_used: true)
       end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
         outcome: :failure,
-        color: "green",
+        color: Stoplight::Color::GREEN,
         duration_ms: 1.2,
         failure: have_attributes(exception: error, tracked: true),
         fallback_used: true,
@@ -68,7 +68,7 @@ RSpec.describe Stoplight::Domain::Telemetry::RunRecorder do
         run_recorder.record_blocked(fallback_used: false, retry_after:)
       end.to emit(Stoplight::Domain::Telemetry::RunCompleted).with(
         outcome: :blocked,
-        color: "green",
+        color: Stoplight::Color::GREEN,
         duration_ms: nil,
         failure: nil,
         fallback_used: false,


### PR DESCRIPTION
This PR changes `Stoplight::Color` and `Stoplight::State` constants type to symbols, fixes tests and adjust current behaviours to new constant types where needed:
- In Redis DataStore since Redis returns Strings
- In Admin Panel

I also introduced a short helper for Admin Panel to decouple it from our gem internals a little bit and added `color` and `state` ParameterTypes for our feature tests.

Closes #923